### PR TITLE
[sc-2024]: Hide payment related messages in training control panel

### DIFF
--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-process/knowledge-box-processes.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-process/knowledge-box-processes.component.html
@@ -19,27 +19,27 @@
         <pa-option *ngFor="let option of labelsets | async" [value]="option.value">{{ option.title }}</pa-option>
       </pa-select>
 
-      <p [class.warning]="!agreement">
-        {{ 'stash.settings.processes.training.time_requirement' | translate: { hours: hoursRequired } }}
-      </p>
+      <ng-container *ngIf="isBillingEnabled | async">
+        <p [class.warning]="!agreement">
+          {{ 'stash.settings.processes.training.time_requirement' | translate: { hours: hoursRequired } }}
+        </p>
 
-      <div class="agreement-container">
-        <stf-checkbox [(selected)]="agreement[type]" [disabled]="cannotTrain | async" color="dark">{{
-          'stash.settings.processes.training.agreement' | translate
-        }}</stf-checkbox>
-      </div>
+        <div class="agreement-container">
+          <pa-checkbox [disabled]="cannotTrain | async"
+                       [(value)]="agreement[type]">{{'stash.settings.processes.training.agreement' | translate}}</pa-checkbox>
+        </div>
+      </ng-container>
     </div>
+
     <div *ngIf="running[type]" class="active-training warning">
       {{ 'stash.settings.processes.training.active' | translate }}
     </div>
     <div class="cta-container">
-      <stf-button
-        minWidth="110px"
-        [color]="running[type] ? 'secondary' : 'primary'"
-        [disabled]="(!running[type] && !agreement[type]) || (cannotTrain | async)"
-        (click)="startOrStopTraining(type)"
-        >{{ 'stash.settings.processes.training.' + (running[type] ? 'stop' : 'start') | translate }}</stf-button
-      >
+      <pa-button [kind]="running[type] ? 'secondary' : 'primary'"
+                 [disabled]="(!running[type] && !agreement[type]) || (cannotTrain | async)"
+                 (click)="startOrStopTraining(type)">
+        {{ 'stash.settings.processes.training.' + (running[type] ? 'stop' : 'start') | translate }}
+      </pa-button>
     </div>
   </section>
 </div>

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-process/knowledge-box-processes.component.spec.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-process/knowledge-box-processes.component.spec.ts
@@ -1,9 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { SDKService, TranslatePipeMock } from '@flaps/core';
+import {PostHogService, SDKService, TranslatePipeMock} from '@flaps/core';
 import { TrainingStatus } from '@nuclia/core';
 import { of } from 'rxjs';
 
 import { KnowledgeBoxProcessesComponent } from './knowledge-box-processes.component';
+import {MockModule} from "ng-mocks";
+import {PaButtonModule, PaDropdownModule, PaTextFieldModule, PaTogglesModule} from "@guillotinaweb/pastanaga-angular";
 
 describe('KnowledgeBoxProcessComponent', () => {
   let component: KnowledgeBoxProcessesComponent;
@@ -11,6 +13,7 @@ describe('KnowledgeBoxProcessComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: [MockModule(PaTextFieldModule), MockModule(PaDropdownModule), MockModule(PaButtonModule), MockModule(PaTogglesModule)],
       declarations: [KnowledgeBoxProcessesComponent, TranslatePipeMock],
       providers: [
         {
@@ -19,6 +22,12 @@ describe('KnowledgeBoxProcessComponent', () => {
             currentKb: of({ getStatus: () => TrainingStatus.not_running }),
           },
         },
+        {
+          provide: PostHogService,
+          useValue: {
+            isFeatureEnabled: jest.fn(() => of(true))
+          }
+        }
       ],
     }).compileComponents();
   });

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box.module.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box.module.ts
@@ -35,7 +35,13 @@ import { ServiceAccessComponent } from './service-access/service-access.componen
 import { UploadBarComponent } from './upload-bar/upload-bar.component';
 import { HintModule } from '../components/hint/hint.module';
 import { UsersManageModule } from './knowledge-box-users/users-manage/users-manage.module';
-import { PaButtonModule, PaDropdownModule, PaTextFieldModule, PaTooltipModule } from '@guillotinaweb/pastanaga-angular';
+import {
+  PaButtonModule,
+  PaDropdownModule,
+  PaTextFieldModule,
+  PaTogglesModule,
+  PaTooltipModule
+} from '@guillotinaweb/pastanaga-angular';
 import { KnowledgeBoxProcessesComponent } from './knowledge-box-process/knowledge-box-processes.component';
 
 const Components = [
@@ -82,6 +88,7 @@ const Components = [
     PaTextFieldModule,
     PaDropdownModule,
     PaTooltipModule,
+    PaTogglesModule,
   ],
   declarations: [...Components],
   exports: [],

--- a/package.json
+++ b/package.json
@@ -155,6 +155,7 @@
     "jest": "27.5.1",
     "jest-preset-angular": "11.1.2",
     "jsrsasign": "^10.1.0",
+    "ng-mocks": "^14.1.1",
     "ng-packagr": "14.0.2",
     "ngx-build-plus": "11.0.0",
     "nx": "14.3.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -12467,6 +12467,11 @@ netmask@^1.0.6:
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-1.0.6.tgz#20297e89d86f6f6400f250d9f4f6b4c1945fcd35"
   integrity sha1-ICl+idhvb2QA8lDZ9Pa0wZRfzTU=
 
+ng-mocks@^14.1.1:
+  version "14.1.1"
+  resolved "https://registry.yarnpkg.com/ng-mocks/-/ng-mocks-14.1.1.tgz#09f8b553243c7fafa6a9f7203f5e6b5b5da8d17b"
+  integrity sha512-8KrVD+GC2Q5J38K6voOAcPVXh3KxrgF+thoCF4yB/v8eykRn2kvA5Qxa46/ku9oo0q4O+amQhi9xAqZp0unXVQ==
+
 ng-packagr@14.0.2:
   version "14.0.2"
   resolved "https://registry.yarnpkg.com/ng-packagr/-/ng-packagr-14.0.2.tgz#5c824b753a4c5e2851c0e130fd98f4df77f6c04b"


### PR DESCRIPTION
- Hide payment related messages in training control panel when feature flag is disabled
- Add ng-mocks dep to fix missing element errors in KnowledgeBoxProcessComponent tests
- Use Pastanaga buttons and checkboxes instead of STF ones in KnowledgeBoxProcessComponent