### PR TITLE
Manage demo kb id in posthog

### DIFF
--- a/apps/app/src/environments/environment.prod.ts
+++ b/apps/app/src/environments/environment.prod.ts
@@ -6,5 +6,4 @@ export const environment = {
     new_api: true,
   },
   locales: ['en-US', 'es', 'ca'],
-  demoKb: 'f57eec29-c291-4492-b51f-55bb7c10ef3a',
 };

--- a/apps/app/src/environments/environment.ts
+++ b/apps/app/src/environments/environment.ts
@@ -6,5 +6,4 @@ export const environment = {
     new_api: true,
   },
   locales: ['en-US', 'es', 'ca'],
-  demoKb: '2b11acc2-34d9-43e1-8527-0b330b68fa38',
 };

--- a/libs/core/src/lib/analytics/index.ts
+++ b/libs/core/src/lib/analytics/index.ts
@@ -1,1 +1,2 @@
+export * from './post-hog.service';
 export * from './tracking.service';

--- a/libs/core/src/lib/analytics/post-hog.service.spec.ts
+++ b/libs/core/src/lib/analytics/post-hog.service.spec.ts
@@ -1,16 +1,93 @@
-import { TestBed } from '@angular/core/testing';
-
 import { PostHogService } from './post-hog.service';
