### PR TITLE
Fix scss variables import in common lib

### DIFF
--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import 'variables';
 
 .knowledge-box-home {
   padding: 4.5vw var(--app-layout-margin-right);

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-keys/knowledge-box-keys.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-keys/knowledge-box-keys.component.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import 'variables';
 
 .knowledge-box-keys {
   padding: 70px var(--app-layout-margin-right);

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-profile/knowledge-box-profile.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-profile/knowledge-box-profile.component.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import 'variables';
 
 .knowledge-box-profile {
   padding: rhythm(6) rhythm(12);

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-training/knowledge-box-training.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-training/knowledge-box-training.component.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import 'variables';
 
 .knowledge-box-training {
   width: 770px;

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-training/training-history/training-history.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-training/training-history/training-history.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../variables';
+@import 'variables';
 
 .training-history {
   padding: rhythm(6) rhythm(12);

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-users/users-manage/users-manage.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-users/users-manage/users-manage.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../variables';
+@import 'variables';
 
 .users-left,
 .users-amount {

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box/knowledge-box.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box/knowledge-box.component.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import 'variables';
 
 .upload-bar-container {
   position: sticky;

--- a/apps/dashboard/src/app/knowledge-box/service-access/service-access.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/service-access/service-access.component.scss
@@ -1,4 +1,4 @@
-@import '../../../variables';
+@import 'variables';
 
 .service-access-container {
   h3 {

--- a/libs/common/src/lib/label/label-sets/label-set-list/label-set-list.component.scss
+++ b/libs/common/src/lib/label/label-sets/label-set-list/label-set-list.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../../apps/dashboard/src/variables';
+@import 'apps/dashboard/src/variables';
 
 :host {
   display: block;

--- a/libs/common/src/lib/label/label-sets/label-set/color-picker/color-picker.component.scss
+++ b/libs/common/src/lib/label/label-sets/label-set/color-picker/color-picker.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../../../apps/dashboard/src/variables';
+@import 'apps/dashboard/src/variables';
 
 .color-picker {
   display: flex;

--- a/libs/common/src/lib/label/label-sets/label-set/label-set.component.scss
+++ b/libs/common/src/lib/label/label-sets/label-set/label-set.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../../apps/dashboard/src/variables';
+@import 'apps/dashboard/src/variables';
 
 $dashboard-header-height: rhythm(9);
 $page-title-height: rhythm(8);

--- a/libs/common/src/lib/label/label-sets/label-set/label/label.component.scss
+++ b/libs/common/src/lib/label/label-sets/label-set/label/label.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../../../apps/dashboard/src/variables';
+@import 'apps/dashboard/src/variables';
 
 .label {
   align-items: center;

--- a/libs/common/src/lib/pagination/pagination.component.scss
+++ b/libs/common/src/lib/pagination/pagination.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 .pagination {
   align-items: center;

--- a/libs/common/src/lib/select-account-kb/select-account/select-account.component.scss
+++ b/libs/common/src/lib/select-account-kb/select-account/select-account.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../apps/dashboard/src/variables';
+@import 'apps/dashboard/src/variables';
 
 .select {
   position: relative;

--- a/libs/common/src/lib/upload/upload-bar/upload-bar.component.scss
+++ b/libs/common/src/lib/upload/upload-bar/upload-bar.component.scss
@@ -1,4 +1,4 @@
-@import '../../../../../../apps/dashboard/src/variables';
+@import 'apps/dashboard/src/variables';
 
 .upload-bar {
   @include dark-mode();

--- a/libs/common/src/lib/user/_user-layout.scss
+++ b/libs/common/src/lib/user/_user-layout.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 .main-container {
   display: flex;

--- a/libs/common/src/lib/user/check-mail/check-mail.component.scss
+++ b/libs/common/src/lib/user/check-mail/check-mail.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 .check-email-container {
   padding: 0 rhythm(24);

--- a/libs/common/src/lib/user/consent/consent.component.scss
+++ b/libs/common/src/lib/user/consent/consent.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 .user-background {
   align-items: center;

--- a/libs/common/src/lib/user/login/login.component.scss
+++ b/libs/common/src/lib/user/login/login.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 @import '../user-layout';
 
 .login_form {

--- a/libs/common/src/lib/user/onboarding/onboarding.component.scss
+++ b/libs/common/src/lib/user/onboarding/onboarding.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 .onboarding-container {
   background: $color-light-stronger;

--- a/libs/common/src/lib/user/profile/profile.component.scss
+++ b/libs/common/src/lib/user/profile/profile.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 .profile {
   padding: 10vh 0;

--- a/libs/common/src/lib/user/recover/recover.component.scss
+++ b/libs/common/src/lib/user/recover/recover.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 @import '../user-layout';
 
 .main-container {

--- a/libs/common/src/lib/user/reset/reset.component.scss
+++ b/libs/common/src/lib/user/reset/reset.component.scss
@@ -1,2 +1,2 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 @import '../user-layout';

--- a/libs/common/src/lib/user/signup/signup.component.scss
+++ b/libs/common/src/lib/user/signup/signup.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 @import '../user-layout';
 
 .main-container {

--- a/libs/common/src/lib/user/sso/sso-button.component.scss
+++ b/libs/common/src/lib/user/sso/sso-button.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 :host {
   display: flex;

--- a/libs/common/src/lib/user/user-container/user-container.component.scss
+++ b/libs/common/src/lib/user/user-container/user-container.component.scss
@@ -1,4 +1,4 @@
-@import 'variables';
+@import 'apps/dashboard/src/variables';
 
 .user-background {
   height: 100%;


### PR DESCRIPTION
We don't want big relative paths for scss variables import, and we don't want errors in our IDEs which are not finding the global `@import 'variables';` in our libs (because variables is defined in each app).
Knowing our variables are always the same whatever the app, we decided to reference the absolute path of dashboard's variables in common lib.