### PR TITLE
[sc-2107] prevent removing the last user of a kb

### DIFF
--- a/apps/dashboard/src/app/account/account-kbs/account-kbs.component.html
+++ b/apps/dashboard/src/app/account/account-kbs/account-kbs.component.html
@@ -1,59 +1,64 @@
 <div class="loading-shade" *ngIf="isLoading">
   <mat-spinner></mat-spinner>
 </div>
-<div class="account-kbs" *ngIf="zones && account && knowledgeBoxes">
+<div *ngIf="zones && account && knowledgeBoxes"
+     class="account-kbs">
   <h2>{{ 'account.related_kbs' | translate }}</h2>
 
   <div class="account-kbs-list">
     <div class="account-kb" *ngFor="let kb of knowledgeBoxes" fxLayoutAlign="space-between center">
-      <a
-        class="account-kb-title"
-        [class.disabled]="!kb.role_on_kb && !account.can_manage_account"
-        [routerLink]="kb.role_on_kb ? getKbUrl(account.slug, kb.slug!) : null"
+      <a class="account-kb-title"
+         [class.disabled]="!kb.role_on_kb && !account.can_manage_account"
+         [routerLink]="kb.role_on_kb ? getKbUrl(account.slug, kb.slug!) : null"
       >
         {{ kb.title }}
       </a>
       <div fxLayout="row" fxLayoutAlign="start center">
         <ng-container *ngIf="account.can_manage_account">
-          <pa-button
-            *ngIf="isUsersEnabled | async"
-            class="icon-button"
-            icon="add-user"
-            aspect="basic"
-            paTooltip="account.stash.users"
-            (click)="manageKbUsers(kb)"
-            >{{ 'account.stash.users' | translate }}</pa-button
-          >
+          <pa-button *ngIf="isUsersEnabled | async"
+                     class="icon-button"
+                     icon="add-user"
+                     aspect="basic"
+                     paTooltip="account.stash.users"
+                     (click)="manageKbUsers(kb)">
+            {{ 'account.stash.users' | translate }}
+          </pa-button>
 
-          <pa-button
-            *ngIf="!!kb.role_on_kb && isUsersEnabled | async"
-            class="icon-button"
-            icon="edit"
-            aspect="basic"
-            paTooltip="account.stash.edit"
-            (click)="manageKb(kb.slug!)"
-            >{{ 'account.stash.edit' | translate }}</pa-button
-          >
+          <pa-button *ngIf="!!kb.role_on_kb && isUsersEnabled | async"
+                     class="icon-button"
+                     icon="edit"
+                     aspect="basic"
+                     paTooltip="account.stash.edit"
+                     (click)="manageKb(kb.slug!)">
+            {{ 'account.stash.edit' | translate }}
+          </pa-button>
         </ng-container>
 
         <ng-container *ngIf="kb.role_on_kb === 'SOWNER' || account.can_manage_account">
-          <pa-button
-            *ngIf="kb.state === 'PUBLISHED'"
-            size="small"
-            icon="lock"
-            aspect="basic"
-            iconAndText
-            (click)="retireKb(kb)"
-            >{{ 'account.stash.retire' | translate }}</pa-button
-          >
+          <pa-button *ngIf="kb.state === 'PUBLISHED'"
+                     size="small"
+                     icon="lock"
+                     aspect="basic"
+                     iconAndText
+                     (click)="retireKb(kb)">
+            {{ 'account.stash.retire' | translate }}
+          </pa-button>
 
-          <pa-button *ngIf="kb.state === 'PRIVATE'" size="small" icon="unlock" iconAndText (click)="publishKb(kb)">{{
-            'account.stash.publish' | translate
-          }}</pa-button>
+          <pa-button *ngIf="kb.state === 'PRIVATE'"
+                     size="small"
+                     icon="unlock"
+                     iconAndText
+                     (click)="publishKb(kb)">
+            {{ 'account.stash.publish' | translate }}
+          </pa-button>
 
