### PR TITLE
Fix [sc-2936]: display expanded tiles properly

### DIFF
--- a/libs/search-widget/src/common/modal/ConfirmDialog.svelte
+++ b/libs/search-widget/src/common/modal/ConfirmDialog.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import Button from "../button/Button.svelte";
+  import Button from '../button/Button.svelte';
+  import { freezeBackground, unblockBackground } from './modal.utils';
 
   export let show = false;
   export let closeable = false;
@@ -9,19 +10,12 @@
     {label: 'Confirm', action: 'confirm', kind: 'primary'}
   ];
 
-  let overflow = 'initial';
-  $: {
-    if (show) {
-      overflow = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = overflow;
-    }
-  }
+  $: show && freezeBackground();
 
   const dispatch = createEventDispatcher();
   const close = (action) => {
     show = false;
+    unblockBackground();
     dispatch(action);
   };
   const outsideClick = () => {

--- a/libs/search-widget/src/common/modal/Modal.svelte
+++ b/libs/search-widget/src/common/modal/Modal.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher, onMount } from 'svelte';
   import ModalHeader from './ModalHeader.svelte';
+  import { freezeBackground, unblockBackground } from './modal.utils';
 
   export let show = false;
   export let popup = false;
@@ -9,19 +10,11 @@
   export let parentPosition: DOMRect | undefined = undefined;
   export let alignTo = '';
 
+  $: show && freezeBackground();
+
   const dispatch = createEventDispatcher();
-  let overflow = 'initial';
   let modalContentHeight: string = '100%';
   let modalContentContainer: HTMLElement;
