### PR TITLE
Fix [sc-3457]: Display account deletion confirmation entirely

### DIFF
--- a/apps/dashboard/src/app/account/account-manage/account-delete/account-delete.component.html
+++ b/apps/dashboard/src/app/account/account-manage/account-delete/account-delete.component.html
@@ -4,7 +4,9 @@
   </pa-modal-title>
   <pa-modal-content>
     <div>
-      <pa-checkbox [(value)]="deleteAccount">
+      <pa-checkbox
+        noEllipsis
+        [(value)]="deleteAccount">
         {{ 'account.delete_account_confirm' | translate: { account: (account | async)?.title } }}
       </pa-checkbox>
     </div>

--- a/mrs.developer.json
+++ b/mrs.developer.json
@@ -4,6 +4,6 @@
     "https": "https://github.com/plone/pastanaga-angular.git",
     "path": "/projects/pastanaga-angular/src",
     "package": "@guillotinaweb/pastanaga-angular",
-    "tag": "2.58.5"
+    "tag": "2.58.6"
   }
 }


### PR DESCRIPTION
Use the new `noEllipsis` option on the checkbox used for asking account deletion confirmation