-          <pa-button size="small" icon="trash" kind="destructive" iconAndText (click)="deleteKb(kb)">{{
-            'generic.delete' | translate
-          }}</pa-button>
+          <pa-button size="small"
+                     icon="trash"
+                     kind="destructive"
+                     iconAndText
+                     (click)="deleteKb(kb)">
+            {{ 'generic.delete' | translate }}
+          </pa-button>
         </ng-container>
       </div>
     </div>
@@ -66,7 +71,7 @@
 
     <pa-button size="small" [disabled]="knowledgeBoxes.length >= maxKnowledgeBoxes" (click)="addKb(zones, account)">{{
       'account.stash.add' | translate
-    }}</pa-button>
+      }}</pa-button>
   </div>
 
   <div class="account-kbs-empty" *ngIf="knowledgeBoxes.length === 0 && !(canAddKb | async)">

--- a/apps/dashboard/src/app/account/account-users/account-users.component.html
+++ b/apps/dashboard/src/app/account/account-users/account-users.component.html
@@ -31,7 +31,7 @@
         {{ 'generic.user' | translate }}
       </th>
       <td mat-cell *matCellDef="let user">
-        {{ user.name }}
+        {{ user.name }} – {{ user.email }}
       </td>
     </ng-container>
 

--- a/apps/dashboard/src/app/components/stash-navbar/stash-navbar.component.html
+++ b/apps/dashboard/src/app/components/stash-navbar/stash-navbar.component.html
@@ -3,29 +3,26 @@
     <div *ngIf="!(inAccount | async)" class="navbar-content">
       <div class="nav-group">
         <div class="group-items" tourAnchor="step5">
-          <a
-            *ngIf="isLinkEnabled | async"
-            (click)="createNewLink()"
-            class="nav-link"
-            [class.disabled]="!(isAdminOrContrib | async)"
+          <a *ngIf="isLinkEnabled | async"
+             class="nav-link"
+             [class.disabled]="!(isAdminOrContrib | async)"
+             (click)="createNewLink()"
           >
             <pa-icon name="link"></pa-icon>
             <span class="nav-link-title">{{ 'stash.side.link' | translate }}</span>
           </a>
-          <a
-            *ngIf="isUploadEnabled | async"
-            (click)="uploadNewFiles(false)"
-            class="nav-link"
-            [class.disabled]="!(isAdminOrContrib | async)"
+          <a *ngIf="isUploadEnabled | async"
+             class="nav-link"
+             [class.disabled]="!(isAdminOrContrib | async)"
+             (click)="uploadNewFiles(false)"
           >
             <pa-icon name="file"></pa-icon>
             <span class="nav-link-title">{{ 'stash.side.file' | translate }}</span>
           </a>
-          <a
-            *ngIf="isUploadFolderEnabled | async"
-            (click)="uploadNewFiles(true)"
-            class="nav-link"
-            [class.disabled]="!(isAdminOrContrib | async)"
+          <a *ngIf="isUploadFolderEnabled | async"
+             class="nav-link"
+             [class.disabled]="!(isAdminOrContrib | async)"
+             (click)="uploadNewFiles(true)"
           >
             <pa-icon name="folder"></pa-icon>
             <span class="nav-link-title">{{ 'stash.side.folder' | translate }}</span>
@@ -34,39 +31,35 @@
       </div>
       <div class="nav-group">
         <div class="group-items" tourAnchor="step6">
-          <a
-            *ngIf="isActivityEnabled | async"
-            [routerLink]="kbUrl + '/activity'"
-            routerLinkActive="active"
-            class="nav-link"
-            [class.disabled]="!(isAdminOrContrib | async)"
+          <a *ngIf="isActivityEnabled | async"
+             [routerLink]="kbUrl + '/activity'"
+             routerLinkActive="active"
+             class="nav-link"
+             [class.disabled]="!(isAdminOrContrib | async)"
           >
             <pa-icon name="activity-log"></pa-icon>
             <span class="nav-link-title">{{ 'stash.side.activity' | translate }}</span>
           </a>
-          <a
-            *ngIf="isResourcesEnabled | async"
-            [routerLink]="kbUrl + '/resources'"
-            routerLinkActive="active"
-            class="nav-link"
+          <a *ngIf="isResourcesEnabled | async"
+             [routerLink]="kbUrl + '/resources'"
+             routerLinkActive="active"
+             class="nav-link"
           >
             <pa-icon name="list"></pa-icon>
             <span class="nav-link-title">{{ 'stash.side.list' | translate }}</span>
           </a>
