### PR TITLE
[sc-4262] Fix search and pdf viewer in expanded tile 

### DIFF
--- a/libs/search-widget/src/tiles/base-tile/BaseTile.svelte
+++ b/libs/search-widget/src/tiles/base-tile/BaseTile.svelte
@@ -25,7 +25,6 @@
   import { getExternalUrl, goToUrl, mapSmartParagraph2WidgetParagraph } from '../../core/utils';
   import { navigateToLink } from '../../core/stores/widget.store';
   import {
-    fieldData,
     fieldFullId,
     fieldSummary,
     isPreviewing,
@@ -121,7 +120,6 @@
       });
     }
     resourceTitle.set(result.title || '');
-    viewerSearchQuery.set(globalQuery.getValue());
 
     navigateToLink
       .pipe(
@@ -157,6 +155,7 @@
     if (!expanded) {
       expanded = true;
       isPreviewing.set(true);
+      viewerSearchQuery.set(globalQuery.getValue());
       freezeBackground(true);
     }
     setTimeout(() => setHeaderActionWidth());
@@ -299,7 +298,7 @@
         resourceTitle={result.title}
         on:clickOnTitle={() => onClickParagraph(undefined, -1)}
         on:close={closePreview}>
-        {#if !isMobile && !noResultNavigator}
+        {#if !isMobile && !noResultNavigator && !sidePanelExpanded}
           <SearchResultNavigator
             resultIndex={$matchingParagraphs$.length > 0 ? resultIndex : -1}
             total={$matchingParagraphs$.length}

--- a/libs/search-widget/src/tiles/viewers/PdfViewer.svelte
+++ b/libs/search-widget/src/tiles/viewers/PdfViewer.svelte
@@ -14,7 +14,6 @@
   const pdfJsViewer = window['pdfjs-dist/web/pdf_viewer'];
   pdfJsLib.GlobalWorkerOptions.workerSrc = `${getPdfJsBaseUrl()}/build/pdf.worker.js`;
 
-  let innerHeight = window.innerHeight;
   let innerWidth = window.innerWidth;
   let pdfContainerElement: HTMLElement;
   let containerOffsetWidth;
@@ -37,7 +36,8 @@
   $: src && loadPdf();
   $: pdfViewer && paragraph && paragraph.text && findSelectedText();
   $: pdfViewer && !paragraph && unselectText();
-  $: containerOffsetWidth && resize();
+  $: isMobile = innerWidth < 448;
+  $: scale = isMobile ? 'page-fit' : 'auto';
 
   onMount(() => {
     loadPdf();
@@ -96,7 +96,7 @@
     // Display the right page and highlight the paragraph
     eventBus.on('pagesinit', () => {
       totalPage = pdfViewer.pagesCount;
-      pdfViewer.currentScaleValue = 'page-fit';
+      pdfViewer.currentScaleValue = scale;
       zoom = pdfViewer.currentScale;
       pdfInitialized = true;
 
@@ -155,12 +155,14 @@
 
   function resize() {
     if (!!pdfViewer && pdfInitialized) {
-      pdfViewer.currentScaleValue = 'page-fit';
+      pdfViewer.currentScaleValue = scale;
     }
   }
 </script>
 
-<svelte:window on:resize={resize} />
+<svelte:window
+  bind:innerWidth
+  on:resize={resize} />
 <div
   class="pdf-container"
   bind:this={pdfContainerElement}


### PR DESCRIPTION
- Fix expanded tile side panel search
  - hide main search result navigator when the side panel is open
  - don't reset `viewerSearchQuery` with main search query when clicking on a paragraph
  - initialize viewer search query with main query on
- Fix PDF viewer
  - don't change current scale when opening the side panel
  - use page-fit scale only for mobile (use auto-scale otherwise)