### PR TITLE
[sc-2342] video tile improvements

### DIFF
--- a/libs/search-widget/src/_video-widget/ParagraphPlayer.scss
+++ b/libs/search-widget/src/_video-widget/ParagraphPlayer.scss
@@ -17,7 +17,7 @@
 
 @media (hover: hover) {
   .sw-paragraph-player:hover {
-    background-color: var(--color-neutral-lightest);
+    background-color: var(--color-neutral-background);
     border-top-left-radius: var(--rhythm-1_5);
   }
 

--- a/libs/search-widget/src/_video-widget/ParagraphPlayer.scss
+++ b/libs/search-widget/src/_video-widget/ParagraphPlayer.scss
@@ -10,7 +10,7 @@
   &.stack {
     flex-direction: column;
     gap: var(--rhythm-0_5);
-    padding: var(--rhythm-1_5);
+    padding: var(--rhythm-2);
   }
   .paragraph-text {
     overflow-wrap: break-word;

--- a/libs/search-widget/src/_video-widget/ParagraphPlayer.scss
+++ b/libs/search-widget/src/_video-widget/ParagraphPlayer.scss
@@ -2,6 +2,7 @@
   cursor: pointer;
   display: flex;
   gap: var(--rhythm-1);
+  transition: background-color var(--transition-superfast);
 
   &:not(.stack) {
     align-items: center;
@@ -9,6 +10,7 @@
   &.stack {
     flex-direction: column;
     gap: var(--rhythm-0_5);
+    padding: var(--rhythm-1_5);
   }
   .paragraph-text {
     overflow-wrap: break-word;
@@ -16,12 +18,15 @@
 }
 
 @media (hover: hover) {
-  .sw-paragraph-player:hover {
-    background-color: var(--color-neutral-background);
-    border-top-left-radius: var(--rhythm-1_5);
+  .sw-paragraph-player:not(.stack) .paragraph-text {
+    padding-right: var(--rhythm-1_5);
   }
 
-  .sw-paragraph-player:not(.stack):hover {
-    border-bottom-left-radius: var(--rhythm-1_5);
+  .sw-paragraph-player:hover {
+    background-color: var(--color-neutral-background);
+  }
+
+  .sw-paragraph-player:not(.stack) {
+    border-radius: var(--rhythm-1_5);
   }
 }

--- a/libs/search-widget/src/_video-widget/SearchResults.scss
+++ b/libs/search-widget/src/_video-widget/SearchResults.scss
@@ -11,5 +11,11 @@
 .results {
   display: flex;
   flex-direction: column;
-  gap: var(--rhythm-3);
+  gap: var(--rhythm-2);
+}
+
+@media (min-width: 648px) {
+  .results {
+    gap: var(--rhythm-1);
+  }
 }

--- a/libs/search-widget/src/_video-widget/SearchResults.scss
+++ b/libs/search-widget/src/_video-widget/SearchResults.scss
@@ -13,9 +13,3 @@
   flex-direction: column;
   gap: var(--rhythm-2);
 }
-
-@media (min-width: 648px) {
-  .results {
-    gap: var(--rhythm-1);
-  }
-}

--- a/libs/search-widget/src/_video-widget/SearchResults.svelte
+++ b/libs/search-widget/src/_video-widget/SearchResults.svelte
@@ -2,18 +2,21 @@
 
 <script lang="ts">
   import { onMount } from 'svelte';
-  import { forkJoin, map, switchMap, take } from 'rxjs';
+  import { debounceTime, forkJoin, map, switchMap, take } from 'rxjs';
   import { nucliaState, nucliaStore } from '../core/store';
   import { loadFonts, loadSvgSprite } from '../core/utils';
   import { _ } from '../core/i18n';
   import LoadingDots from '../components/spinner/LoadingDots.svelte';
   import VideoTile from './VideoTile.svelte';
   import globalCss from './_global.scss';
+  import { fade } from 'svelte/transition';
+  import { Duration } from './transition.utils';
 
   const showResults = nucliaStore().triggerSearch.pipe(map(() => true));
   const results = nucliaState().results;
   const hasSearchError = nucliaState().hasSearchError;
   const pendingResults = nucliaState().pendingResults;
+  const showLoading = pendingResults.pipe(debounceTime(2000));
   let svgSprite;
 
   const enhancedResults = results.pipe(
@@ -53,11 +56,14 @@
         <span>{$_('error.search-beta')}</span>
       </div>
     {:else if $pendingResults}
-      <LoadingDots />
+      {#if $showLoading}
+        <LoadingDots />
+      {/if}
     {:else if $results.length === 0}
       <strong>{$_('results.empty')}</strong>
     {:else}
-      <div class="results">
+      <div class="results"
+           transition:fade={{duration: Duration.SUPERFAST}}>
         {#each $paragraphResults as result}
           <VideoTile {result} />
         {/each}

--- a/libs/search-widget/src/_video-widget/ThumbnailPlayer.svelte
+++ b/libs/search-widget/src/_video-widget/ThumbnailPlayer.svelte
@@ -4,6 +4,7 @@
   import Icon from './Icon.svelte';
   import { fade } from 'svelte/transition';
   import Spinner from '../components/spinner/Spinner.svelte';
+  import { Duration } from './transition.utils';
 
   export let thumbnail = '';
   export let aspectRatio;
@@ -20,7 +21,7 @@
 {#if thumbnail}
   <div class="sw-thumbnail-player"
        tabindex="-1"
-       in:fade={{ delay: 240 }}
+       in:fade={{ delay: Duration.SUPERFAST }}
        on:click={play}>
     <Thumbnail src={thumbnail}
                noBackground
@@ -31,7 +32,7 @@
       <div class="action-container"
            class:play-icon={!spinner}
            tabindex="0"
-           in:fade={{ delay: 240 }}
+           in:fade={{ delay: Duration.SUPERFAST }}
            on:keyup={(e) => {
              if (e.key === 'Enter') play();
            }}>

--- a/libs/search-widget/src/_video-widget/ThumbnailPlayer.svelte
+++ b/libs/search-widget/src/_video-widget/ThumbnailPlayer.svelte
@@ -16,6 +16,11 @@
   const play = () => {
     dispatch('play');
   };
+
+  const onLoad = () => {
+    loaded = true;
+    dispatch('loaded');
+  }
 </script>
 
 {#if thumbnail}
@@ -26,7 +31,7 @@
     <Thumbnail src={thumbnail}
                noBackground
                {aspectRatio}
-               on:loaded={() => (loaded = true)} />
+               on:loaded={onLoad} />
 
     {#if loaded}
       <div class="action-container"

--- a/libs/search-widget/src/_video-widget/TimePlayer.scss
+++ b/libs/search-widget/src/_video-widget/TimePlayer.scss
@@ -1,6 +1,6 @@
 .sw-time-player {
   align-items: center;
-  background: var(--color-neutral-lightest);
+  background: var(--color-neutral-background);
   border-radius: var(--rhythm-4);
   cursor: pointer;
   display: flex;
@@ -19,7 +19,7 @@
   }
 
   &:active {
-    background: var(--color-neutral-regular);
+    background: var(--color-neutral-light);
   }
   &:focus {
     box-shadow: var(--focus-shadow);
@@ -40,6 +40,6 @@
 }
 @media (hover: hover) {
   .sw-time-player:not(.hovering):hover {
-    background: var(--color-neutral-light);
+    background: var(--color-neutral-lighter);
   }
 }

--- a/libs/search-widget/src/_video-widget/TimePlayer.scss
+++ b/libs/search-widget/src/_video-widget/TimePlayer.scss
@@ -9,6 +9,7 @@
   max-width: var(--rhythm-9);
   padding: 0 var(--rhythm-1_5) 0 var(--rhythm-1);
   position: relative;
+  transition: background-color var(--transition-superfast);
 
   &.minimized {
     border-radius: 50%;

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -53,11 +53,11 @@
     height: calc(
       var(--paragraph-height) * var(--paragraph-count) + var(--paragraph-gap) * (var(--paragraph-count) - 1)
     );
+    overflow: hidden;
     transition: height var(--transition-fast);
 
     &.can-expand:not(.expanded) {
       height: calc(var(--paragraph-height) * 4 + var(--paragraph-gap) * 3);
-      overflow: hidden;
     }
   }
 

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -95,10 +95,6 @@
     display: none;
   }
 
-  &.expanded .search-result-paragraphs {
-    box-shadow: inset 0 -1px 0 0  var(--expanded-background-color);
-  }
-
   &.expanded .side-panel .scrollable-area {
     min-height: var(--collapsible-header-height);
     overflow: auto;
@@ -195,7 +191,7 @@
         width: 100%;
 
         .scrollable-area {
-          max-height: calc(var(--side-panel-height) - var(--collapsible-header-height));
+          max-height: calc(var(--side-panel-height) - var(--collapsible-header-height)*2);
         }
 
         .search-result-paragraphs {
@@ -230,7 +226,13 @@
     }
 
     &.expanded .result-details {
-      max-height: calc(var(--video-tile-height) - var(--header-height) - var(--rhythm-2));
+      --result-details-height: calc(var(--video-tile-height) - var(--header-height) - var(--rhythm-2));
+      max-height: var(--result-details-height);
+
+      .scrollable-area {
+        max-height: calc(var(--result-details-height) - var(--collapsible-header-height)*3);
+        overflow: auto;
+      }
     }
     &.expanded .side-panel {
       --find-input-height: var(--rhythm-5);
@@ -273,6 +275,10 @@
       min-height: var(--collapsible-header-height);
       max-height: calc(100% - var(--find-input-height) - var(--find-input-margin) - var(--full-transcript-header));
       overflow: auto;
+    }
+
+    &.expanded .full-transcript-container {
+      min-height: var(--collapsible-header-height);
     }
 
     &.expanded .on-animation {

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -95,8 +95,12 @@
   }
 
   &.expanded .side-panel {
-    overflow: auto;
     padding: var(--rhythm-2);
+
+    .scrollable-area {
+      min-height: var(--rhythm-6);
+      overflow: auto;
+    }
   }
 
   &.expanded .transcript-container {
@@ -109,10 +113,6 @@
     display: flex;
     justify-content: space-between;
     padding: var(--rhythm-1_5);
-
-    &.with-spacing {
-      margin: 0 0 var(--rhythm-1);
-    }
 
     // remove the focus style when clicking
     &:focus:not(:focus-visible) {
@@ -236,13 +236,10 @@
     &.expanded .find-bar-container {
       align-items: center;
       background: var(--color-light-stronger);
-      border-bottom: var(--find-input-margin) solid var(--expanded-background-color);
       display: flex;
       gap: var(--rhythm-1);
+      margin-bottom: var(--find-input-margin);
       padding-left: var(--rhythm-1);
-      position: sticky;
-      top: 0;
-      z-index: 1;
     }
 
     &.expanded .find-bar-container .find-input {
@@ -263,13 +260,9 @@
 
     &.expanded .search-result-paragraphs {
       --full-transcript-header: var(--rhythm-8);
-      border-bottom: var(--rhythm-1) solid var(--expanded-background-color);
       min-height: var(--rhythm-6);
       max-height: calc(100% - var(--find-input-height) - var(--find-input-margin) - var(--full-transcript-header));
       overflow: auto;
-      position: sticky;
-      top: calc(var(--find-input-height) + var(--find-input-margin));
-      z-index: 1;
     }
 
     &.expanded .on-animation {

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -155,17 +155,10 @@
     &:not(.expanded) {
       --width-thumbnail: var(--rhythm-28);
 
-      align-items: center;
-
       .result-details {
         flex: 1 0 auto;
         width: calc(100% - var(--width-thumbnail) - var(--flex-gap));
       }
-    }
-
-    h3 {
-      font-size: var(--font-size-title-m);
-      line-height: var(--line-height-title-m);
     }
 
     .thumbnail-container {

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -1,7 +1,7 @@
 .sw-video-tile {
   --paragraph-height: var(--rhythm-4);
   --paragraph-gap: var(--rhythm-0_5);
-  --expanded-background-color: var(--color-neutral-light);
+  --expanded-background-color: var(--color-neutral-lighter);
 
   display: flex;
   flex-direction: column;
@@ -290,6 +290,6 @@
 }
 @media (hover: hover) {
   .sw-video-tile .all-result-toggle:hover {
-    color: var(--color-neutral-strong);
+    color: var(--color-dark-stronger);
   }
 }

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -63,6 +63,7 @@
 
   &.expanded {
     --header-height: var(--rhythm-7);
+    --collapsible-header-height: var(--rhythm-6);
 
     background: var(--expanded-background-color);
     padding-top: var(--header-height);
@@ -94,13 +95,13 @@
     display: none;
   }
 
-  &.expanded .side-panel {
-    padding: var(--rhythm-2);
+  &.expanded .search-result-paragraphs {
+    box-shadow: inset 0 -1px 0 0  var(--expanded-background-color);
+  }
 
-    .scrollable-area {
-      min-height: var(--rhythm-6);
-      overflow: auto;
-    }
+  &.expanded .side-panel .scrollable-area {
+    min-height: var(--collapsible-header-height);
+    overflow: auto;
   }
 
   &.expanded .transcript-container {
@@ -188,9 +189,19 @@
         height: var(--youtube-height);
       }
       .result-details {
-        height: calc(100vh - var(--header-height) - var(--youtube-height));
-        overflow: auto;
+        --side-panel-height: calc(100vh - var(--header-height) - var(--youtube-height));
+        height: var(--side-panel-height);
+        overflow: hidden;
         width: 100%;
+
+        .scrollable-area {
+          max-height: calc(var(--side-panel-height) - var(--collapsible-header-height));
+        }
+
+        .search-result-paragraphs {
+          overflow: auto;
+          max-height: calc(var(--side-panel-height) - var(--collapsible-header-height));
+        }
       }
     }
   }
@@ -229,7 +240,6 @@
       flex: 1 0 auto;
       flex-direction: column;
       max-height: 100%;
-      padding: 0;
       width: var(--side-panel-width);
     }
 
@@ -260,7 +270,7 @@
 
     &.expanded .search-result-paragraphs {
       --full-transcript-header: var(--rhythm-8);
-      min-height: var(--rhythm-6);
+      min-height: var(--collapsible-header-height);
       max-height: calc(100% - var(--find-input-height) - var(--find-input-margin) - var(--full-transcript-header));
       overflow: auto;
     }

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -23,7 +23,7 @@
     font-weight: var(--font-weight-semi-bold);
     gap: var(--rhythm-1);
     line-height: var(--rhythm-3);
-    margin-top: var(--rhythm-2);
+    margin-top: var(--rhythm-1);
     transition: color var(--transition-superfast);
 
     .icon {

--- a/libs/search-widget/src/_video-widget/VideoTile.scss
+++ b/libs/search-widget/src/_video-widget/VideoTile.scss
@@ -43,13 +43,13 @@
   .paragraphs-container {
     display: flex;
     flex-direction: column;
-    gap: var(--paragraph-gap);
     list-style: none;
     margin: 0;
     padding: 0;
   }
 
   &:not(.expanded) .result-details .paragraphs-container {
+    gap: var(--paragraph-gap);
     height: calc(
       var(--paragraph-height) * var(--paragraph-count) + var(--paragraph-gap) * (var(--paragraph-count) - 1)
     );
@@ -63,10 +63,6 @@
 
   &.expanded {
     --header-height: var(--rhythm-7);
-
-    &:not(.showFullTranscripts) {
-      --paragraph-gap: var(--rhythm-3);
-    }
 
     background: var(--expanded-background-color);
     padding-top: var(--header-height);
@@ -105,7 +101,6 @@
 
   &.expanded .transcript-container {
     background: var(--color-light-stronger);
-    padding: var(--rhythm-1_5);
   }
 
   &.expanded .transcript-expander-header {
@@ -113,9 +108,9 @@
     cursor: pointer;
     display: flex;
     justify-content: space-between;
+    padding: var(--rhythm-1_5);
 
     &.with-spacing {
-      padding: var(--rhythm-1_5);
       margin: 0 0 var(--rhythm-1);
     }
 
@@ -269,7 +264,7 @@
     &.expanded .search-result-paragraphs {
       --full-transcript-header: var(--rhythm-8);
       border-bottom: var(--rhythm-1) solid var(--expanded-background-color);
-      min-height: var(--rhythm-3);
+      min-height: var(--rhythm-6);
       max-height: calc(100% - var(--find-input-height) - var(--find-input-margin) - var(--full-transcript-header));
       overflow: auto;
       position: sticky;

--- a/libs/search-widget/src/_video-widget/VideoTile.svelte
+++ b/libs/search-widget/src/_video-widget/VideoTile.svelte
@@ -152,7 +152,6 @@
 <svelte:window bind:innerWidth/>
 <div class="sw-video-tile"
      class:expanded
-     class:showAllResults
      class:showFullTranscripts
      bind:this={videoTileElement}
      style:--video-tile-height={videoTileHeight ? videoTileHeight : ''}>

--- a/libs/search-widget/src/_video-widget/VideoTile.svelte
+++ b/libs/search-widget/src/_video-widget/VideoTile.svelte
@@ -18,6 +18,7 @@
   import Icon from './Icon.svelte';
   import { fade, slide } from 'svelte/transition';
   import Player from '../viewer/previewers/Player.svelte';
+  import { Duration } from './transition.utils';
 
   export let result: IResource = { id: '' };
 
@@ -69,7 +70,7 @@
   };
 
   $: isMobile = innerWidth < 448;
-  $: defaultTransitionDuration = expanded ? 480 : 0;
+  $: defaultTransitionDuration = expanded ? Duration.MODERATE : 0;
   $: isExpandedFullScreen = innerWidth < 820;
   $: filteredMatchingParagraphs = !findInTranscript
     ? matchingParagraphs
@@ -179,7 +180,7 @@
     {#if $resource}
       <div class="summary-container"
            hidden="{!expanded}"
-           transition:fade={{duration: 160}}>
+           transition:fade={{duration: Duration.SUPERFAST}}>
         <div class="summary">{summary}</div>
       </div>
     {/if}
@@ -189,7 +190,7 @@
     <header>
       <h3 class="ellipsis">{result?.title}</h3>
       {#if expanded}
-        <div in:fade={{duration: 240}}>
+        <div in:fade={{duration: Duration.FAST}}>
           <CloseButton aspect="basic"
                        on:click={closePreview}/>
         </div>

--- a/libs/search-widget/src/_video-widget/VideoTile.svelte
+++ b/libs/search-widget/src/_video-widget/VideoTile.svelte
@@ -272,7 +272,7 @@
           {/if}
         </div>
 
-        <div class="scrollable-area"
+        <div class="full-transcript-container"
              class:on-animation={animatingShowFullTranscript}>
           <div hidden="{!expanded}"
                tabindex="0"
@@ -290,7 +290,7 @@
             </div>
           </div>
           {#if showFullTranscripts}
-            <div class="full-transcript-container transcript-container"
+            <div class="transcript-container scrollable-area"
                  in:slide={{duration: defaultTransitionDuration, delay: defaultTransitionDuration}}
                  out:slide={{duration: defaultTransitionDuration}}>
               <ul class="paragraphs-container">

--- a/libs/search-widget/src/_video-widget/VideoTile.svelte
+++ b/libs/search-widget/src/_video-widget/VideoTile.svelte
@@ -202,8 +202,7 @@
         {/if}
       </header>
 
-      <div class:side-panel={expanded}
-           class:on-animation={animatingShowFullTranscript}>
+      <div class:side-panel={expanded}>
         <div class="find-bar-container"
              tabindex="0"
              hidden="{!expanded}">
@@ -264,36 +263,40 @@
             </ul>
           {/if}
         </div>
-        <div hidden="{!expanded}"
-             tabindex="0"
-             class="transcript-expander-header with-spacing"
-             class:expanded={showFullTranscripts}
-             on:click={toggleTranscriptPanel}
-             on:keyup={(e) => {
+
+        <div class="scrollable-area"
+             class:on-animation={animatingShowFullTranscript}>
+          <div hidden="{!expanded}"
+               tabindex="0"
+               class="transcript-expander-header"
+               class:expanded={showFullTranscripts}
+               on:click={toggleTranscriptPanel}
+               on:keyup={(e) => {
              if (e.key === 'Enter') toggleTranscriptPanel();
            }}>
-          <div tabindex="-1" class="transcript-expander-header-title">
-            <strong>Full transcript</strong>
+            <div tabindex="-1" class="transcript-expander-header-title">
+              <strong>Full transcript</strong>
+            </div>
+            <div tabindex="-1" class="transcript-expander-header-chevron">
+              <Icon name="chevron-right"/>
+            </div>
           </div>
-          <div tabindex="-1" class="transcript-expander-header-chevron">
-            <Icon name="chevron-right"/>
-          </div>
+          {#if showFullTranscripts}
+            <div class="full-transcript-container transcript-container"
+                 in:slide={{duration: defaultTransitionDuration, delay: defaultTransitionDuration}}
+                 out:slide={{duration: defaultTransitionDuration}}>
+              <ul class="paragraphs-container">
+                {#each filteredTranscripts as paragraph}
+                  <ParagraphPlayer {paragraph}
+                                   selected={paragraph === paragraphInPlay}
+                                   stack
+                                   on:play={(event) => playTranscript(event.detail.paragraph)}
+                  />
+                {/each}
+              </ul>
+            </div>
+          {/if}
         </div>
-        {#if showFullTranscripts}
-          <div class="full-transcript-container transcript-container"
-               in:slide={{duration: defaultTransitionDuration, delay: defaultTransitionDuration}}
-               out:slide={{duration: defaultTransitionDuration}}>
-            <ul class="paragraphs-container">
-              {#each filteredTranscripts as paragraph}
-                <ParagraphPlayer {paragraph}
-                                 selected={paragraph === paragraphInPlay}
-                                 stack
-                                 on:play={(event) => playTranscript(event.detail.paragraph)}
-                />
-              {/each}
-            </ul>
-          </div>
-        {/if}
       </div>
 
       {#if !expanded && $matchingParagraphs.length > 4}

--- a/libs/search-widget/src/_video-widget/VideoTile.svelte
+++ b/libs/search-widget/src/_video-widget/VideoTile.svelte
@@ -37,6 +37,7 @@
   let findInTranscript = '';
   let transcripts: MediaWidgetParagraph[] = [];
   let showAllResults = false;
+  let thumbnailLoaded = false;
   let videoLoading = true;
   let showFullTranscripts = false;
   let animatingShowFullTranscript = false;
@@ -163,6 +164,7 @@
       <ThumbnailPlayer thumbnail={result.thumbnail}
                        spinner={expanded && videoLoading}
                        aspectRatio={expanded ? '16/9' : '5/4'}
+                       on:loaded={() => thumbnailLoaded = true}
                        on:play={playFromStart}/>
     </div>
 
@@ -187,123 +189,126 @@
     {/if}
   </div>
 
-  <div class="result-details">
-    <header>
-      <h3 class="ellipsis">{result?.title}</h3>
-      {#if expanded}
-        <div in:fade={{duration: Duration.FAST}}>
-          <CloseButton aspect="basic"
-                       on:click={closePreview}/>
-        </div>
-      {/if}
-    </header>
-
-    <div class:side-panel={expanded}
-         class:on-animation={animatingShowFullTranscript}>
-      <div class="find-bar-container"
-           tabindex="0"
-           hidden="{!expanded}">
-        <Icon name="search"/>
-        <input class="find-input"
-               type="text"
-               autocomplete="off"
-               aria-label="Find a transcript"
-               placeholder="Find a transcript"
-               tabindex="-1"
-               bind:value={findInTranscript}
-        />
-      </div>
-
-      <div class="search-result-paragraphs"
-           tabindex="-1"
-           class:on-animation={animatingShowFullTranscript}
-           class:transcript-container={expanded}>
-        {#if !showFullTranscripts && findInTranscript && $filteredMatchingParagraphs.length === 0}
-          <strong>{findInTranscript}</strong> not found in your search results…
-        {/if}
-        {#if showFullTranscripts}
-          <div tabindex="0"
-               class="transcript-expander-header"
-               transition:slide={{duration: defaultTransitionDuration}}
-               on:introstart="{() => animatingShowFullTranscript = true}"
-               on:introend="{() => animatingShowFullTranscript = false}"
-               on:outrostart="{() => animatingShowFullTranscript = true}"
-               on:outroend="{() => animatingShowFullTranscript = false}"
-               on:click={toggleTranscriptPanel}
-               on:keyup={(e) => {
-             if (e.key === 'Enter') toggleTranscriptPanel();
-           }}>
-            <div tabindex="-1" class="transcript-expander-header-title">
-              <strong>{$matchingParagraphs.length} search results</strong>
-            </div>
-            <div tabindex="-1"
-                 class="transcript-expander-header-chevron">
-              <Icon name="chevron-right"/>
-            </div>
+  {#if thumbnailLoaded}
+    <div class="result-details"
+         transition:fade={{duration: Duration.SUPERFAST}}>
+      <header>
+        <h3 class="ellipsis">{result?.title}</h3>
+        {#if expanded}
+          <div in:fade={{duration: Duration.FAST}}>
+            <CloseButton aspect="basic"
+                         on:click={closePreview}/>
           </div>
         {/if}
+      </header>
 
-        {#if !expanded || !showFullTranscripts}
-          <ul transition:slide={{duration: defaultTransitionDuration}}
-              class="paragraphs-container"
-              class:expanded={showAllResults}
-              class:can-expand={$matchingParagraphs.length > 4}
-              style="--paragraph-count: {$matchingParagraphs.length}">
-            {#each $filteredMatchingParagraphs as paragraph}
-              <ParagraphPlayer {paragraph}
-                               ellipsis={!expanded}
-                               minimized={isMobile && !expanded}
-                               stack={expanded}
-                               selected={paragraph === paragraphInPlay}
-                               on:play={(event) => playParagraph(event.detail.paragraph)}/>
-            {/each}
-          </ul>
-        {/if}
-      </div>
-      <div hidden="{!expanded}"
-           tabindex="0"
-           class="transcript-expander-header with-spacing"
-           class:expanded={showFullTranscripts}
-           on:click={toggleTranscriptPanel}
-           on:keyup={(e) => {
+      <div class:side-panel={expanded}
+           class:on-animation={animatingShowFullTranscript}>
+        <div class="find-bar-container"
+             tabindex="0"
+             hidden="{!expanded}">
+          <Icon name="search"/>
+          <input class="find-input"
+                 type="text"
+                 autocomplete="off"
+                 aria-label="Find a transcript"
+                 placeholder="Find a transcript"
+                 tabindex="-1"
+                 bind:value={findInTranscript}
+          />
+        </div>
+
+        <div class="search-result-paragraphs"
+             tabindex="-1"
+             class:on-animation={animatingShowFullTranscript}
+             class:transcript-container={expanded}>
+          {#if !showFullTranscripts && findInTranscript && $filteredMatchingParagraphs.length === 0}
+            <strong>{findInTranscript}</strong> not found in your search results…
+          {/if}
+          {#if showFullTranscripts}
+            <div tabindex="0"
+                 class="transcript-expander-header"
+                 transition:slide={{duration: defaultTransitionDuration}}
+                 on:introstart="{() => animatingShowFullTranscript = true}"
+                 on:introend="{() => animatingShowFullTranscript = false}"
+                 on:outrostart="{() => animatingShowFullTranscript = true}"
+                 on:outroend="{() => animatingShowFullTranscript = false}"
+                 on:click={toggleTranscriptPanel}
+                 on:keyup={(e) => {
              if (e.key === 'Enter') toggleTranscriptPanel();
            }}>
-        <div tabindex="-1" class="transcript-expander-header-title">
-          <strong>Full transcript</strong>
+              <div tabindex="-1" class="transcript-expander-header-title">
+                <strong>{$matchingParagraphs.length} search results</strong>
+              </div>
+              <div tabindex="-1"
+                   class="transcript-expander-header-chevron">
+                <Icon name="chevron-right"/>
+              </div>
+            </div>
+          {/if}
+
+          {#if !expanded || !showFullTranscripts}
+            <ul transition:slide={{duration: defaultTransitionDuration}}
+                class="paragraphs-container"
+                class:expanded={showAllResults}
+                class:can-expand={$matchingParagraphs.length > 4}
+                style="--paragraph-count: {$matchingParagraphs.length}">
+              {#each $filteredMatchingParagraphs as paragraph}
+                <ParagraphPlayer {paragraph}
+                                 ellipsis={!expanded}
+                                 minimized={isMobile && !expanded}
+                                 stack={expanded}
+                                 selected={paragraph === paragraphInPlay}
+                                 on:play={(event) => playParagraph(event.detail.paragraph)}/>
+              {/each}
+            </ul>
+          {/if}
         </div>
-        <div tabindex="-1" class="transcript-expander-header-chevron">
-          <Icon name="chevron-right"/>
+        <div hidden="{!expanded}"
+             tabindex="0"
+             class="transcript-expander-header with-spacing"
+             class:expanded={showFullTranscripts}
+             on:click={toggleTranscriptPanel}
+             on:keyup={(e) => {
+             if (e.key === 'Enter') toggleTranscriptPanel();
+           }}>
+          <div tabindex="-1" class="transcript-expander-header-title">
+            <strong>Full transcript</strong>
+          </div>
+          <div tabindex="-1" class="transcript-expander-header-chevron">
+            <Icon name="chevron-right"/>
+          </div>
         </div>
+        {#if showFullTranscripts}
+          <div class="full-transcript-container transcript-container"
+               in:slide={{duration: defaultTransitionDuration, delay: defaultTransitionDuration}}
+               out:slide={{duration: defaultTransitionDuration}}>
+            <ul class="paragraphs-container">
+              {#each filteredTranscripts as paragraph}
+                <ParagraphPlayer {paragraph}
+                                 selected={paragraph === paragraphInPlay}
+                                 stack
+                                 on:play={(event) => playTranscript(event.detail.paragraph)}
+                />
+              {/each}
+            </ul>
+          </div>
+        {/if}
       </div>
-      {#if showFullTranscripts}
-        <div class="full-transcript-container transcript-container"
-             in:slide={{duration: defaultTransitionDuration, delay: defaultTransitionDuration}}
-             out:slide={{duration: defaultTransitionDuration}}>
-          <ul class="paragraphs-container">
-            {#each filteredTranscripts as paragraph}
-              <ParagraphPlayer {paragraph}
-                               selected={paragraph === paragraphInPlay}
-                               stack
-                               on:play={(event) => playTranscript(event.detail.paragraph)}
-              />
-            {/each}
-          </ul>
+
+      {#if !expanded && $matchingParagraphs.length > 4}
+        <div class="all-result-toggle"
+             class:expanded={showAllResults}
+             on:click={() => (showAllResults = !showAllResults)}>
+          Display {showAllResults ? 'less' : 'all'} results
+
+          <div class="icon">
+            <Icon name="chevron-right" size="small"/>
+          </div>
         </div>
       {/if}
     </div>
-
-    {#if !expanded && $matchingParagraphs.length > 4}
-      <div class="all-result-toggle"
-           class:expanded={showAllResults}
-           on:click={() => (showAllResults = !showAllResults)}>
-        Display {showAllResults ? 'less' : 'all'} results
-
-        <div class="icon">
-          <Icon name="chevron-right" size="small"/>
-        </div>
-      </div>
-    {/if}
-  </div>
+  {/if}
 </div>
 
 <style lang="scss" src="./VideoTile.scss"></style>

--- a/libs/search-widget/src/_video-widget/VideoTile.svelte
+++ b/libs/search-widget/src/_video-widget/VideoTile.svelte
@@ -19,9 +19,11 @@
   import { fade, slide } from 'svelte/transition';
   import Player from '../viewer/previewers/Player.svelte';
   import { Duration } from './transition.utils';
+  import { createEventDispatcher } from 'svelte';
 
   export let result: IResource = {id: ''};
 
+  const dispatch = createEventDispatcher();
   let innerWidth = window.innerWidth;
 
   let videoTileElement: HTMLElement;
@@ -99,6 +101,9 @@
   const playFrom = (time: number, selectedParagraph?: Search.Paragraph) => {
     videoTime = time;
     expanded = true;
+    if (isExpandedFullScreen) {
+      dispatch('fullscreenPreview');
+    }
     const paragraph$ = selectedParagraph && isFileOrLink(selectedParagraph.field_type)
       ? of(selectedParagraph)
       : matchingParagraphs.pipe(map((paragraphList) => paragraphList.filter(p => isFileOrLink(p.field_type))[0] || paragraphList[0]));
@@ -145,6 +150,9 @@
     showFullTranscripts = false;
     paragraphInPlay = undefined;
     findInTranscript = '';
+    if (isExpandedFullScreen) {
+      dispatch('closePreview');
+    }
   };
 
   const toggleTranscriptPanel = () => {

--- a/libs/search-widget/src/_video-widget/transition.utils.ts
+++ b/libs/search-widget/src/_video-widget/transition.utils.ts
@@ -1,0 +1,6 @@
+export enum Duration {
+  SUPERFAST = 160,
+  FAST = 240,
+  MODERATE = 480,
+  SLOW = 800,
+}

--- a/libs/search-widget/src/common-style.scss
+++ b/libs/search-widget/src/common-style.scss
@@ -4,11 +4,12 @@
   --color-dark-stronger-rgb: 13, 13, 13;
   --color-light-stronger: var(--custom-color-light-stronger, #fff);
 
-  --color-neutral-strong: var(--custom-color-neutral-strong, hsl(0, 0%, 44%));
-  --color-neutral-regular: var(--custom-color-neutral-regular, hsl(0, 0%, 77%));
-  --color-neutral-light: var(--custom-color-neutral-light, hsl(0, 0%, 90%));
-  --color-neutral-lighter: var(--custom-color-neutral-lighter, hsl(0, 0%, 94%));
-  --color-neutral-lightest: var(--custom-color-neutral-lightest, hsl(240, 7%, 97%));
+  --color-neutral-regular: var(--custom-color-neutral-strong, hsl(0, 0%, 44%));
+  --color-neutral-light: var(--custom-color-neutral-regular, hsl(0, 0%, 77%));
+  --color-neutral-lighter: var(--custom-color-neutral-light, hsl(0, 0%, 90%));
+  --color-neutral-lightest: var(--custom-color-neutral-lighter, hsl(0, 0%, 94%));
+
+  --color-neutral-background: var(--custom-color-neutral-lightest, hsl(240, 7%, 97%));
 
   --color-primary-stronger: var(--custom-color-primary-stronger, hsl(336, 100%, 24%));
   --color-primary-strong: var(--custom-color-primary-strong, hsl(336, 100%, 36%));
@@ -105,9 +106,9 @@
   --form-widget-border-width: var(--custom-form-widget-border-width, 1px);
   --form-widget-border-style: var(--custom-form-widget-border-style, solid);
   --form-widget-border-style-stronger: var(--custom-form-widget-border-style-stronger, solid);
-  --form-widget-border-color: var(--custom-form-widget-border-color, var(--color-neutral-strong));
+  --form-widget-border-color: var(--custom-form-widget-border-color, var(--color-neutral-regular));
   --form-widget-border-radius: var(--custom-form-widget-border-radius, 0);
-  --form-widget-placeholder-color: var(--custom-form-widget-placeholder-color, --color-neutral-strong);
+  --form-widget-placeholder-color: var(--custom-form-widget-placeholder-color, --color-neutral-regular);
 
   --input-widget-padding: var(--custom-input-widget-padding, var(--search-input-padding));
   --input-widget-border-width: var(--custom-input-widget-border-width, 0 0 1px 0);
@@ -124,7 +125,7 @@
   --resource-modal-height: var(--custom-resource-modal-height, calc(100vh - var(--rhythm-16)));
   --resource-modal-height-md: var(--custom-resource-modal-height-md, 85vh);
 
-  --search-bar-border: var(--custom-search-bar-border, 1px solid var(--color-neutral-strong));
+  --search-bar-border: var(--custom-search-bar-border, 1px solid var(--color-neutral-regular));
   --search-bar-border-focus: var(--custom-search-bar-border-focus, 1px solid var(--color-primary-regular));
   --search-bar-border-radius: var(--custom-search-bar-border-radius, 0);
   --search-bar-padding: var(--custom-search-bar-padding, var(--default-search-field-padding));

--- a/libs/search-widget/src/common-style.scss
+++ b/libs/search-widget/src/common-style.scss
@@ -80,7 +80,8 @@
   /* TRANSITIONS */
   --transition-superfast: 0.16s ease-in-out;
   --transition-fast: 0.24s ease;
-  --transition-moderate: 0.480s ease;
+  --transition-moderate: 0.48s ease;
+  --transition-slow: 0.8s cubic-bezier(0.6, 0, 0.4, 1);
 
 
   /* TOKEN */

--- a/libs/search-widget/src/components/button/Button.scss
+++ b/libs/search-widget/src/components/button/Button.scss
@@ -51,7 +51,7 @@
   }
 
   &.solid:not(:disabled):active {
-    background: var(--color-neutral-regular);
+    background: var(--color-neutral-light);
   }
 
   &.basic {
@@ -60,9 +60,9 @@
     border: var(--color-dark-stronger);
   }
   &.basic:not(:disabled):hover {
-    background: var(--color-neutral-lighter);
+    background: var(--color-neutral-lightest);
   }
   &.basic:not(:disabled):active {
-    background: var(--color-neutral-light);
+    background: var(--color-neutral-lighter);
   }
 }

--- a/libs/search-widget/src/components/toggle/toggle.scss
+++ b/libs/search-widget/src/components/toggle/toggle.scss
@@ -19,7 +19,7 @@
     left: 0;
     right: 0;
     bottom: 0;
-    background-color: var(--color-neutral-strong);
+    background-color: var(--color-neutral-regular);
     -webkit-transition: 0.4s;
     transition: 0.4s;
     border-radius: 18px;

--- a/libs/search-widget/src/viewer/ActionMenu.scss
+++ b/libs/search-widget/src/viewer/ActionMenu.scss
@@ -14,7 +14,7 @@
     text-align: center;
   }
   button:hover {
-    background-color: var(--color-neutral-lightest);
+    background-color: var(--color-neutral-background);
   }
   ul {
     position: absolute;
@@ -35,11 +35,11 @@
     white-space: nowrap;
   }
   li:hover {
-    background-color: var(--color-neutral-lightest);
+    background-color: var(--color-neutral-background);
   }
   li.destructive {
-    border-top: 1px solid var(--color-neutral-lightest);
-    border-bottom: 1px solid var(--color-neutral-lightest);
+    border-top: 1px solid var(--color-neutral-background);
+    border-bottom: 1px solid var(--color-neutral-background);
     color: var(--color-secondary-stronger);
   }
   li.destructive:hover {

--- a/libs/search-widget/src/viewer/Header.scss
+++ b/libs/search-widget/src/viewer/Header.scss
@@ -5,7 +5,7 @@
   min-height: 76px;
   padding-left: 1em;
   background-color: var(--color-light-stronger);
-  border-bottom: 1px solid var(--color-neutral-regular);
+  border-bottom: 1px solid var(--color-neutral-light);
 
   .icon {
     width: 22px;

--- a/libs/search-widget/src/viewer/InputViewer.scss
+++ b/libs/search-widget/src/viewer/InputViewer.scss
@@ -27,7 +27,7 @@
     font-family: inherit;
     outline: none;
     color: inherit;
-    background-color: var(--color-neutral-lightest);
+    background-color: var(--color-neutral-background);
     background-position: 0.75em center;
     background-repeat: no-repeat;
     text-overflow: ellipsis;
@@ -69,6 +69,6 @@
   }
   select:focus-visible {
     outline: 0;
-    color: var(--color-neutral-strong);
+    color: var(--color-neutral-regular);
   }
 }

--- a/libs/search-widget/src/viewer/LabelMenu.scss
+++ b/libs/search-widget/src/viewer/LabelMenu.scss
@@ -23,7 +23,7 @@
     -webkit-appearance: none;
   }
   button:hover {
-    background-color: var(--color-neutral-lightest);
+    background-color: var(--color-neutral-background);
   }
   button .name {
     flex: 0 1 auto;
@@ -76,7 +76,7 @@
   }
   .current-labels {
     padding: 0.5em;
-    border-bottom: 1px solid var(--color-neutral-lightest);
+    border-bottom: 1px solid var(--color-neutral-background);
   }
   .current-label {
     margin: 0 0 0.25em 0;

--- a/libs/search-widget/src/widgets/results/Results.scss
+++ b/libs/search-widget/src/widgets/results/Results.scss
@@ -24,7 +24,7 @@
   .result {
     margin-bottom: 2em;
     padding-bottom: 1em;
-    border-bottom: 1px solid var(--color-neutral-regular);
+    border-bottom: 1px solid var(--color-neutral-light);
   }
 
   .result:last-child {
@@ -35,7 +35,7 @@
   .box {
     margin: 0 -1.25em;
     padding: 2.25em 1.25em;
-    background-color: var(--color-neutral-lightest);
+    background-color: var(--color-neutral-background);
     border-radius: 4px;
   }
 
@@ -64,7 +64,7 @@
     padding: 0.5em 1em;
     border: 0;
     background: var(--color-light-stronger);
-    color: var(--color-neutral-strong);
+    color: var(--color-neutral-regular);
     font: inherit;
     font-weight: var(--font-weight-semi-bold);
     cursor: pointer;

--- a/libs/search-widget/src/widgets/row/Thumbnail.scss
+++ b/libs/search-widget/src/widgets/row/Thumbnail.scss
@@ -6,7 +6,7 @@
   }
 
   .thumbnail-background {
-    background-color: var(--color-neutral-lighter);
+    background-color: var(--color-neutral-lightest);
   }
 
   .thumbnail-placeholder {

--- a/libs/search-widget/src/widgets/row/Thumbnail.scss
+++ b/libs/search-widget/src/widgets/row/Thumbnail.scss
@@ -1,4 +1,6 @@
 .sw-thumbnail {
+  display: flex;
+
   img {
     object-fit: contain;
     object-position: center;

--- a/libs/search-widget/src/widgets/row/Thumbnail.svelte
+++ b/libs/search-widget/src/widgets/row/Thumbnail.svelte
@@ -2,6 +2,7 @@
   import { createEventDispatcher, onDestroy } from 'svelte';
   import { getFile } from '../../core/api';
   import { fade } from 'svelte/transition';
+  import { Duration } from '../../_video-widget/transition.utils';
 
   export let src: string;
   export let aspectRatio: '5/4' | '16/9' = '5/4';
@@ -26,16 +27,17 @@
 
 <div class="sw-thumbnail">
   {#if loaded}
-    <img
-      in:fade={{ duration: 240 }}
-      src={thumbnail}
-      alt="Thumbnail"
-      style:aspect-ratio={aspectRatio}
-      class:thumbnail-background={!noBackground}
+    <img in:fade={{ duration: Duration.SUPERFAST }}
+         src={thumbnail}
+         alt="Thumbnail"
+         style:aspect-ratio={aspectRatio}
+         class:thumbnail-background={!noBackground}
     />
   {/if}
   {#if !loaded}
-    <div in:fade={{ duration: 160 }} class:thumbnail-background={!noBackground} class="thumbnail-placeholder" />
+    <div in:fade={{ duration: Duration.SUPERFAST }}
+         class:thumbnail-background={!noBackground}
+         class="thumbnail-placeholder" />
   {/if}
 </div>
 

--- a/libs/search-widget/src/widgets/search-input/SearchInput.scss
+++ b/libs/search-widget/src/widgets/search-input/SearchInput.scss
@@ -17,7 +17,7 @@
   }
 
   input::placeholder {
-    color: var(--color-neutral-strong);
+    color: var(--color-neutral-regular);
     transition: all 0s ease;
   }
 
@@ -77,7 +77,7 @@
 
   .powered-by {
     align-items: center;
-    color: var(--color-neutral-regular);
+    color: var(--color-neutral-light);
     display: flex;
     gap: var(--rhythm-0_5);
     position: absolute;

--- a/libs/search-widget/src/widgets/suggestions/Suggestions.scss
+++ b/libs/search-widget/src/widgets/suggestions/Suggestions.scss
@@ -15,7 +15,7 @@
   .paragraph:focus {
     padding-left: 29px;
     border-left: 3px solid var(--color-primary-regular);
-    outline: 0px;
+    outline: 0;
   }
   .show-more {
     display: inline-block;
@@ -34,7 +34,7 @@
   p {
     text-align: right;
     font-size: small;
-    color: var(--color-neutral-strong);
+    color: var(--color-neutral-regular);
     margin: 0;
   }
   .intents {


### PR DESCRIPTION
* Search results improvements
  - align all content to the top of the video
  - keep the same font size for titles on desktop and on mobile (font-size: 18px, line-height: 26px)
* Fix scrolling behavior on fullscreen preview
* Scrollable area doesn't include find bar and collapsed search results
* Search results: display video and texts at the same time
* Fix thumbnail loading transition and height
* Fix selected paragraph
* Hovering paragraph improvements
  - Search results: round corners on both sides
  - Video tile: full width paragraph in transcripts
  - Background transition on TimePlayer and ParagraphPlayer 
* Fix show-all-results transition
* Search results – let a bit less space between videos
  - There is some white space above and below the video thumbnail because the thumbnail height is computed to fit the width based on 4/5 ratio. So we need to reduce the gap between the video tile to take this space into account and have ~24px between videos.
* Wait two seconds before displaying the loading dots
  - Add Duration enum to make it easier to manage Svelte transition duration
* [sc-2301]: Re-align Sistema neutral colors
* Fix all-result-toggle color

