### PR TITLE
Fix search query in resource list

### DIFF
--- a/apps/dashboard/src/app/resources/resource-list.component.ts
+++ b/apps/dashboard/src/app/resources/resource-list.component.ts
@@ -37,6 +37,7 @@ import {
   ResourceStatus,
   resourceToAlgoliaFormat,
   Search,
+  SortOrder,
 } from '@nuclia/core';
 import { BackendConfigurationService, SDKService, StateService, STFUtils } from '@flaps/core';
 import { SisModalService, SisToastService } from '@nuclia/sistema';
@@ -55,7 +56,7 @@ interface ListFilters {
   page?: string;
   size?: string;
   sortBy?: string;
-  sortDirection?: 'asc' | 'desc';
+  sortDirection?: SortOrder;
 }
 
 interface KeyValue {
@@ -482,7 +483,7 @@ export class ResourceListComponent implements AfterViewInit, OnInit, OnDestroy {
             inTitleOnly: titleOnly,
             page_number: page,
             page_size: this.pageSize,
-            sort: 'created',
+            sort: { field: 'created' },
             with_status: this.statusDisplayed.value,
           }),
           this.labelSets$.pipe(take(1)),

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -1,4 +1,4 @@
-# 1.1.2 (unreleased)
+# 1.1.2 (2023-01-20)
 
 ### Bugfix
 
@@ -9,6 +9,7 @@
 - Add `filename` and `md5` in `CloudLink` model
 - Add `updateField` method on resource
 - Allow to get suggestions based on title only
+- Sort option on search is now an object. Add corresponding `SortOption` interface and `SortOrder` type in our model.
 
 # 1.1.1 (2023-01-03)
 

--- a/libs/sdk-core/package.json
+++ b/libs/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuclia/core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "SDK allowing to integrate Nuclia services in your frontend application",
   "license": "MIT",
   "keywords": [

--- a/libs/sdk-core/src/lib/db/search/search.models.ts
+++ b/libs/sdk-core/src/lib/db/search/search.models.ts
@@ -3,6 +3,14 @@ import type { FIELD_TYPE, IResource } from '../resource';
 
 export type ResourceStatus = 'PENDING' | 'PROCESSED' | 'ERROR';
 
+export type SortOrder = 'asc' | 'desc';
+
+export interface SortOption {
+  field: 'created' | 'modified' | 'title';
+  limit?: number;
+  order?: SortOrder;
+}
+
 export interface SearchOptions {
   // non API-official options
   inTitleOnly?: boolean;
@@ -11,7 +19,7 @@ export interface SearchOptions {
   highlight?: boolean;
   faceted?: string[];
   filters?: string[];
-  sort?: 'created' | 'modified';
+  sort?: SortOption;
   page_number?: number;
   page_size?: number;
   max_score?: number;


### PR DESCRIPTION
  - Sort option on search is now an object.
  - Add corresponding `SortOption` interface and `SortOrder` type in our model.
  - Improve serialization in search to support options from object (like sort)