### PR TITLE
[sc-2111] Modify thumbnail dimensions in search results

### DIFF
--- a/libs/search-widget/src/widgets/row/Row.svelte
+++ b/libs/search-widget/src/widgets/row/Row.svelte
@@ -82,7 +82,7 @@
     </div>
     <div class="block-4">
       {#if thumbnail}
-        <div class="thumbnail">
+        <div class="thumbnail" class:semantic>
           <img src={thumbnail} alt="Thumbnail" />
         </div>
       {/if}
@@ -163,7 +163,11 @@
     position: relative;
     width: 100%;
     height: 0;
-    padding-top: 50%;
+    padding-top: 80%;
+    background-color: var(--color-dark-light);
+  }
+  .thumbnail.semantic {
+    background-color: #f0f0f0;
   }
   .thumbnail img {
     position: absolute;
@@ -171,8 +175,10 @@
     left: 0;
     width: 100%;
     height: 100%;
-    object-fit: cover;
-    object-position: top;
+    object-fit: contain;
+    object-position: center;
+    padding: 0.75em;
+    box-sizing: border-box;
   }
   .paragraph-list {
     padding: 0 0 0 1em;


### PR DESCRIPTION
- Display the thumbnails without modifying its aspect ratio or cropping the image.
- Add a background color to the thumbnails container, so that all thumbnails look uniform.