### PR TITLE
Fix [sc-1842]: rename widget

### DIFF
--- a/apps/dashboard/src/app/widgets/edit/edit-widget.component.html
+++ b/apps/dashboard/src/app/widgets/edit/edit-widget.component.html
@@ -56,16 +56,22 @@
         </div>
       </div>
       <div class="buttons">
-        <pa-button kind="primary" [disabled]="!mainForm.valid || mainForm.pristine" (click)="save()">
+        <pa-button kind="primary"
+                   [disabled]="!mainForm.valid || mainForm.pristine"
+                   (click)="save()">
           {{ 'generic.save' | translate }}
         </pa-button>
-        <pa-button minWidth="110px" [disabled]="mainForm.pristine" (click)="cancel()">
+        <pa-button [disabled]="mainForm.pristine"
+                   (click)="cancel()">
           {{ 'generic.cancel' | translate }}
         </pa-button>
-        <pa-button minWidth="110px" [disabled]="isDefaultWidget" (click)="rename()">
+        <pa-button [disabled]="isDefaultWidget"
+                   (click)="rename()">
           {{ 'stash.widgets.rename' | translate }}
         </pa-button>
-        <pa-button kind="destructive" minWidth="110px" [disabled]="isDefaultWidget" (click)="deleteWidget()">
+        <pa-button kind="destructive"
+                   [disabled]="isDefaultWidget"
+                   (click)="deleteWidget()">
           {{ 'generic.delete' | translate }}
         </pa-button>
       </div>

--- a/apps/dashboard/src/app/widgets/edit/edit-widget.component.scss
+++ b/apps/dashboard/src/app/widgets/edit/edit-widget.component.scss
@@ -1,4 +1,4 @@
-@import 'apps/dashboard/src/variables';
+@import 'variables';
 
 .edit-widget {
   width: 770px;

--- a/apps/dashboard/src/app/widgets/edit/edit-widget.component.scss
+++ b/apps/dashboard/src/app/widgets/edit/edit-widget.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 .edit-widget {
   width: 770px;

--- a/apps/dashboard/src/app/widgets/widgets.module.ts
+++ b/apps/dashboard/src/app/widgets/widgets.module.ts
@@ -7,7 +7,7 @@ import { PaButtonModule, PaDropdownModule, PaTextFieldModule, PaTogglesModule } 
 import { TranslateModule } from '@ngx-translate/core';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 import { AddWidgetDialogModule } from './add/add-widget.module';
-import { EditWidgetComponent } from './edit-widget.component';
+import { EditWidgetComponent } from './edit/edit-widget.component';
 
 import { WidgetsComponent } from './widgets.component';
 


### PR DESCRIPTION
Renaming a widget is not allowed byt the backend, so we have to delete and re-create it with the new id.