### PR TITLE
Fix [sc-3459]: display icons in Safari

### DIFF
--- a/libs/search-widget/src/common/icons/Icon.svelte
+++ b/libs/search-widget/src/common/icons/Icon.svelte
@@ -7,9 +7,7 @@
   <svg
     class="sw-svg-icon {size}"
     tabindex="-1">
-    <use
-      xmlns:xlink="http://www.w3.org/1999/xlink"
-      xlink:href="#{name}" />
+    <use href="#{name}" />
   </svg>
 {/if}
 

--- a/libs/search-widget/src/widgets/search-video-widget/SearchBar.svelte
+++ b/libs/search-widget/src/widgets/search-video-widget/SearchBar.svelte
@@ -109,7 +109,7 @@
 <div
   class="nuclia-widget"
   data-version="__NUCLIA_DEV_VERSION__">
-  {#if ready}
+  {#if ready && !!svgSprite}
     <SearchInput searchBarWidget={true} />
   {/if}
   <div

--- a/libs/search-widget/src/widgets/search-widget/Widget.svelte
+++ b/libs/search-widget/src/widgets/search-widget/Widget.svelte
@@ -140,7 +140,7 @@
 <div
   class="nuclia-widget"
   data-version="__NUCLIA_DEV_VERSION__">
-  {#if ready}
+  {#if ready && !!svgSprite}
     {#if type === 'popup'}
       <PopupSearch />
     {:else if type === 'embedded'}

--- a/libs/search-widget/src/widgets/viewer-widget/ViewerWidget.svelte
+++ b/libs/search-widget/src/widgets/viewer-widget/ViewerWidget.svelte
@@ -96,7 +96,7 @@
 <div
   class="nuclia-widget"
   data-version="__NUCLIA_DEV_VERSION__">
-  {#if ready}
+  {#if ready && !!svgSprite}
     <ViewerModal />
   {/if}
 


### PR DESCRIPTION
  - There was a race condition: our svg sprite was loaded in the DOM slightly after the SearchInput, so the icons in SearchInput was not loaded in the DOM.
  - cleanup Icon component: During the investigations, we realised we were using deprecated HTML code (`xlink:href`) and useless `xmlns:xlink`