-          <a
-            *ngIf="isOntologiesEnabled | async"
-            [routerLink]="kbUrl + '/ontologies'"
-            routerLinkActive="active"
-            class="nav-link"
+          <a *ngIf="isOntologiesEnabled | async"
+             [routerLink]="kbUrl + '/ontologies'"
+             routerLinkActive="active"
+             class="nav-link"
           >
             <pa-icon name="label"></pa-icon>
             <span class="nav-link-title">{{ 'resource.classification' | translate }}</span>
           </a>
-          <a
-            *ngIf="isEntitiesEnabled | async"
-            [routerLink]="[kbUrl + '/entities']"
-            routerLinkActive="active"
-            class="nav-link"
+          <a *ngIf="isEntitiesEnabled | async"
+             [routerLink]="[kbUrl + '/entities']"
+             routerLinkActive="active"
+             class="nav-link"
           >
             <pa-icon name="search-plus"></pa-icon>
             <span class="nav-link-title">{{ 'generic.insights' | translate }}</span>
@@ -76,11 +69,10 @@
 
       <div class="nav-group">
         <div class="group-items" tourAnchor="step7">
-          <a
-            [routerLink]="kbUrl + '/manage'"
-            routerLinkActive="active"
-            class="nav-link"
-            [class.disabled]="!(isAdminOrContrib | async)"
+          <a [routerLink]="kbUrl + '/manage'"
+             routerLinkActive="active"
+             class="nav-link"
+             [class.disabled]="!(isAdminOrContrib | async)"
           >
             <pa-icon name="settings"></pa-icon>
             <span class="nav-link-title">{{ 'stash.side.settings' | translate }}</span>
@@ -88,10 +80,9 @@
         </div>
         <ng-container *ngIf="isAccountManager | async">
           <div *ngIf="isUsersEnabled | async" class="group-items" tourAnchor="step9">
-            <a
-              [routerLink]="kbUrl + '/users'"
-              routerLinkActive="active"
-              class="nav-link"
+            <a [routerLink]="kbUrl + '/users'"
+               routerLinkActive="active"
+               class="nav-link"
             >
               <pa-icon name="users"></pa-icon>
               <span class="nav-link-title">{{ 'stash.side.users' | translate }}</span>
@@ -99,19 +90,22 @@
           </div>
         </ng-container>
         <div *ngIf="isWidgetsEnabled | async" class="group-items" tourAnchor="step8">
-          <a
-            [routerLink]="kbUrl + '/widgets'"
-            routerLinkActive="active"
-            class="nav-link"
-            [class.disabled]="!(isAdminOrContrib | async)"
+          <a [routerLink]="kbUrl + '/widgets'"
+             routerLinkActive="active"
+             class="nav-link"
+             [class.disabled]="!(isAdminOrContrib | async)"
           >
             <pa-icon name="widget"></pa-icon>
             <span class="nav-link-title">{{ 'stash.side.widgets' | translate }}</span>
           </a>
         </div>
         <ng-container *ngIf="isAccountManager | async">
-          <div *ngIf="isAPIKeysEnabled | async" class="group-items" tourAnchor="step10">
-            <a [routerLink]="kbUrl + '/keys'" routerLinkActive="active" class="nav-link">
+          <div *ngIf="isAPIKeysEnabled | async"
+               class="group-items"
+               tourAnchor="step10">
+            <a [routerLink]="kbUrl + '/keys'"
+               routerLinkActive="active"
+               class="nav-link">
               <pa-icon name="lock-off"></pa-icon>
               <span class="nav-link-title">{{ 'stash.side.api_keys' | translate }}</span>
             </a>
@@ -131,34 +125,45 @@
         </div>
       </div>
     </div>
-    <div *ngIf="(inAccount | async) && (isAccountManager | async)" class="navbar-content dark">
+    <div *ngIf="(inAccount | async) && (isAccountManager | async)"
+         class="navbar-content dark">
       <div class="nav-group">
         <div class="group-items">
