### PR TITLE
Fix [sc-2338]: prevent HTML remainder from bad transition

### DIFF
--- a/libs/search-widget/src/_video-widget/ThumbnailPlayer.svelte
+++ b/libs/search-widget/src/_video-widget/ThumbnailPlayer.svelte
@@ -18,7 +18,10 @@
 </script>
 
 {#if thumbnail}
-  <div class="sw-thumbnail-player" tabindex="-1" on:click={play}>
+  <div class="sw-thumbnail-player"
+       tabindex="-1"
+       in:fade={{ delay: 240 }}
+       on:click={play}>
     <Thumbnail src={thumbnail}
                noBackground
                {aspectRatio}

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -210,6 +210,10 @@
 
 @media (min-width: 821px) {
   .sw-video-tile {
+    .thumbnail-container {
+      min-width: var(--rhythm-28);
+    }
+
     &.expanded {
       --side-panel-width: var(--rhythm-39);
       --youtube-height: calc((100vw - var(--side-panel-width)) * 9 / 16);

--- a/libs/search-widget/src/_video-widget/VideoTile.svelte
+++ b/libs/search-widget/src/_video-widget/VideoTile.svelte
@@ -157,8 +157,7 @@
      style:--video-tile-height={videoTileHeight ? videoTileHeight : ''}>
 
   <div class="thumbnail-container">
-    <div hidden={expanded && !videoLoading}
-         transition:fade={{duration: 240}}>
+    <div hidden={expanded && !videoLoading}>
         <ThumbnailPlayer thumbnail={result.thumbnail}
                          spinner={expanded && videoLoading}
                          aspectRatio={expanded ? '16/9' : '5/4'}


### PR DESCRIPTION
Svelte transitions are working only within an if block