### PR TITLE
[sc-4106] set resource origin when uploading links

### DIFF
--- a/apps/dashboard/src/app/upload/upload.service.ts
+++ b/apps/dashboard/src/app/upload/upload.service.ts
@@ -26,6 +26,7 @@ import {
 } from 'rxjs';
 
 export const FILES_TO_IGNORE = ['.DS_Store', 'Thumbs.db'];
+const REGEX_YOUTUBE_URL = /^(?:https?:)?(?:\/\/)?(?:youtu\.be\/|(?:www\.|m\.)?youtube\.com\/)/;
 
 @Injectable({ providedIn: 'root' })
 export class UploadService {
@@ -123,6 +124,20 @@ export class UploadService {
         );
       }),
       map(() => {}),
+    );
+  }
+
+  createLinkResource(uri: string, classifications: Classification[]) {
+    return this.sdk.currentKb.pipe(
+      take(1),
+      switchMap((kb) =>
+        kb.createLinkResource(
+          { uri },
+          { classifications },
+          true,
+          REGEX_YOUTUBE_URL.test(uri) ? undefined : { url: uri },
+        ),
+      ),
     );
   }
 

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add `fields` in `SearchOptions`
 - Add `ResourceFieldProperties` enum in kb models
 - Add `show` and `extracted` params to `getField` method in `Resource`
+- Add `origin` param to `createLinkResource`
 
 # 1.1.3 (2023-02-08)
 

--- a/libs/sdk-core/src/lib/db/kb/kb.models.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.models.ts
@@ -1,5 +1,5 @@
 import type { Observable } from 'rxjs';
-import type { IResource, LinkField, Resource, UserMetadata } from '../resource';
+import type { IResource, LinkField, Origin, Resource, UserMetadata } from '../resource';
 import type { FileMetadata, FileWithMetadata, UploadResponse, UploadStatus } from '../upload';
 import type { Search, SearchOptions } from '../search';
 
@@ -109,7 +109,12 @@ export interface IWritableKnowledgeBox extends IKnowledgeBox {
 
   createResource(resource: IResource): Observable<{ uuid: string }>;
 
-  createLinkResource(link: LinkField, metadata?: UserMetadata): Observable<{ uuid: string }>;
+  createLinkResource(
+    link: LinkField,
+    metadata?: UserMetadata,
+    synchronous?: boolean,
+    origin?: Origin,
+  ): Observable<{ uuid: string }>;
 
   upload(file: File | FileWithMetadata, TUS?: boolean, metadata?: FileMetadata): Observable<UploadResponse>;
 

--- a/libs/sdk-core/src/lib/db/kb/kb.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.ts
@@ -241,6 +241,9 @@ export class WritableKnowledgeBox extends KnowledgeBox implements IWritableKnowl
         usermetadata: metadata,
         title: link.uri,
         icon: 'application/stf-link',
+        origin: {
+          url: link.uri,
+        },
       },
       synchronous,
     );

--- a/libs/sdk-core/src/lib/db/kb/kb.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.ts
@@ -12,7 +12,7 @@ import {
   ServiceAccountCreation,
 } from './kb.models';
 import type { INuclia } from '../../models';
-import type { ICreateResource, IResource, LinkField, UserMetadata } from '../resource';
+import type { ICreateResource, IResource, LinkField, Origin, UserMetadata } from '../resource';
 import { Resource } from '../resource';
 import type { UploadResponse } from '../upload';
 import { batchUpload, FileMetadata, FileWithMetadata, upload, UploadStatus } from '../upload';
@@ -234,16 +234,19 @@ export class WritableKnowledgeBox extends KnowledgeBox implements IWritableKnowl
     );
   }
 
-  createLinkResource(link: LinkField, metadata?: UserMetadata, synchronous = true): Observable<{ uuid: string }> {
+  createLinkResource(
+    link: LinkField,
+    metadata?: UserMetadata,
+    synchronous = true,
+    origin?: Origin,
+  ): Observable<{ uuid: string }> {
     return this.createResource(
       {
         links: { link },
         usermetadata: metadata,
         title: link.uri,
         icon: 'application/stf-link',
-        origin: {
-          url: link.uri,
-        },
+        ...(origin ? { origin } : {}),
       },
       synchronous,
     );


### PR DESCRIPTION
- Set resource `origin.url` property when creating links from the dashboard
- Don't set `origin.url` when the link is a YouTube video