### PR TITLE
Fix [sc-1999]: don't import PaDropdownModule for pa-select

### DIFF
--- a/apps/dashboard/src/app/account/account.module.ts
+++ b/apps/dashboard/src/app/account/account.module.ts
@@ -40,7 +40,6 @@ import { UsersManageModule } from '../knowledge-box/knowledge-box-users/users-ma
 import { HintModule } from '../components/hint/hint.module';
 import {
   PaButtonModule,
-  PaDropdownModule,
   PaIconModule,
   PaTextFieldModule,
   PaTogglesModule,
@@ -93,7 +92,6 @@ const Components = [
     PaButtonModule,
     PaTooltipModule,
     PaTextFieldModule,
-    PaDropdownModule,
     PaTogglesModule,
     PaIconModule,
   ],

--- a/apps/dashboard/src/app/widgets/widgets.module.ts
+++ b/apps/dashboard/src/app/widgets/widgets.module.ts
@@ -3,13 +3,7 @@ import { NgModule } from '@angular/core';
 import { ReactiveFormsModule } from '@angular/forms';
 import { RouterModule } from '@angular/router';
 import { STFSectionNavbarModule } from '@flaps/common';
-import {
-  PaButtonModule,
-  PaDropdownModule,
-  PaIconModule,
-  PaTextFieldModule,
-  PaTogglesModule,
-} from '@guillotinaweb/pastanaga-angular';
+import { PaButtonModule, PaIconModule, PaTextFieldModule, PaTogglesModule } from '@guillotinaweb/pastanaga-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 import { AddWidgetDialogModule } from './add/add-widget.module';
@@ -38,7 +32,6 @@ const routes = [
     RouterModule.forChild(routes),
     ReactiveFormsModule,
     PaTextFieldModule,
-    PaDropdownModule,
     PaButtonModule,
     PaTogglesModule,
     AddWidgetDialogModule,

--- a/apps/desktop/src/app/connectors/connectors.module.ts
+++ b/apps/desktop/src/app/connectors/connectors.module.ts
@@ -6,13 +6,7 @@ import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import {
-  PaButtonModule,
-  PaCardModule,
-  PaDropdownModule,
-  PaTextFieldModule,
-  PaTooltipModule,
-} from '@guillotinaweb/pastanaga-angular';
+import { PaButtonModule, PaCardModule, PaTextFieldModule, PaTooltipModule } from '@guillotinaweb/pastanaga-angular';
 import { FolderUploadModule } from './folder-upload/folder-upload.module';
 
 @NgModule({
@@ -22,7 +16,6 @@ import { FolderUploadModule } from './folder-upload/folder-upload.module';
     ReactiveFormsModule,
     FormsModule,
     PaTextFieldModule,
-    PaDropdownModule,
     PaButtonModule,
     FolderUploadModule,
     TranslateModule,

--- a/mrs.developer.json
+++ b/mrs.developer.json
@@ -4,6 +4,6 @@
     "https": "https://github.com/plone/pastanaga-angular.git",
     "path": "/projects/pastanaga-angular/src",
     "package": "@guillotinaweb/pastanaga-angular",
-    "tag": "2.55.0"
+    "tag": "2.55.1"
   }
 }


### PR DESCRIPTION
With Pastanaga 2.55.1 PaTextFieldModule is enough for using <pa-option> with <pa-select>