-
-  $: {
-    if (show) {
-      overflow = document.body.style.overflow;
-      document.body.style.overflow = 'hidden';
-    } else {
-      document.body.style.overflow = overflow;
-    }
-  }
 
   function setModalContentHeight() {
     if (modalContentContainer) {
@@ -35,6 +28,7 @@
 
   const close = () => {
     show = false;
+    unblockBackground();
     dispatch('close');
   };
   const outsideClick = () => {

--- a/libs/search-widget/src/common/modal/modal.utils.ts
+++ b/libs/search-widget/src/common/modal/modal.utils.ts
@@ -1,0 +1,21 @@
+export function freezeBackground() {
+  const scrollY = window.scrollY;
+  const body = document.body;
+  body.style.position = 'fixed';
+  body.style.top = `-${scrollY}px`;
+}
+
+export function unblockBackground(fullscreenModal = false) {
+  const body = document.body;
+  const scrollY = body.style.top;
+  body.style.position = '';
+  body.style.top = '';
+
+  // When modal is fullscreen like tiles, we need a timeout.
+  // But when modal is not fullscreen, the timeout makes the background flicker on close.
+  fullscreenModal ? setTimeout(() => scrollBackTo(scrollY)) : scrollBackTo(scrollY);
+}
+
+function scrollBackTo(scrollY: string) {
+  window.scrollTo(0, parseInt(scrollY || '0') * -1);
+}

--- a/libs/search-widget/src/tiles/_tile.scss
+++ b/libs/search-widget/src/tiles/_tile.scss
@@ -48,7 +48,7 @@
     left: 0;
     overflow: hidden;
     padding-top: var(--header-height);
-    position: absolute;
+    position: fixed;
     right: 0;
     top: 0;
     z-index: 1000;

--- a/libs/search-widget/src/tiles/pdf-tile/PdfTile.svelte
+++ b/libs/search-widget/src/tiles/pdf-tile/PdfTile.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { IResource, Resource, Search } from '@nuclia/core';
-  import { createEventDispatcher, onDestroy, onMount } from 'svelte';
+  import { onDestroy, onMount } from 'svelte';
   import { Duration } from '../../common/transition.utils';
   import { fade, slide } from 'svelte/transition';
   import Thumbnail from '../../common/thumbnail/Thumbnail.svelte';
@@ -19,6 +19,7 @@
   import SearchResultNavigator from './SearchResultNavigator.svelte';
   import Icon from '../../common/icons/Icon.svelte';
   import { getPdfJsBaseUrl, getPdfJsStyle } from '../../core/utils';
+  import { freezeBackground, unblockBackground } from '../../common/modal/modal.utils';
 
   export let result: IResource = {id: ''} as IResource;
 
@@ -31,7 +32,6 @@
     padding: 2px 4px;
   }`;
 
-  const dispatch = createEventDispatcher();
   let innerWidth = window.innerWidth;
   const closeButtonWidth = 48;
 
@@ -54,7 +54,6 @@
 
   $: isMobile = innerWidth < 448;
   $: defaultTransitionDuration = expanded ? Duration.MODERATE : 0;
-  $: isExpandedFullScreen = innerWidth < 820;
 
   let resource: Resource | undefined;
   let paragraphList: PdfWidgetParagraph[];
@@ -81,6 +80,7 @@
     if (!expanded) {
       findInPdfQuery.next(globalQuery.value);
       expanded = true;
+      freezeBackground();
     }
     setTimeout(() => setHeaderActionWidth());
 
@@ -110,9 +110,7 @@
 
   const closePreview = () => {
     reset();
-    if (isExpandedFullScreen) {
-      dispatch('closePreview');
-    }
+    unblockBackground(true);
   };
 
   const setHeaderActionWidth = () => {

--- a/libs/search-widget/src/widgets/search-video-widget/SearchResults.svelte
+++ b/libs/search-widget/src/widgets/search-video-widget/SearchResults.svelte
@@ -11,7 +11,7 @@
   import globalCss from '../../common/_global.scss';
   import { fade } from 'svelte/transition';
   import { Duration } from '../../common/transition.utils';
-  import PdfTile from "../../tiles/pdf-tile/PdfTile.svelte";
+  import PdfTile from '../../tiles/pdf-tile/PdfTile.svelte';
 
   const showResults = nucliaStore().triggerSearch.pipe(map(() => true));
   const results = nucliaState().results;
@@ -42,36 +42,10 @@
     map((results) => results.filter((result) => result.hasParagraphs).map((result) => result.resource)),
   );
 
-  const scrollingListener = () => {
-    document.documentElement.style.setProperty('--scroll-y', `${window.scrollY}px`);
-  };
-
   onMount(() => {
     loadFonts();
     loadSvgSprite().subscribe((sprite) => (svgSprite = sprite));
-
-    window.addEventListener('scroll', scrollingListener);
   });
-
-  onDestroy(() => {
-    window.removeEventListener('scroll', scrollingListener);
-  });
-
-  // Prevent the page to scroll behind the fullscreen expanded tile
-  const onFullscreenPreview = () => {
-    const scrollY = document.documentElement.style.getPropertyValue('--scroll-y');
-    const body = document.body;
-    body.style.position = 'fixed';
-    body.style.top = `-${scrollY}`;
-  }
-
-  const onFullscreenPreviewClosed = () => {
-    const body = document.body;
-    const scrollY = body.style.top;
-    body.style.position = '';
-    body.style.top = '';
-    setTimeout(() => window.scrollTo(0, parseInt(scrollY || '0') * -1));
-  }
 </script>
 
 <svelte:element this="style">{@html globalCss}</svelte:element>
@@ -94,13 +68,9 @@
            transition:fade={{duration: Duration.SUPERFAST}}>
         {#each $paragraphResults as result}
           {#if result.icon === 'application/pdf'}
-            <PdfTile {result}
-                     on:fullscreenPreview={onFullscreenPreview}
-                     on:closePreview={onFullscreenPreviewClosed} ></PdfTile>
+            <PdfTile {result} />
           {:else}
-            <VideoTile {result}
-                       on:fullscreenPreview={onFullscreenPreview}
-                       on:closePreview={onFullscreenPreviewClosed} />
+            <VideoTile {result} />
           {/if}
         {/each}
       </div>


### PR DESCRIPTION
  - Use `position: fixed` on expanded tiles
  - Create common `freezeBackground` and `unblockBackground` functions used by all our modals (based on https://css-tricks.com/prevent-page-scrolling-when-a-modal-is-open/)
  - Freeze the background when tile is expanded
  - Unblock the background when expanded tile is closed