### PR TITLE
[sc-3675] Refactor results by fields

### DIFF
--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -15,9 +15,8 @@
   /**
    * Classifier_test kb (already trained, owned by Carmen): cbb4afd0-26e6-480a-a814-4e08398bdf3e
    * Kb with different kind of media (owned by Mat): 5c2bc432-a579-48cd-b408-4271e5e7a43c
-   * Kb with PDFs and text contents (owned by Mat): ffbc498b-993c-4052-ab2a-1453c7e50198
    */
-  let kb = 'ffbc498b-993c-4052-ab2a-1453c7e50198';
+  let kb = 'f5d0ec7f-9ac3-46a3-b284-a38d5333d9e6';
 
   onMount(() => {
     widget?.setActions([

--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -16,7 +16,7 @@
    * Classifier_test kb (already trained, owned by Carmen): cbb4afd0-26e6-480a-a814-4e08398bdf3e
    * Kb with different kind of media (owned by Mat): 5c2bc432-a579-48cd-b408-4271e5e7a43c
    */
-  let kb = 'f5d0ec7f-9ac3-46a3-b284-a38d5333d9e6';
+  let kb = '6b241c4d-3eb1-4ed8-9c4f-c88dbf738416';
 
   onMount(() => {
     widget?.setActions([

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Fix `getAnnotatedEntities` method to filter out `cancelled_by_user` annotations from the list.
 - Rename interface `ParagraphAnnotation` to `ParagraphClassification` to avoid confusion
 - Update training types: labeler split in two `resoure-labeler` and `paragraph-labeler`
+- Add `field` property to `Search.SmartResult` interface
 
 # 1.1.2 (2023-01-20)
 

--- a/libs/sdk-core/src/lib/db/search/search.models.ts
+++ b/libs/sdk-core/src/lib/db/search/search.models.ts
@@ -1,5 +1,5 @@
 import type { ExtractedDataTypes, ResourceProperties } from '../kb';
-import type { FIELD_TYPE, IResource, RelationType, RelationEntityType } from '../resource';
+import type { FIELD_TYPE, FieldId, IResource, RelationEntityType, RelationType } from '../resource';
 
 export type ResourceStatus = 'PENDING' | 'PROCESSED' | 'ERROR';
 
@@ -68,6 +68,7 @@ export namespace Search {
 
   export interface SmartResult extends IResource {
     paragraphs?: SmartParagraph[];
+    field?: FieldId;
   }
 
   export interface SmartParagraph extends Paragraph {

--- a/libs/search-widget/src/core/stores/search.store.spec.ts
+++ b/libs/search-widget/src/core/stores/search.store.spec.ts
@@ -1,0 +1,90 @@
+import { addParagraphToSmartResults } from './search.store';
+import type { FIELD_TYPE, Search } from '@nuclia/core';
+
+describe('search.store', () => {
+  const r1: Search.SmartResult = {
+    id: 'r1',
+  };
+  const r1p1: Search.SmartParagraph = {
+    field: 'r1/f1',
+    field_type: 'file',
+    rid: 'r1',
+    score: 0.9,
+    text: 'r1p1 text',
+    labels: [],
+  };
+  const r2p1: Search.SmartParagraph = {
+    field: 'r2/f1',
+    field_type: 'file',
+    rid: 'r2',
+    score: 0.9,
+    text: 'r2p1 text',
+    labels: [],
+  };
+  const r2p2: Search.SmartParagraph = {
+    field: 'r2/f1',
+    field_type: 'file',
+    rid: 'r2',
+    score: 0.5,
+    text: 'r2p2 text',
+    labels: [],
+  };
+  const r2p3: Search.SmartParagraph = {
+    field: 'r2/f2',
+    field_type: 'file',
+    rid: 'r2',
+    score: 0.6,
+    text: 'r2p3 text',
+    labels: [],
+  };
+  const r2: Search.SmartResult = {
+    id: 'r2',
+    paragraphs: [r2p1],
+    field: { field_id: r2p1.field, field_type: r2p1.field_type as FIELD_TYPE },
+  };
+
+  describe('addParagraphToSmartResults', () => {
+    it('should return existing smartResults when paragraph is undefined', () => {
+      expect(addParagraphToSmartResults([], r1, undefined)).toEqual([]);
+      expect(addParagraphToSmartResults([r1], r2, undefined)).toEqual([r1]);
+    });
+
+    it('should add a resource when paragraph’s resource is not in smart results already ', () => {
+      expect(addParagraphToSmartResults([], r1, r1p1)).toEqual([
+        {
+          ...r1,
+          paragraphs: [r1p1],
+          field: { field_id: r1p1.field, field_type: r1p1.field_type },
+        },
+      ]);
+      expect(addParagraphToSmartResults([r2], r1, r1p1)).toEqual([
+        { ...r2 },
+        {
+          ...r1,
+          paragraphs: [r1p1],
+          field: { field_id: r1p1.field, field_type: r1p1.field_type },
+        },
+      ]);
+    });
+
+    it('should add paragraph in smart result’s existing resource', () => {
+      expect(addParagraphToSmartResults([r2], r2, r2p2)).toEqual([
+        {
+          ...r2,
+          paragraphs: [r2p1, r2p2],
+        },
+      ]);
+    });
+
+    it('should not add paragraph which already exists in smart results', () => {
+      expect(addParagraphToSmartResults([r2], r2, r2p1)).toEqual([r2]);
+    });
+
+    it('should duplicate resource when adding paragraph from another field', () => {
+      expect(addParagraphToSmartResults([r2], r2, r2p3)).toEqual([
+        { ...r2 },
+        { id: r2.id, field: { field_id: r2p3.field, field_type: r2p3.field_type }, paragraphs: [r2p3] },
+      ]);
+    });
+  });
+});

--- a/libs/search-widget/src/core/stores/search.store.spec.ts
+++ b/libs/search-widget/src/core/stores/search.store.spec.ts
@@ -78,6 +78,18 @@ describe('search.store', () => {
 
     it('should not add paragraph which already exists in smart results', () => {
       expect(addParagraphToSmartResults([r2], r2, r2p1)).toEqual([r2]);
+      const sameWithMarks = {
+        ...r2p1,
+        field: 'r3/f1',
+        text: `\n  Messi <mark>is</mark> <mark>the</mark> <mark>best</mark> <mark>player</mark>. \n`,
+      };
+      const sameWithBlanks = { ...r2p1, field: 'r3/f1', text: ` Messi is the best player.\n` };
+      const r3: Search.SmartResult = {
+        id: 'r3',
+        paragraphs: [sameWithMarks],
+        field: { field_id: 'r3/f1', field_type: r2p1.field_type as FIELD_TYPE },
+      };
+      expect(addParagraphToSmartResults([r3], { id: 'r3' }, sameWithBlanks)).toEqual([r3]);
     });
 
     it('should duplicate resource when adding paragraph from another field', () => {

--- a/libs/search-widget/src/core/stores/search.store.ts
+++ b/libs/search-widget/src/core/stores/search.store.ts
@@ -205,7 +205,7 @@ export function addParagraphToSmartResults(
   );
   if (existingResource) {
     const existingParagraph = existingResource.paragraphs?.find(
-      (p) => p.text.replace(marksRE, '') === paragraph.text.replace(marksRE, ''),
+      (p) => p.text.replace(marksRE, '').trim() === paragraph.text.replace(marksRE, '').trim(),
     );
     if (!existingParagraph) {
       existingResource.paragraphs = existingResource.paragraphs || [];


### PR DESCRIPTION
Add field property to SmartResult, and make sure SmartResult list has one entry by field. This way we can have several tiles for one resource if some results are coming from different fields of the resource.

And fix https://app.shortcut.com/flaps/story/3827/merging-paragraph-and-sentence-search-results-may-have-duplicates