### PR TITLE
Moving line around to trigger build and deploy dashboard

### DIFF
--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-training/knowledge-box-training.component.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-training/knowledge-box-training.component.ts
@@ -29,8 +29,8 @@ interface TrainingOption {
 export class KnowledgeBoxTrainingComponent implements OnInit, OnDestroy {
   private unsubscribeAll: Subject<void> = new Subject();
 
-  cannotTrain = this.stateService.account.pipe(map((account) => !!account && account.type === 'stash-basic'));
   hasResources = this.sdk.counters.pipe(map((counters) => counters.resources > 0));
+  cannotTrain = this.stateService.account.pipe(map((account) => !!account && account.type === 'stash-basic'));
   trainingTypes = TrainingType;
   labelSets: Observable<TrainingOption[]> = this.sdk.currentKb.pipe(
     switchMap((kb) => kb.getLabels()),


### PR DESCRIPTION
Last two merged PRs were not deployed because of a problem on jenkins, this useless change is to allow a new build and deploy.