-          <a [routerLink]="(accountUrl | async) + '/settings'" routerLinkActive="active" class="nav-link">
+          <a [routerLink]="(accountUrl | async) + '/settings'"
+             routerLinkActive="active"
+             class="nav-link">
             <pa-icon name="settings"></pa-icon>
             <span class="nav-link-title">{{ 'account.settings' | translate }}</span>
           </a>
         </div>
         <div class="group-items">
-          <a [routerLink]="(accountUrl | async) + '/kbs'" routerLinkActive="active" class="nav-link">
+          <a [routerLink]="(accountUrl | async) + '/kbs'"
+             routerLinkActive="active"
+             class="nav-link">
             <pa-icon name="knowledge-box"></pa-icon>
             <span class="nav-link-title">{{ 'account.knowledgeboxes' | translate }}</span>
           </a>
         </div>
         <div class="group-items">
-          <a [routerLink]="(accountUrl | async) + '/users'" routerLinkActive="active" class="nav-link">
+          <a [routerLink]="(accountUrl | async) + '/users'"
+             routerLinkActive="active"
+             class="nav-link">
             <pa-icon name="users"></pa-icon>
             <span class="nav-link-title">{{ 'account.users' | translate }}</span>
           </a>
         </div>
         <div class="group-items">
-          <a [routerLink]="(accountUrl | async) + '/nua'" routerLinkActive="active" class="nav-link">
+          <a [routerLink]="(accountUrl | async) + '/nua'"
+             routerLinkActive="active"
+             class="nav-link">
             <pa-icon name="key"></pa-icon>
             <span class="nav-link-title">{{ 'account.nua_keys' | translate }}</span>
           </a>
         </div>
         <div *ngIf="isBillingEnabled | async" class="group-items">
-          <a [routerLink]="(accountUrl | async) + '/billing'" routerLinkActive="active" class="nav-link">
+          <a [routerLink]="(accountUrl | async) + '/billing'"
+             routerLinkActive="active"
+             class="nav-link">
             <pa-icon name="payment"></pa-icon>
             <span class="nav-link-title">{{ 'account.billing' | translate }}</span>
           </a>

--- a/apps/dashboard/src/app/components/stash-navbar/stash-navbar.component.scss
+++ b/apps/dashboard/src/app/components/stash-navbar/stash-navbar.component.scss
@@ -64,6 +64,13 @@ $height-breakpoint: 730px;
           top: 0;
           width: rhythm(0.25);
         }
