### PR TITLE
[sc-4030] Dataset import proposed when not empty

### DIFF
--- a/apps/dashboard/src/app/resources/resource-list.component.html
+++ b/apps/dashboard/src/app/resources/resource-list.component.html
@@ -368,7 +368,7 @@
 
     <div
       class="pagination"
-      *ngIf="!(isEmpty | async)">
+      *ngIf="resultsLength > 0">
       <stf-pagination
         [page]="page"
         [total]="totalPages"
@@ -376,7 +376,7 @@
         (next)="nextPage()"></stf-pagination>
     </div>
     <div
-      *ngIf="isEmpty | async"
+      *ngIf="isMainView && !!data && resultsLength === 0"
       class="empty-kb">
       <p>
         <strong>{{ 'resource.empty' | translate }}</strong>

--- a/apps/dashboard/src/app/resources/resource-list.component.ts
+++ b/apps/dashboard/src/app/resources/resource-list.component.ts
@@ -121,8 +121,6 @@ export class ResourceListComponent implements AfterViewInit, OnInit, OnDestroy {
   unsubscribeAll = new Subject<void>();
   refreshing = true;
 
-  private _isEmpty = new BehaviorSubject<boolean>(false);
-  isEmpty = this._isEmpty.asObservable();
   private _statusCount: BehaviorSubject<{ pending: number; error: number }> = new BehaviorSubject({
     pending: 0,
     error: 0,
@@ -832,7 +830,6 @@ export class ResourceListComponent implements AfterViewInit, OnInit, OnDestroy {
       })),
       tap((count) => {
         this._statusCount.next({ pending: count.pending, error: count.error });
-        this._isEmpty.next(count.pending === 0 && count.error === 0 && count.processed === 0);
       }),
     );
   }

--- a/apps/dashboard/src/app/resources/sample-dataset/dataset-import.component.html
+++ b/apps/dashboard/src/app/resources/sample-dataset/dataset-import.component.html
@@ -5,7 +5,7 @@
     {{ 'onboarding.dataset.option1.description' | translate }}
   </p>
 
-  <app-dataset-selector></app-dataset-selector>
+  <app-dataset-selector (imported)="onDatasetImported($event)"></app-dataset-selector>
 
   <div class="upload-data">
     <h2>{{ 'onboarding.dataset.option2' | translate }}</h2>


### PR DESCRIPTION
- Use data from `/counter` endpoint to check if the knowledge box is empty (at the moment it's more robust than using`fulltext.facets`)