### PR TITLE
Fix error view on resource list

### DIFF
--- a/app.babel
+++ b/app.babel
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<babeledit_project be_version="4.0.1" version="1.3">
+<babeledit_project be_version="4.0.3" version="1.3">
 	<!--
 
     BabelEdit project file
@@ -9321,6 +9321,26 @@
 					</concept_node>
 					<concept_node>
 						<name>resource.classification</name>
+						<description/>
+						<comment/>
+						<default_text/>
+						<translations>
+							<translation>
+								<language>ca-ES</language>
+								<approved>false</approved>
+							</translation>
+							<translation>
+								<language>en-US</language>
+								<approved>false</approved>
+							</translation>
+							<translation>
+								<language>es-ES</language>
+								<approved>false</approved>
+							</translation>
+						</translations>
+					</concept_node>
+					<concept_node>
+						<name>resource.classification-column</name>
 						<description/>
 						<comment/>
 						<default_text/>

--- a/apps/dashboard/src/app/resources/resource-list.component.html
+++ b/apps/dashboard/src/app/resources/resource-list.component.html
@@ -224,7 +224,7 @@
           <th
             cdk-header-cell
             *cdkHeaderCellDef>
-            {{ 'resource.classification' | translate }}
+            {{ 'resource.classification-column' | translate }}
           </th>
           <td
             cdk-cell

--- a/apps/dashboard/src/app/resources/resource-list.component.ts
+++ b/apps/dashboard/src/app/resources/resource-list.component.ts
@@ -34,6 +34,7 @@ import {
   LabelSets,
   ProcessingStatusResponse,
   Resource,
+  RESOURCE_STATUS,
   ResourceStatus,
   resourceToAlgoliaFormat,
   Search,
@@ -257,7 +258,7 @@ export class ResourceListComponent implements AfterViewInit, OnInit, OnDestroy {
       { value: 'title', label: 'resource.title', visible: true, showInPending: true },
       {
         value: 'classification',
-        label: 'resource.classification',
+        label: 'resource.classification-column',
         visible: this.userPreferences.columns.includes('classification'),
         optional: true,
       },
@@ -324,6 +325,10 @@ export class ResourceListComponent implements AfterViewInit, OnInit, OnDestroy {
 
   bulkDelete() {
     this.delete(this.selection.selected);
+  }
+
+  bulkReprocess() {
+    // TODO
   }
 
   delete(resources: Resource[]) {
@@ -480,6 +485,7 @@ export class ResourceListComponent implements AfterViewInit, OnInit, OnDestroy {
           hasQuery && !titleOnly
             ? [Search.Features.PARAGRAPH, Search.Features.VECTOR, Search.Features.DOCUMENT]
             : [Search.Features.DOCUMENT];
+        const status = this.statusDisplayed.value;
         return forkJoin([
           of(kb),
           kb.search(query, searchFeatures, {
@@ -487,7 +493,8 @@ export class ResourceListComponent implements AfterViewInit, OnInit, OnDestroy {
             page_number: page,
             page_size: this.pageSize,
             sort: { field: 'created' },
-            with_status: this.statusDisplayed.value,
+            filters: status === RESOURCE_STATUS.PROCESSED ? undefined : [`/n/s/${status}`],
+            with_status: status === RESOURCE_STATUS.PROCESSED ? status : undefined,
           }),
           this.labelSets$.pipe(take(1)),
         ]);

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -419,6 +419,7 @@
 	"resource.add_labels_success": "S'han afegit correctament etiquetes a {{count}} recursos",
 	"resource.authorship": "Autoria",
 	"resource.classification": "Classificació de recursos",
+	"resource.classification-column": "Classificació",
 	"resource.classification-page-link": "pàgina de Classificació",
 	"resource.classification.no-paragraph-labelset": "No hi ha cap etiqueta establerta per als paràgrafs. Podeu afegir-ne alguns",
 	"resource.classification.no-resource-labelset": "No hi ha cap etiqueta establerta per als recursos. Podeu afegir-ne alguns",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -465,6 +465,7 @@
 	"resource.add_labels_success": "Labels successfully added on {{count}} resources",
 	"resource.authorship": "Authorship",
 	"resource.classification": "Resource classification",
+	"resource.classification-column": "Classification",
 	"resource.classification-page-link": "Classification page",
 	"resource.classification.no-paragraph-labelset": "There is no label set for paragraphs. You can add some in",
 	"resource.classification.no-resource-labelset": "There is no label set for resources. You can add some in",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -419,6 +419,7 @@
 	"resource.add_labels_success": "Etiquetas añadidas correctamente en {{count}} recursos",
 	"resource.authorship": "Autoría",
 	"resource.classification": "Clasificación de recursos",
+	"resource.classification-column": "Clasificación",
 	"resource.classification-page-link": "página de Clasificación",
 	"resource.classification.no-paragraph-labelset": "No hay un conjunto de etiquetas para los párrafos. Puedes agregar algunos en",
 	"resource.classification.no-resource-labelset": "No hay ninguna etiqueta establecida para los recursos. Puedes agregar algunos en",


### PR DESCRIPTION
 - Display only resources processed at least once on processed page, even if processing failed or if processing is happening again
 - On processing and failure views, filter resources by status
 - Fix Classification column title