+
+        &.disabled {
+          color: $color-text-menu-option-disabled;
+          cursor: not-allowed;
+          pointer-events: none;
+        }
+
         > .nav-link-title {
           flex: 1 1 auto;
           padding-left: rhythm(2);
@@ -98,10 +105,4 @@ $height-breakpoint: 730px;
 
 .dark {
   @include dark-mode();
-}
-
-.disabled {
-  color: $color-text-menu-option-disabled;
-  cursor: not-allowed;
-  pointer-events: none;
 }

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-users/users-manage/users-manage.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-users/users-manage/users-manage.component.html
@@ -10,13 +10,12 @@
 <ng-container *ngIf="kb && isAccountManager | async">
   <div class="add-user" *ngIf="canAddUsers | async">
     <form (ngSubmit)="addUser()" [formGroup]="addForm" fxLayout="row" fxLayoutGap="24px" fxLayoutAlign="start center">
-      <input
-        type="email"
-        formControlName="email"
-        stfFilterInput
-        [inputHeight]="32"
-        [inputColor]="modal ? 'gray' : 'white'"
-        placeholder="{{ 'accounts.add_user_input' | translate }}"
+      <input type="email"
+             formControlName="email"
+             stfFilterInput
+             [inputHeight]="32"
+             [inputColor]="modal ? 'gray' : 'white'"
+             placeholder="{{ 'accounts.add_user_input' | translate }}"
       />
       <select stfSelect selectSize="small" [selectColor]="modal ? 'gray' : 'white'" formControlName="role">
         <option value="" *ngIf="addForm.value.role === ''">
@@ -39,7 +38,7 @@
       {{ 'generic.user' | translate }}
     </th>
     <td cdk-cell *cdkCellDef="let user">
-      {{ user.name }}
+      {{ user.name }} – {{ user.email }}
     </td>
   </ng-container>
 
@@ -48,12 +47,11 @@
       {{ 'stash.users.role' | translate }}
     </th>
     <td cdk-cell *cdkCellDef="let user">
-      <select
-        stfSelect
-        selectSize="small"
-        (ngModelChange)="changeRole(user.id, $event)"
-        [ngModel]="user.role"
-        [disabled]="!(isAccountManager | async)"
+      <select stfSelect
+              selectSize="small"
+              (ngModelChange)="changeRole(user.id, $event)"
+              [ngModel]="user.role"
+              [disabled]="(isAccountManager | async) === false || (user.role === 'SOWNER' && (hasSeveralOwners | async) === false)"
       >
         <ng-container *ngFor="let role of roles">
           <option [value]="role">
@@ -67,10 +65,11 @@
   <ng-container cdkColumnDef="actions">
     <th cdk-header-cell *cdkHeaderCellDef></th>
     <td cdk-cell *cdkCellDef="let user">
-      <pa-button *ngIf="isAccountManager | async"
+      <pa-button *ngIf="(isAccountManager | async) === true"
                  aspect="basic"
                  icon="trash"
                  size="small"
+                 [disabled]="(usersKb | async)?.length < 2 || (user.role === 'SOWNER' && (hasSeveralOwners | async) === false)"
                  (click)="deleteUser(user)">{{'generic.delete' | translate}}</pa-button>
     </td>
   </ng-container>

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-users/users-manage/users-manage.component.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-users/users-manage/users-manage.component.ts
@@ -1,10 +1,9 @@
-import { Component, ChangeDetectionStrategy, ChangeDetectorRef, Input } from '@angular/core';
+import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input } from '@angular/core';
 import { UntypedFormBuilder, Validators } from '@angular/forms';
 import { TranslateService } from '@ngx-translate/core';
-import { filter, map } from 'rxjs';
-import { KbUser } from '@flaps/core';
-import { StateService } from '@flaps/core';
-import { SORTED_KB_ROLES, KB_ROLE_TITLES } from '../../utils';
+import { filter, map, Observable } from 'rxjs';
+import { KbUser, StateService } from '@flaps/core';
+import { KB_ROLE_TITLES, SORTED_KB_ROLES } from '../../utils';
 import { UsersManageService } from './users-manage.service';
 import { KBRoles } from '@nuclia/core';
 import { SisToastService } from '@nuclia/sistema';
@@ -41,6 +40,9 @@ export class UsersManageComponent {
   isAccountManager = this.account.pipe(
     filter((account) => !!account),
     map((account) => account!.can_manage_account),
+  );
+  hasSeveralOwners: Observable<boolean> = this.usersKb.pipe(
+    map((users: KbUser[]) => users.filter((user) => user.role === 'SOWNER')?.length > 1),
   );
   canAddUsers = this.account.pipe(
     map((account) => account!.max_users == null || account!.current_users < account!.max_users),

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -61,7 +61,7 @@
 	"account.type.kb": "Knowledge box",
 	"account.type.manage": "Manage",
 	"account.users": "Account users management",
-	"account.users_amount": "Total amount of users in the account",
+	"account.users_amount": "Total number of users in the account",
 	"account.users_left": "Total sits left",
 	"account.zone_description": "Zone where data will be host",
 	"accounts.add_user_input": "User's email",

--- a/libs/core/src/lib/models/users.model.ts
+++ b/libs/core/src/lib/models/users.model.ts
@@ -23,7 +23,7 @@ export interface KbUser {
   id: string;
   name: string;
   email: string;
-  role: AccountRoles;
+  role: KBRoles;
 }
 
 export interface SetUserKb {


### PR DESCRIPTION
Disable delete button on:
- the only user left for this kb
- the only owner of the KB (we can delete an owner of a KB only if there is another owner on the kb)

Disable select role of a user when:
- the user is not an account manager
- the user is an account manager but the user is the only owner of the kb

Fix disabled style in the navbar