### PR TITLE
Fix paragraph classification bugs on save

### DIFF
--- a/apps/dashboard/src/app/resources/edit/classification/paragraph-classification/paragraph-classification.component.ts
+++ b/apps/dashboard/src/app/resources/edit/classification/paragraph-classification/paragraph-classification.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { EditResourceService } from '../../edit-resource.service';
-import { combineLatest, filter, map, Observable, Subject, switchMap, tap } from 'rxjs';
+import { combineLatest, filter, map, Observable, Subject, switchMap, take, tap } from 'rxjs';
 import {
   Classification,
   FieldId,
@@ -139,14 +139,19 @@ export class ParagraphClassificationComponent implements OnInit, OnDestroy {
 
   save() {
     this.isSaving = true;
-    this.fieldId.pipe(switchMap((field) => this.editResource.saveClassifications(field, this.paragraphs))).subscribe({
-      next: () => {
-        this.isModified = false;
-        this.isSaving = false;
-        this.cdr.markForCheck();
-      },
-      error: () => (this.isSaving = false),
-    });
+    this.fieldId
+      .pipe(
+        switchMap((field) => this.editResource.saveClassifications(field, this.paragraphs)),
+        take(1),
+      )
+      .subscribe({
+        next: () => {
+          this.isModified = false;
+          this.isSaving = false;
+          this.cdr.markForCheck();
+        },
+        error: () => (this.isSaving = false),
+      });
   }
 
   cancel() {

--- a/apps/dashboard/src/app/resources/edit/edit-resource.helpers.spec.ts
+++ b/apps/dashboard/src/app/resources/edit/edit-resource.helpers.spec.ts
@@ -81,7 +81,6 @@ describe('Edit resource helpers', () => {
             key: 'p2',
             classifications: [{ labelset: 'heroes', label: 'catwoman' }],
           },
-          { key: 'p3', classifications: [] },
         ],
         token: [{ token: 'Joker', klass: 'villain', start: 0, end: 4 }],
       },

--- a/apps/dashboard/src/app/resources/edit/edit-resource.helpers.ts
+++ b/apps/dashboard/src/app/resources/edit/edit-resource.helpers.ts
@@ -56,10 +56,16 @@ export function getFieldMetadataForClassifications(
   paragraphs: ParagraphWithTextAndClassifications[],
   existingEntries: UserFieldMetadata[],
 ): UserFieldMetadata[] {
-  const paragraphClassifications: ParagraphClassification[] = paragraphs.map((p) => ({
-    key: p.paragraphId,
-    classifications: p.userClassifications,
-  }));
+  const paragraphClassifications: ParagraphClassification[] = paragraphs
+    .map((p) =>
+      p.userClassifications.length > 0
+        ? {
+            key: p.paragraphId,
+            classifications: p.userClassifications,
+          }
+        : null,
+    )
+    .filter((classification) => !!classification) as ParagraphClassification[];
 
   let existingField = false;
   const newEntries = existingEntries.map((entry) => {


### PR DESCRIPTION
- Don't send empty classification array in the payload to prevent 422 error `{"detail":"ensure classifications has at least 1 items"}` from the backend
- Prevent success toast to show up several times when switching field view