### PR TITLE
Fix [sc-3807]: audio tile

### DIFF
--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -16,7 +16,7 @@
    * Classifier_test kb (already trained, owned by Carmen): cbb4afd0-26e6-480a-a814-4e08398bdf3e
    * Kb with different kind of media (owned by Mat): 5c2bc432-a579-48cd-b408-4271e5e7a43c
    */
-  let kb = '6b241c4d-3eb1-4ed8-9c4f-c88dbf738416';
+  let kb = '5c2bc432-a579-48cd-b408-4271e5e7a43c';
 
   onMount(() => {
     widget?.setActions([

--- a/libs/search-widget/src/old-components/viewer/previewers/Player.svelte
+++ b/libs/search-widget/src/old-components/viewer/previewers/Player.svelte
@@ -5,7 +5,7 @@
   export let src: string;
   export let type: string;
   export let time: number | undefined;
-  let firstLoad: boolean = false;
+  let firstLoadDone = false;
   let currentTime: number | undefined;
   let paused: boolean = true;
   let player: HTMLMediaElement;
@@ -26,7 +26,7 @@
     }
   });
 
-  $: if (firstLoad && typeof time === 'number') {
+  $: if (firstLoadDone && typeof time === 'number') {
     currentTime = time;
     play();
   }
@@ -85,7 +85,7 @@
         crossorigin="anonymous"
         controls
         on:canplay={() => {
-          if (!firstLoad) firstLoad = true;
+          if (!firstLoadDone) firstLoadDone = true;
           dispatch('videoReady');
         }}
         bind:this={player}
@@ -103,7 +103,7 @@
       crossorigin="anonymous"
       controls
       on:canplay={() => {
-        if (!firstLoad) firstLoad = true;
+        if (!firstLoadDone) firstLoadDone = true;
       }}
       bind:this={player}
       bind:currentTime

--- a/libs/search-widget/src/tiles/audio-tile/AudioTile.svelte
+++ b/libs/search-widget/src/tiles/audio-tile/AudioTile.svelte
@@ -83,12 +83,12 @@
   };
 
   const playParagraph = (paragraph: MediaWidgetParagraph) => {
-    playFrom(paragraph.start_seconds);
+    playFrom(paragraph.start_seconds || 0);
     paragraphInPlay = paragraph;
   };
 
   const playTranscript = (paragraph) => {
-    mediaTime = paragraph.start_seconds || 0;
+    playFrom(paragraph.start_seconds || 0);
     paragraphInPlay = paragraph;
   };
 
@@ -161,7 +161,7 @@
         hasBackground={!result.thumbnail}
         aspectRatio={expanded ? '16/9' : '5/4'}
         on:loaded={() => (thumbnailLoaded = true)}
-        on:open={playFromStart} />
+        on:play={playFromStart} />
     </div>
 
     {#if expanded}
@@ -172,6 +172,7 @@
           <AudioPlayer
             time={mediaTime}
             src={$mediaUri}
+            on:audioReady={() => (mediaLoading = false)}
             on:error={() => (mediaLoading = false)} />
         {/if}
       </div>

--- a/libs/search-widget/src/tiles/video-tile/VideoTile.svelte
+++ b/libs/search-widget/src/tiles/video-tile/VideoTile.svelte
@@ -182,7 +182,7 @@
         hasBackground={!result.thumbnail}
         aspectRatio={expanded ? '16/9' : '5/4'}
         on:loaded={() => (thumbnailLoaded = true)}
-        on:open={playFromStart} />
+        on:play={playFromStart} />
     </div>
 
     {#if expanded}


### PR DESCRIPTION
- fix ThumbnailPlayer event listener so clicking on the thumbnail starts the video/audio
- toggle mediaLoading when audio is ready so audio player is displayed
- fix play from paragraph and from transcript on audio tile
- fix play from 0
- add ability to play/pause audio with space key