### PR TITLE
[sc 3035] add suggested label as filter

### DIFF
--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -5,7 +5,7 @@
   import { NucliaViewerWidget } from '../../../libs/search-widget/src/widgets/viewer-widget';
   import { NucliaSearchBar, NucliaSearchResults } from '../../../libs/search-widget/src/widgets/search-video-widget';
 
-  let selected = 'two-widgets';
+  let selected = 'form';
   let showConfiguration = true;
   let widget: NucliaWidget;
   let viewerWidget: NucliaViewerWidget;
@@ -16,7 +16,7 @@
    * Kb with PDF without page indicators (owned by Mat): 8f39fe4e-04e0-4767-bc83-69fc4c9c31c6
    * Kb with different kind of media (owned by Mat): f67d94ee-bd5b-4044-8844-a291c2ac244c
    */
-  let kb = 'd64d2048-8bd2-474a-9ef2-213f85e90025';
+  let kb = 'cbb4afd0-26e6-480a-a814-4e08398bdf3e';
 
   onMount(() => {
     widget?.setActions([

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.7 (unreleased)
 
 - Fix resource data if null
+- Add `getLabelFromFilter` and `getFilterFromLabel` functions
 
 # 1.0.6 (2022-11-17)
 

--- a/libs/sdk-core/src/lib/db/search/filter.ts
+++ b/libs/sdk-core/src/lib/db/search/filter.ts
@@ -1,0 +1,10 @@
+import type { Classification } from '../resource';
+
+export function getFilterFromLabel(label: Classification) {
+  return `/l/${label.labelset}/${label.label}`;
+}
+
+export function getLabelFromFilter(filter: string): Classification {
+  const items = filter.split('/');
+  return { labelset: items[2], label: items[3] };
+}

--- a/libs/sdk-core/src/lib/db/search/index.ts
+++ b/libs/sdk-core/src/lib/db/search/index.ts
@@ -1,2 +1,3 @@
+export * from './filter';
 export * from './search.models';
 export * from './search';

--- a/libs/search-widget/src/common/label/label.utils.ts
+++ b/libs/search-widget/src/common/label/label.utils.ts
@@ -3,12 +3,19 @@ import { isViewerOpen } from '../../core/stores/modal.store';
 import { nucliaStore } from '../../core/old-stores/main.store';
 import { typeAhead } from '../../core/stores/suggestions.store';
 
-export const labelRegexp = new RegExp(/LABEL=\{([^/]+\/[^}]+)}/, 'g');
-export const typingLabelRegexp = new RegExp(/LABEL=?\{?[^}]*}?/, 'g');
-
 export function searchBy(label: Classification) {
   isViewerOpen.set(false);
-  const labelFilter = `LABEL={${label.labelset}/${label.label}}`;
+  const labelFilter = getFilterFromLabel(label);
   typeAhead.set('');
   nucliaStore().filters.next([labelFilter]);
+  nucliaStore().triggerSearch.next();
+}
+
+export function getFilterFromLabel(label: Classification) {
+  return `/l/${label.labelset}/${label.label}`;
+}
+
+export function getLabelFromFilter(filter: string): Classification {
+  const items = filter.split('/');
+  return { labelset: items[2], label: items[3] };
 }

--- a/libs/search-widget/src/common/label/label.utils.ts
+++ b/libs/search-widget/src/common/label/label.utils.ts
@@ -1,4 +1,5 @@
 import type { Classification } from '@nuclia/core';
+import { getFilterFromLabel } from '@nuclia/core';
 import { isViewerOpen } from '../../core/stores/modal.store';
 import { nucliaStore } from '../../core/old-stores/main.store';
 import { typeAhead } from '../../core/stores/suggestions.store';
@@ -9,13 +10,4 @@ export function searchBy(label: Classification) {
   typeAhead.set('');
   nucliaStore().filters.next([labelFilter]);
   nucliaStore().triggerSearch.next();
-}
-
-export function getFilterFromLabel(label: Classification) {
-  return `/l/${label.labelset}/${label.label}`;
-}
-
-export function getLabelFromFilter(filter: string): Classification {
-  const items = filter.split('/');
-  return { labelset: items[2], label: items[3] };
 }

--- a/libs/search-widget/src/core/models.ts
+++ b/libs/search-widget/src/core/models.ts
@@ -105,10 +105,6 @@ export interface LinkPreviewParams {
   file: CloudLink;
 }
 
-export interface Intents {
-  labels?: Classification[];
-}
-
 export interface EntityGroup {
   id: string;
   title?: string;

--- a/libs/search-widget/src/core/old-stores/main.store.ts
+++ b/libs/search-widget/src/core/old-stores/main.store.ts
@@ -12,7 +12,7 @@ import {
   tap,
 } from 'rxjs';
 import type { Classification, IResource, Search, SearchOptions } from '@nuclia/core';
-import { getFilterFromLabel } from '../../common/label/label.utils';
+import { getFilterFromLabel } from '@nuclia/core';
 
 type NucliaStore = {
   query: BehaviorSubject<string>;
@@ -99,18 +99,15 @@ export const setDisplayedResource = (resource: DisplayedResource) => {
 export const addLabelFilter = (label: Classification) => {
   const filter = getFilterFromLabel(label);
   const currentFilters = nucliaStore().filters.value;
-  nucliaStore().filters.next(currentFilters.concat([filter]));
+  if (!currentFilters.includes(filter)) {
+    nucliaStore().filters.next(currentFilters.concat([filter]));
+  }
 };
 
 export const removeLabelFilter = (label: Classification) => {
   const filter = getFilterFromLabel(label);
   const currentFilters = nucliaStore().filters.value;
-  const filterIndex = currentFilters.findIndex((f) => f === filter);
-  if (filterIndex > -1) {
-    const newFilters = [...currentFilters];
-    newFilters.splice(filterIndex, 1);
-    nucliaStore().filters.next(newFilters);
-  }
+  nucliaStore().filters.next(currentFilters.filter((f) => f !== filter));
 };
 
 const getSortedResources = (results: Search.Results) => {

--- a/libs/search-widget/src/core/old-stores/main.store.ts
+++ b/libs/search-widget/src/core/old-stores/main.store.ts
@@ -11,7 +11,8 @@ import {
   Subject,
   tap,
 } from 'rxjs';
-import type { IResource, Search, SearchOptions } from '@nuclia/core';
+import type { Classification, IResource, Search, SearchOptions } from '@nuclia/core';
+import { getFilterFromLabel } from '../../common/label/label.utils';
 
 type NucliaStore = {
   query: BehaviorSubject<string>;
@@ -93,6 +94,23 @@ export const resetStore = () => {
 
 export const setDisplayedResource = (resource: DisplayedResource) => {
   nucliaStore().displayedResource.next(resource);
+};
+
+export const addLabelFilter = (label: Classification) => {
+  const filter = getFilterFromLabel(label);
+  const currentFilters = nucliaStore().filters.value;
+  nucliaStore().filters.next(currentFilters.concat([filter]));
+};
+
+export const removeLabelFilter = (label: Classification) => {
+  const filter = getFilterFromLabel(label);
+  const currentFilters = nucliaStore().filters.value;
+  const filterIndex = currentFilters.findIndex((f) => f === filter);
+  if (filterIndex > -1) {
+    const newFilters = [...currentFilters];
+    newFilters.splice(filterIndex, 1);
+    nucliaStore().filters.next(newFilters);
+  }
 };
 
 const getSortedResources = (results: Search.Results) => {

--- a/libs/search-widget/src/core/stores/effects.ts
+++ b/libs/search-widget/src/core/stores/effects.ts
@@ -4,8 +4,6 @@ import { suggestions, typeAhead } from './suggestions.store';
 import { debounceTime, distinctUntilChanged, filter, forkJoin, map, merge, Observable, of, Subscription } from 'rxjs';
 import { switchMap } from 'rxjs/operators';
 import { NO_RESULTS } from '../models';
-import { typingLabelRegexp } from '../../common/label/label.utils';
-import { nucliaStore } from '../old-stores/main.store';
 import { searchWidget } from './widget.store';
 import type { Classification, Search } from '@nuclia/core';
 
@@ -34,8 +32,6 @@ export function activateTypeAheadSuggestions() {
     typeAhead.pipe(debounceTime(350)),
   )
     .pipe(
-      // trim and remove LABEL filter if any
-      map((query) => (query || '').replace(typingLabelRegexp, '').trim()),
       // Don't trigger suggestion after inactivity if only spaces were added at the end of the query
       distinctUntilChanged((previous, current) => previous === current),
       switchMap((query) => {
@@ -57,19 +53,6 @@ export function activateTypeAheadSuggestions() {
       }),
     )
     .subscribe((suggestionList) => suggestions.set(suggestionList));
-
-  subscriptions.push(subscription);
-}
-
-/**
- * Subscribe to filters, update query and trigger search
- */
-export function activateFilters() {
-  const subscription = nucliaStore().filters.subscribe((filters) => {
-    const query = filters.join(' ');
-    nucliaStore().query.next(query);
-    nucliaStore().triggerSearch.next();
-  });
 
   subscriptions.push(subscription);
 }

--- a/libs/search-widget/src/core/stores/effects.ts
+++ b/libs/search-widget/src/core/stores/effects.ts
@@ -42,7 +42,6 @@ export function activateTypeAheadSuggestions() {
         if (!query || query.length <= 2) {
           return of({
             results: NO_RESULTS,
-            intents: {},
           });
         }
         const requests: [Observable<Search.Suggestions>, Observable<Classification[]>] = searchWidget.getValue()
@@ -52,7 +51,7 @@ export function activateTypeAheadSuggestions() {
         return forkJoin(requests).pipe(
           map(([results, predictions]) => ({
             results,
-            intents: { labels: predictions },
+            labels: predictions,
           })),
         );
       }),

--- a/libs/search-widget/src/core/stores/suggestions.store.ts
+++ b/libs/search-widget/src/core/stores/suggestions.store.ts
@@ -1,12 +1,11 @@
 import { SvelteState } from '../state-lib';
 import type { Classification, Search } from '@nuclia/core';
-import type { Intents } from '../models';
 import { NO_RESULTS } from '../models';
 import { combineLatest, map, Observable } from 'rxjs';
 
 export type Suggestions = {
   results: Search.Results;
-  intents: Intents;
+  labels?: Classification[];
 };
 
 interface SuggestionState {
@@ -19,7 +18,6 @@ export const suggestionState = new SvelteState<SuggestionState>({
   typeAhead: '',
   suggestions: {
     results: NO_RESULTS,
-    intents: {},
   },
   hasError: false,
 });
@@ -53,10 +51,10 @@ export const suggestedParagraphs: Observable<Search.Paragraph[]> = suggestionSta
   (state) => state.suggestions.results.paragraphs?.results || [],
 );
 
-export const suggestedIntents: Observable<Classification[]> = suggestionState.reader<Classification[]>(
-  (state) => state.suggestions.intents.labels || [],
+export const suggestedLabels: Observable<Classification[]> = suggestionState.reader<Classification[]>(
+  (state) => state.suggestions.labels || [],
 );
 
-export const hasSuggestions: Observable<boolean> = combineLatest([suggestedParagraphs, suggestedIntents]).pipe(
-  map(([suggestedParagraphs, suggestedIntents]) => suggestedParagraphs.length > 0 || suggestedIntents.length > 0),
+export const hasSuggestions: Observable<boolean> = combineLatest([suggestedParagraphs, suggestedLabels]).pipe(
+  map(([suggestedParagraphs, suggestedLabels]) => suggestedParagraphs.length > 0 || suggestedLabels.length > 0),
 );

--- a/libs/search-widget/src/old-components/search-input/SearchInput.scss
+++ b/libs/search-widget/src/old-components/search-input/SearchInput.scss
@@ -1,6 +1,7 @@
 .sw-search-input {
   display: flex;
   flex-direction: column;
+  position: relative;
 
   .input-container {
     box-sizing: border-box;
@@ -80,6 +81,13 @@
     .input-container {
       line-height: var(--line-height-body);
       padding: var(--input-widget-padding);
+    }
+
+    .filters-container {
+      position: absolute;
+      left: calc(100% + var(--rhythm-2));
+      top: 50%;
+      transform: translateY(-50%);
     }
   }
 

--- a/libs/search-widget/src/old-components/search-input/SearchInput.svelte
+++ b/libs/search-widget/src/old-components/search-input/SearchInput.svelte
@@ -8,7 +8,7 @@
   import Suggestions from '../suggestions/Suggestions.svelte';
   import {
     hasSuggestions,
-    suggestedIntents,
+    suggestedLabels,
     suggestedParagraphs,
     suggestionsHasError,
     typeAhead,
@@ -170,7 +170,7 @@
   <div class="sw-suggestions-container">
     <Suggestions
       paragraphs={$suggestedParagraphs}
-      intents={$suggestedIntents} />
+      labels={$suggestedLabels} />
   </div>
 </Modal>
 

--- a/libs/search-widget/src/old-components/search-input/SearchInput.svelte
+++ b/libs/search-widget/src/old-components/search-input/SearchInput.svelte
@@ -17,7 +17,7 @@
   import Label from '../../common/label/Label.svelte';
   import { map, Observable } from 'rxjs';
   import type { Classification } from '@nuclia/core';
-  import { getLabelFromFilter } from '../../common/label/label.utils';
+  import { getLabelFromFilter } from '@nuclia/core';
 
   export let popupSearch = false;
   export let embeddedSearch = false;
@@ -36,8 +36,9 @@
   const filters = nucliaState().filters.pipe(
     tap((filters) => {
       // search box size changes when there are filters or not
-      if (hasFilters !== filters.length > 0) {
-        hasFilters = filters.length > 0;
+      const hasFiltersNow = filters.length > 0;
+      if (hasFilters !== hasFiltersNow) {
+        hasFilters = hasFiltersNow;
         setTimeout(() => setInputPosition());
       }
     }),

--- a/libs/search-widget/src/old-components/search-input/SearchInput.svelte
+++ b/libs/search-widget/src/old-components/search-input/SearchInput.svelte
@@ -133,7 +133,7 @@
     {/if}
   </div>
 
-  {#if $filters.length > 0 && (embeddedSearch || searchBarWidget)}
+  {#if $filters.length > 0}
     <div class="filters-container">
       {#each $labels as label (label.label)}
         <Label

--- a/libs/search-widget/src/old-components/suggestions/Suggestions.svelte
+++ b/libs/search-widget/src/old-components/suggestions/Suggestions.svelte
@@ -11,7 +11,7 @@
   import Label from '../../common/label/Label.svelte';
 
   export let paragraphs: Search.Paragraph[] = [];
-  export let intents: Classification[] = [];
+  export let labels: Classification[] = [];
 
   const goToResource = (params: DisplayedResource, text?: string) => {
     if (navigateToLink.getValue() && params.paragraph?.field_type === FieldType.LINK) {
@@ -24,6 +24,11 @@
       setDisplayedResource(params);
     }
   };
+
+  const addFilter = (label: Classification) => {
+    // TODO
+    console.log(label);
+  };
 </script>
 
 <div class="sw-suggestions">
@@ -33,13 +38,16 @@
       <span>{$_('error.search-beta')}</span>
     </div>
   {:else}
-    {#if intents.length > 0}
+    {#if labels.length > 0}
       <section>
         <h3>{$_('suggest.intents')}</h3>
         <ul class="intents">
-          {#each intents as intent}
+          {#each labels as label}
             <li>
-              <Label label={intent} />
+              <Label
+                {label}
+                clickable
+                on:click={addFilter(label)} />
             </li>
           {/each}
         </ul>

--- a/libs/search-widget/src/old-components/suggestions/Suggestions.svelte
+++ b/libs/search-widget/src/old-components/suggestions/Suggestions.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import type { Classification, LinkField, Search } from '@nuclia/core';
   import { FIELD_TYPE } from '@nuclia/core';
-  import { setDisplayedResource } from '../../core/old-stores/main.store';
+  import { addLabelFilter, setDisplayedResource } from '../../core/old-stores/main.store';
   import { getField } from '../../core/api';
   import { goToUrl, isYoutubeUrl } from '../../core/utils';
   import { _ } from '../../core/i18n';
@@ -24,11 +24,6 @@
       setDisplayedResource(params);
     }
   };
-
-  const addFilter = (label: Classification) => {
-    // TODO
-    console.log(label);
-  };
 </script>
 
 <div class="sw-suggestions">
@@ -47,7 +42,7 @@
               <Label
                 {label}
                 clickable
-                on:click={addFilter(label)} />
+                on:click={() => addLabelFilter(label)} />
             </li>
           {/each}
         </ul>

--- a/libs/search-widget/src/widgets/search-widget/Widget.svelte
+++ b/libs/search-widget/src/widgets/search-widget/Widget.svelte
@@ -14,7 +14,7 @@
   import { setupTriggerSearch } from '../../core/search-bar';
   import globalCss from '../../common/_global.scss';
   import { customStyle, setWidgetActions, widgetType, navigateToLink } from '../../core/stores/widget.store';
-  import { activateFilters, activateTypeAheadSuggestions, unsubscribeAllEffects } from '../../core/stores/effects';
+  import { activateTypeAheadSuggestions, unsubscribeAllEffects } from '../../core/stores/effects';
   import { isViewerOpen } from '../../core/stores/modal.store';
   import { initViewerEffects, unsubscribeViewerEffects } from '../../core/old-stores/viewer-effects';
 
@@ -106,7 +106,6 @@
     customStyle.subscribe((css) => (style = css));
 
     activateTypeAheadSuggestions();
-    activateFilters();
 
     setupTriggerSearch(dispatchCustomEvent);
     initViewerEffects(_permalink);


### PR DESCRIPTION
- Remove intent layer in suggestions to have labels directly
- Add suggested label to filters on click
  - Store the filter string directly instead of an encoded filter query
  - Remove the support for encoded filter query from search input
  - Remove `activateFilters` effect and trigger search directly from `searchBy(label: Classification)` function
- Display filters on the right of popup search input