### PR TITLE
Matpellerin/sc 1529/permalink in widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,22 @@ yarn
 
 ## Dashboard
 
-Run locally:
+Start by creating an account with an email and password (as SSO doesn't work locally).
+
+The dashboard is named `app` in the source code and can be accessed through `frontend/apps/app`.
+In `apps/app/src/environments_config`, create a file `local-stage/app-config.json` with the correct configuration.
+
+Then you can run the dashboard locally and use the credential created previously to log in:
 
 ```
 nx serve app -c local-stage
 ```
 
-(make sure to create `apps/app/src/environments_config/local-stage/app-config.json` with the correct configuration)
 
 ## Widget
+
+In the demo, the knowledge box id is hardcoded in `apps/search-widget-demo/src/App.svelte`. 
+Before launching the demo, replace this id by the one for your own **public** knowledge box.
 
 Run the demo:
 

--- a/apps/app/src/app/components/topbar/topbar.component.ts
+++ b/apps/app/src/app/components/topbar/topbar.component.ts
@@ -22,15 +22,16 @@ export class TopbarComponent implements AfterViewInit {
   searchWidget = this.kb.pipe(
     map((kb) =>
       this.sanitized.bypassSecurityTrustHtml(`<nuclia-search id="search-widget" knowledgebox="${kb.id}"
-    zone="${this.sdk.nuclia.options.zone}"
-    widgetid="dashboard"
-    client="dashboard"
-    cdn="${this.backendConfig.getCDN() ? this.backendConfig.getCDN() + '/' : ''}"
-    backend="${this.backendConfig.getAPIURL()}"
-    state="${kb.state || ''}"
-    kbslug="${kb.slug || ''}"
-    account="${kb.account || ''}"
-    type="input"></nuclia-search>`),
+        zone="${this.sdk.nuclia.options.zone}"
+        widgetid="dashboard"
+        client="dashboard"
+        cdn="${this.backendConfig.getCDN() ? this.backendConfig.getCDN() + '/' : ''}"
+        backend="${this.backendConfig.getAPIURL()}"
+        state="${kb.state || ''}"
+        kbslug="${kb.slug || ''}"
+        account="${kb.account || ''}"
+        type="input"
+        permalink="true"></nuclia-search>`),
     ),
   );
 

--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -22,7 +22,7 @@
       },
       {
         label: 'Close',
-        action: (uid: string) => {
+        action: () => {
           widget.displayResource('');
         },
       },
@@ -35,11 +35,12 @@
     <NucliaWidget
       bind:this={widget}
       zone="europe-1"
-      knowledgebox="d1a08e42-fdea-4be2-9397-adb7b539145a"
+      knowledgebox="fdfb71d7-fe0c-46ad-91e4-c61237127df9"
       backend="https://stashify.cloud/api"
       cdn="/"
       widgetid="dashboard"
       type="input"
+      permalink
     />
   </nav>
 {/if}

--- a/libs/sdk-core/src/lib/models.ts
+++ b/libs/sdk-core/src/lib/models.ts
@@ -95,6 +95,7 @@ export interface NucliaOptions {
   knowledgeBox?: string;
   kbSlug?: string;
   client?: string;
+  permalink?: boolean;
 }
 
 export type PromiseMapper<T> = {

--- a/libs/search-widget/src/core/api.ts
+++ b/libs/search-widget/src/core/api.ts
@@ -42,7 +42,7 @@ export const suggest = (query: string) => {
   );
 };
 
-export const getResource = (uid: string) => {
+export const getResource = (uid: string): Observable<Resource> => {
   if (!nucliaApi) {
     throw new Error('Nuclia API not initialized');
   }

--- a/libs/search-widget/src/core/utils.ts
+++ b/libs/search-widget/src/core/utils.ts
@@ -19,3 +19,9 @@ export const formatTime = (secons: number) => {
 export const formatQueryKey = (key: string): string => {
   return `__nuclia_${key}__`;
 }
+
+export const updateQueryParams = (urlParams: URLSearchParams) => {
+  const params = urlParams.toString();
+  const url = params ? `${location.pathname}?${params}` : location.pathname;
+  history.pushState(null, '', url);
+}

--- a/libs/search-widget/src/core/utils.ts
+++ b/libs/search-widget/src/core/utils.ts
@@ -15,3 +15,7 @@ export const formatTime = (secons: number) => {
   const secondsLabel = seconds < 10 ? '0' + seconds : seconds.toString();
   return `${minutesLabel}.${secondsLabel}`
 }
+
+export const formatQueryKey = (key: string): string => {
+  return `__nuclia_${key}__`;
+}

--- a/libs/search-widget/src/widget.svelte
+++ b/libs/search-widget/src/widget.svelte
@@ -9,7 +9,7 @@
   import { concatMap, debounceTime, filter, map, switchMap, take, tap } from 'rxjs/operators';
   import { onMount } from 'svelte';
   import { NO_RESULTS, PENDING_RESULTS } from './core/models';
-  import { setCDN, formatQueryKey } from './core/utils';
+  import { setCDN, formatQueryKey, updateQueryParams } from './core/utils';
   import { setLang } from './core/i18n';
   import Modal from './components/modal/Modal.svelte';
   import Viewer from './viewer/Viewer.svelte';
@@ -78,7 +78,7 @@
           const urlParams = new URLSearchParams(window.location.search);
           if (urlParams.get(previewQueryKey) !== resource.uuid) {
             urlParams.set(previewQueryKey, resource.uuid);
-            history.pushState(null, '', `?${urlParams.toString()}`);
+            updateQueryParams(urlParams);
           }
         }
       })
@@ -116,7 +116,7 @@
     const urlParams = new URLSearchParams(window.location.search);
     if (urlParams.get(previewQueryKey)) {
       urlParams.delete(previewQueryKey);
-      history.pushState(null, '', `?${urlParams.toString()}`);
+      updateQueryParams(urlParams);
     }
   };
 


### PR DESCRIPTION
- Add permalink option to search widget:
  - add a query param in the URL when previewing a resource
  - directly display the preview when loading an URL with preview query param
- Enable permalink on search widget from dashboard's top bar
- Update readme to improve onboarding experience