### PR TITLE
[sc-2260] video tile improvements timing on hover

### DIFF
--- a/libs/search-widget/src/_video-widget/ParagraphPlayer.svelte
+++ b/libs/search-widget/src/_video-widget/ParagraphPlayer.svelte
@@ -8,17 +8,25 @@
   export let selected = false;
   export let minimized = false;
 
+  let hovering = false;
+
   const dispatch = createEventDispatcher();
   const play = () => {
     dispatch('play', { paragraph });
   }
 </script>
 
-<li class="paragraph" class:stack>
+<li class="paragraph"
+    class:stack
+    on:mouseenter={() => hovering = true}
+    on:mouseleave={() => hovering = false}
+    on:click={play}
+>
   <div style="display: flex">
     <TimePlayer start="{paragraph.start || 0}"
                 end="{paragraph.end}"
                 {selected}
+                hover={hovering}
                 {minimized}
                 on:play={play}/>
   </div>
@@ -29,6 +37,7 @@
 
 <style>
   .paragraph {
+    cursor: pointer;
     display: flex;
     gap: var(--rhythm-1);
   }
@@ -41,6 +50,14 @@
   }
   .paragraph .paragraph-text {
     overflow-wrap: break-word;
+  }
+  .paragraph:hover {
+    background-color: var(--color-neutral-lightest);
+    border-top-left-radius: var(--rhythm-1_5);
+  }
+
+  .paragraph:not(.stack):hover {
+    border-bottom-left-radius: var(--rhythm-1_5);
   }
 
   .ellipsis {

--- a/libs/search-widget/src/_video-widget/TimePlayer.svelte
+++ b/libs/search-widget/src/_video-widget/TimePlayer.svelte
@@ -2,7 +2,6 @@
   import {formatTime} from '../core/utils';
   import {createEventDispatcher} from 'svelte';
   import Icon from './Icon.svelte';
-  import { tooltip } from './tooltip';
 
   export let start = 0;
   export let end = 0;
@@ -22,7 +21,6 @@
      class:minimized
      on:click={play}
      on:keyup={(e) => { if (e.key === 'Enter') play(); }}
-     use:tooltip={{title}}
      tabindex="0">
   <Icon name="play" size="small"/>
   <div tabindex="-1" class="time-label">{formatTime(start)}</div>

--- a/libs/search-widget/src/_video-widget/TimePlayer.svelte
+++ b/libs/search-widget/src/_video-widget/TimePlayer.svelte
@@ -6,6 +6,7 @@
   export let start = 0;
   export let end = 0;
   export let selected = false;
+  export let hover = false;
   export let minimized = false;
 
   $: title = `From ${formatTime(start)}${end > 0 ? ' to ' + formatTime(end) : ''}`;
@@ -18,6 +19,7 @@
 
 <div class="time-player"
      class:selected
+     class:hover
      class:minimized
      on:click={play}
      on:keyup={(e) => { if (e.key === 'Enter') play(); }}
@@ -59,6 +61,9 @@
     outline: 0;
   }
 
+  .time-player.hover {
+    background: var(--color-primary-lightest);
+  }
   .time-player.selected {
     background: var(--color-primary-lightest);
     color: var(--color-primary-regular);

--- a/libs/search-widget/src/_video-widget/VideoTile.svelte
+++ b/libs/search-widget/src/_video-widget/VideoTile.svelte
@@ -228,7 +228,7 @@
         {#each $matchingParagraphs as paragraph}
           <ParagraphPlayer {paragraph}
                            ellipsis
-                           minimized="{true}"
+                           minimized="{isMobile}"
                            on:play={(event) => playParagraph(event.detail.paragraph)}/>
         {/each}
       </ul>

--- a/libs/search-widget/src/core/utils.ts
+++ b/libs/search-widget/src/core/utils.ts
@@ -48,9 +48,7 @@ export const formatTime = (sec: number) => {
   const d = new Date(0);
   d.setSeconds(sec);
   let startIndex = 11;
-  if (sec < 60) {
-    startIndex = 15;
-  } else if (sec < 3600) {
+  if (sec < 3600) {
     startIndex = 14;
   }
   return d.toISOString().substring(startIndex, 19);


### PR DESCRIPTION
- revert [sc-2260]: keep the time visible on desktop
- Make full paragraph line clickable 
- Display timestamp on 4 digits minimum