### PR TITLE
Fix kb-switch so the lock icon is not displayed by mistake

### DIFF
--- a/libs/sistema/src/lib/dropdown-button/dropdown-button.component.ts
+++ b/libs/sistema/src/lib/dropdown-button/dropdown-button.component.ts
@@ -69,9 +69,7 @@ export class DropdownButtonComponent {
 
   @Input()
   set icon(value: string | undefined) {
-    if (value) {
-      this._icon = value;
-    }
+    this._icon = value || '';
   }
   get icon(): string {
     return this._icon;


### PR DESCRIPTION
Dropdown button was not handling resetting icon to empty string properly