### PR TITLE
Fix content-type on upload & fix upload of json files

### DIFF
--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -9,6 +9,10 @@
 - Add `TextFieldFormat` type
 - Add `importDataset` method to `WritableKnowledgeBox`
 
+### Bugfix
+
+- Don't parse the body of a post request when `specialContentType` is set, even if special `content-type` is set to `application/json`
+
 # 1.1.0 (2022-12-08)
 
 ### Breaking change

--- a/libs/sdk-core/src/lib/db/upload.ts
+++ b/libs/sdk-core/src/lib/db/upload.ts
@@ -150,9 +150,8 @@ export const TUSuploadFile = (
   if (metadata?.md5) {
     uploadMetadata.push(`md5 ${btoa(metadata.md5)}`);
   }
-  if (metadata?.contentType) {
-    uploadMetadata.push(`content_type ${btoa(metadata.contentType)}`);
-  }
+  uploadMetadata.push(`content_type ${btoa(metadata?.contentType || 'application/octet-stream')}`);
+
   if (uploadMetadata.length > 0) {
     headers['upload-metadata'] = uploadMetadata.join(',');
   }

--- a/libs/sdk-core/src/lib/rest/rest.ts
+++ b/libs/sdk-core/src/lib/rest/rest.ts
@@ -80,8 +80,7 @@ export class Rest implements IRest {
     doNotParse?: boolean,
     synchronous = false,
   ): Observable<T> {
-    const specialContentType =
-      extraHeaders && extraHeaders['content-type'] && extraHeaders['content-type'] !== 'application/json';
+    const specialContentType = extraHeaders && extraHeaders['content-type'];
     return fromFetch(this.getFullUrl(path), {
       selector: (response) => Promise.resolve(response),
       headers: this.getHeaders(extraHeaders, synchronous),


### PR DESCRIPTION
  - Always set content_type in upload metadata
  - Don't parse the body of a post request when `specialContentType` is set, even if special `content-type` is set to `application/json`