### PR TITLE
[sc-1952] Show error message when searching on a resource fails

### DIFF
--- a/libs/sdk-core/src/lib/db/resource.ts
+++ b/libs/sdk-core/src/lib/db/resource.ts
@@ -18,7 +18,7 @@ import type {
   KeywordSetField,
 } from './resource.models';
 import type { Search } from './search.models';
-import { forkJoin } from 'rxjs';
+import { catchError, forkJoin, map, of } from 'rxjs';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface Resource extends IResource {}
@@ -146,6 +146,11 @@ export class Resource implements IResource {
     if (highlight) {
       params.push(`highlight=true&split=true`);
     }
-    return this.nuclia.rest.get<Search.Results>(`${this.path}/search?${params.join('&')}`);
+    return this.nuclia.rest.get<Search.Results>(`${this.path}/search?${params.join('&')}`).pipe(
+      catchError(() => of({ error: true } as Search.Results)),
+      map((res) =>
+        Object.keys(res).includes('detail') ? ({ error: true } as Search.Results) : (res as Search.Results),
+      ),
+    );
   }
 }

--- a/libs/search-widget/src/viewer/Viewer.svelte
+++ b/libs/search-widget/src/viewer/Viewer.svelte
@@ -31,6 +31,7 @@
   const query = viewerState.query;
   const paragraphs = viewerState.paragraphs;
   const results = viewerState.results;
+  const hasSearchError = viewerState.hasSearchError;
   const showPreview = viewerState.showPreview;
 
   $: {
@@ -91,15 +92,15 @@
     <div class="viewer-left">
       <InputViewer />
 
-      {#if $results}
-        <div class="paragraphs">
+      <div class="paragraphs">
+      {#if $hasSearchError}
+          <div><strong>{$_('error.search')}</strong> <span>{$_('error.search-beta')}</span></div>
+      {:else if $results}
           <Paragraphs paragraphs={$results} />
-        </div>
       {:else}
-        <div class="paragraphs">
           <Paragraphs paragraphs={$paragraphs} />
-        </div>
       {/if}
+      </div>
 
       {#if image}
         <h2>Images</h2>


### PR DESCRIPTION
In the resource viewer of the widget, if a search request fails:
- An error message is displayed
- The user can try another query