### PR TITLE
Fix [sc-1954]: Don't display empty entities in widget preview

### DIFF
--- a/libs/search-widget/src/viewer/Metadata.svelte
+++ b/libs/search-widget/src/viewer/Metadata.svelte
@@ -17,10 +17,11 @@
   let linksPreviews: CloudLink[] = [];
 
   $: {
-    summaries = [resource.summary].concat(resource.getExtractedSummaries()).filter((s) => !!s);
+    const _summaries = resource.summary ? [resource.summary].concat(resource.getExtractedSummaries()) : resource.getExtractedSummaries();
+    summaries = _summaries.filter((s) => !!s);
     entities = Object.entries(resource.getNamedEntities())
       .sort((a, b) => a[0].localeCompare(b[0]))
-      .map((e) => [e[0], e[1].sort((a, b) => a.localeCompare(b))]);
+      .map((e) => [e[0], e[1].filter(value => !!value).sort((a, b) => a.localeCompare(b))]);
     files = getFileUrls(resource.getFiles().reduce((acc, f) => (f.uri ? acc.concat(f.uri) : acc), []));
     linksPreviews = getLinksPreviews(resource);
     links = getLinks(resource);


### PR DESCRIPTION
- Fix [sc-1954]: Don't display empty entities in widget preview
- Cleanup summaries initialization to prevent eslint error