+import { BackendConfigurationService } from '../config';
+import posthog from 'posthog-js';
+import { waitForAsync } from '@angular/core/testing';
+
+jest.mock('posthog-js', () => ({
+  identify: jest.fn(),
+  reset: jest.fn(),
+  capture: jest.fn(),
+  onFeatureFlags: jest.fn((callback) => callback(['flag1', 'flag2'])),
+  isFeatureEnabled: jest.fn(() => true),
+  getFeatureFlag: jest.fn(() => 'flag-data'),
+  people: { set: jest.fn() },
+}));
 
 describe('PostHogService', () => {
   let service: PostHogService;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({});
-    service = TestBed.inject(PostHogService);
+  describe('init', () => {
+    it('should do nothing when isBrowser is false', () => {
+      service = new PostHogService({ isBrowser: false } as BackendConfigurationService);
+      service.init('mail');
+      expect(posthog.identify).not.toHaveBeenCalled();
+    });
+
+    it('should call posthog.identify and set people email when isBrowser is true', () => {
+      service = new PostHogService({ isBrowser: true } as BackendConfigurationService);
+      service.init('mail');
+      expect(posthog.identify).toHaveBeenCalledWith('mail');
+      expect(posthog.people.set).toHaveBeenCalledWith({ email: 'mail' });
+    });
   });
 
-  it('should be created', () => {
-    expect(service).toBeTruthy();
+  describe('reset', () => {
+    it('should do nothing when isBrowser is false', () => {
+      service = new PostHogService({ isBrowser: false } as BackendConfigurationService);
+      service.reset();
+      expect(posthog.reset).not.toHaveBeenCalled();
+    });
+
+    it('should call postHog.reset when isBrowser is true', () => {
+      service = new PostHogService({ isBrowser: true } as BackendConfigurationService);
+      service.reset();
+      expect(posthog.reset).toHaveBeenCalledWith(true);
+    });
+  });
+
+  describe('logEvent', () => {
+    it('should do nothing when isBrowser is false', () => {
+      service = new PostHogService({ isBrowser: false } as BackendConfigurationService);
+      service.logEvent('event');
+      expect(posthog.capture).not.toHaveBeenCalled();
+    });
+
+    it('should call postHog.capture when isBrowser is true', () => {
+      service = new PostHogService({ isBrowser: true } as BackendConfigurationService);
+      service.logEvent('event', { some: 'properties' });
+      expect(posthog.capture).toHaveBeenCalledWith('event', { some: 'properties' });
+    });
+  });
+
+  describe('isFeatureEnabled', () => {
+    it('should return an observable calling posthog.onFeatureFlags and isFeatureEnabled', waitForAsync(() => {
+      service = new PostHogService({ isBrowser: true } as BackendConfigurationService);
+      service.isFeatureEnabled('feature').subscribe((isEnabled) => {
+        expect(isEnabled).toBe(true);
+        expect(posthog.onFeatureFlags).toHaveBeenCalled();
+        expect(posthog.isFeatureEnabled).toHaveBeenCalledWith('feature', { send_event: false });
+      });
+    }));
+  });
+
+  describe('getFeatureFlag', () => {
+    it('should return an observable calling posthog.onFeatureFlags and getFeatureFlag', waitForAsync(() => {
+      service = new PostHogService({ isBrowser: true } as BackendConfigurationService);
+      service.getFeatureFlag('feature').subscribe((data) => {
+        expect(data).toBe('flag-data');
+        expect(posthog.onFeatureFlags).toHaveBeenCalled();
+        expect(posthog.getFeatureFlag).toHaveBeenCalledWith('feature', { send_event: false });
+      });
+    }));
+  });
+
+  describe('getEnabledFeatures', () => {
+    it('should return an observable calling posthog.onFeatureFlags', waitForAsync(() => {
+      service = new PostHogService({ isBrowser: true } as BackendConfigurationService);
+      service.getEnabledFeatures().subscribe((data) => {
+        expect(data).toEqual(['flag1', 'flag2']);
+        expect(posthog.onFeatureFlags).toHaveBeenCalled();
+      });
+    }));
   });
 });

--- a/libs/core/src/lib/analytics/post-hog.service.spec.ts
+++ b/libs/core/src/lib/analytics/post-hog.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { PostHogService } from './post-hog.service';
+
+describe('PostHogService', () => {
+  let service: PostHogService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(PostHogService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/libs/core/src/lib/analytics/post-hog.service.ts
+++ b/libs/core/src/lib/analytics/post-hog.service.ts
@@ -1,0 +1,46 @@
+import { Injectable } from '@angular/core';
+import posthog from 'posthog-js';
+import { BackendConfigurationService } from '../config';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class PostHogService {
+  constructor(private config: BackendConfigurationService) {}
+
+  init(email: string) {
+    if (!this.config.isBrowser) return;
+    posthog.identify(email);
+    // Set email or any other data
+    posthog.people.set({ email });
+  }
+
+  reset() {
+    if (!this.config.isBrowser) return;
+    posthog.reset(true);
+  }
+
+  logEvent(event: string, properties?: { [key: string]: string }) {
+    if (!this.config.isBrowser) return;
+    posthog.capture(event, properties);
+  }
+
+  isFeatureEnabled(feature: string): Observable<boolean> {
+    return new Observable<boolean>((observer) => {
+      posthog.onFeatureFlags(() => {
+        observer.next(posthog.isFeatureEnabled(feature, { send_event: false }));
+        observer.complete();
+      });
+    });
+  }
+
+  getEnabledFeatures(): Observable<string[]> {
+    return new Observable<string[]>((observer) => {
+      posthog.onFeatureFlags((flags) => {
+        observer.next(flags);
+        observer.complete();
+      });
+    });
+  }
+}

--- a/libs/core/src/lib/analytics/post-hog.service.ts
+++ b/libs/core/src/lib/analytics/post-hog.service.ts
@@ -35,6 +35,15 @@ export class PostHogService {
     });
   }
 
+  getFeatureFlag(feature: string): Observable<string | boolean | undefined> {
+    return new Observable((observer) => {
+      posthog.onFeatureFlags(() => {
+        observer.next(posthog.getFeatureFlag(feature, { send_event: false }));
+        observer.complete();
+      });
+    });
+  }
+
   getEnabledFeatures(): Observable<string[]> {
     return new Observable<string[]>((observer) => {
       posthog.onFeatureFlags((flags) => {

--- a/libs/core/src/lib/config/app.init.service.ts
+++ b/libs/core/src/lib/config/app.init.service.ts
@@ -36,7 +36,6 @@ export type StaticEnvironmentConfiguration = {
   };
   base_asset_url?: string;
   locales?: string[]; // List of registred locales in the app
-  demoKb: string;
 };
 
 declare var window: any;


### PR DESCRIPTION
- Create PostHog service and use it in tracking service
- Get post hog feature-flag for demo kb id
- Remove demo kb id from environments

Feature flag for stashify: https://track.stashify.cloud/feature_flags/18
Feature flags for production: https://track.nuclia.cloud/feature_flags/15
