### PR TITLE
[sc-4882] and [sc-4639] Better error management on search

### DIFF
--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -23,7 +23,8 @@
   // let kb = '6b9f8f55-a57f-4ed4-b60e-759da54281fd'; // Robin Hobb
   // let kb = '5c2bc432-a579-48cd-b408-4271e5e7a43c'; // medias
   // let kb = 'f5d0ec7f-9ac3-46a3-b284-a38d5333d9e6'; // le petit prince
-  let kb = '89ffdada-58ee-4199-8303-ad1450de1cbe'; // multiple types
+  // let kb = '89ffdada-58ee-4199-8303-ad1450de1cbe'; // multiple types
+  let kb = '096d9070-f7be-40c8-a24c-19c89072e3ff'; // e2e permanent
 
   onMount(() => {
     resultsWidget?.setTileMenu([

--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -20,10 +20,10 @@
   // let kb = 'd10ea56b-7af9-495d-860f-23b616a44f9a'; // eudald
   // let kb = '5fad8445-ff08-4428-85a4-3c6eeb9d2ece'; // chat
   // let kb = '0b8017a4-083a-4c11-b400-5234fb0530cf'; // carmen
-  let kb = '6b9f8f55-a57f-4ed4-b60e-759da54281fd'; // Robin Hobb
+  // let kb = '6b9f8f55-a57f-4ed4-b60e-759da54281fd'; // Robin Hobb
   // let kb = '5c2bc432-a579-48cd-b408-4271e5e7a43c'; // medias
   // let kb = 'f5d0ec7f-9ac3-46a3-b284-a38d5333d9e6'; // le petit prince
-  // let kb = '89ffdada-58ee-4199-8303-ad1450de1cbe'; // multiple types
+  let kb = '89ffdada-58ee-4199-8303-ad1450de1cbe'; // multiple types
 
   onMount(() => {
     resultsWidget?.setTileMenu([

--- a/libs/common/src/lib/resources/edit-resource/paragraph.service.ts
+++ b/libs/common/src/lib/resources/edit-resource/paragraph.service.ts
@@ -70,10 +70,12 @@ export class ParagraphService {
   }
 
   searchInField(query: string, resource: Resource, field: FieldId, pageNumber = 0): Observable<Search.Results> {
-    return resource.search(query, [Search.ResourceFeatures.PARAGRAPH], {
-      fields: [`${longToShortFieldType(field.field_type)}/${field.field_id}`],
-      page_number: pageNumber,
-    });
+    return resource
+      .search(query, [Search.ResourceFeatures.PARAGRAPH], {
+        fields: [`${longToShortFieldType(field.field_type)}/${field.field_id}`],
+        page_number: pageNumber,
+      })
+      .pipe(map((res) => (res.type === 'error' ? { type: 'searchResults' } : res)));
   }
 
   setupParagraphs(paragraphs: ParagraphWithText[]) {

--- a/libs/common/src/lib/resources/resource-list/processed-resource-table/processed-resource-table.component.spec.ts
+++ b/libs/common/src/lib/resources/resource-list/processed-resource-table/processed-resource-table.component.spec.ts
@@ -5,6 +5,7 @@ import { MockModule, MockProvider } from 'ng-mocks';
 import { TranslateModule } from '@ngx-translate/core';
 import {
   PaButtonModule,
+  PaDropdownModule,
   PaScrollModule,
   PaTableModule,
   PaTogglesModule,
@@ -13,6 +14,7 @@ import {
 import { SDKService } from '@flaps/core';
 import { of } from 'rxjs';
 import { Nuclia, WritableKnowledgeBox } from '@nuclia/core';
+import { DropdownButtonComponent } from '@nuclia/sistema';
 
 describe('ResourceTableComponent', () => {
   let component: ProcessedResourceTableComponent;
@@ -28,6 +30,8 @@ describe('ResourceTableComponent', () => {
         MockModule(PaButtonModule),
         MockModule(PaTogglesModule),
         MockModule(PaTooltipModule),
+        MockModule(PaDropdownModule),
+        DropdownButtonComponent,
       ],
       providers: [
         MockProvider(SDKService, {

--- a/libs/common/src/lib/resources/sample-dataset/sample-dataset.service.ts
+++ b/libs/common/src/lib/resources/sample-dataset/sample-dataset.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { SDKService } from '@flaps/core';
 import { BehaviorSubject, catchError, forkJoin, map, Observable, of, switchMap, take, tap } from 'rxjs';
-import { Resource, Search } from '@nuclia/core';
+import { IErrorResponse, Resource, Search } from '@nuclia/core';
 import { LabelsService } from '../../label/labels.service';
 
 const sampleLabelSet = 'dataset';
@@ -87,9 +87,14 @@ export class SampleDatasetService {
         kb
           .search('', [Search.Features.DOCUMENT], { filters: [`/l/${sampleLabelSet}/${sampleLabel}`], page_size: 20 })
           .pipe(
-            map((results: Search.Results) =>
-              Object.values(results.resources || {}).map((resource) => new Resource(this.sdk.nuclia, kb.id, resource)),
-            ),
+            map((results: Search.Results | IErrorResponse) => {
+              if (results.type === 'error') {
+                return [];
+              }
+              return Object.values(results.resources || {}).map(
+                (resource) => new Resource(this.sdk.nuclia, kb.id, resource),
+              );
+            }),
           ),
       ),
     );

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -1,10 +1,12 @@
-# 1.2.1 (unreleased)
+# 1.2.1 (2023-04-07)
 
 ### Improvements
 
 - Support Kb configuration endpoints
 - Add `error` property in `IFieldData` and corresponding `IError` interface
 - catch error and return an empty label set on `kb.getLabels` method 
+- Add common `IErrorResponse` interface
+- Better error management for search, find, catalog and suggest endpoints
 
 # 1.2.0 (2023-03-28)
 

--- a/libs/sdk-core/package.json
+++ b/libs/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuclia/core",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "SDK allowing to integrate Nuclia services in your frontend application",
   "license": "MIT",
   "keywords": [

--- a/libs/sdk-core/src/lib/db/kb/kb.models.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.models.ts
@@ -1,9 +1,8 @@
 import type { Observable } from 'rxjs';
 import type { IResource, LinkField, Origin, Resource, UserMetadata } from '../resource';
 import type { FileMetadata, FileWithMetadata, UploadResponse, UploadStatus } from '../upload';
-import type { Search, SearchOptions } from '../search';
-import type { Chat } from '../search/chat.models';
-import { IErrorResponse } from '../../models';
+import type { Chat, Search, SearchOptions } from '../search';
+import type { IErrorResponse } from '../../models';
 
 export type KBStates = 'PUBLISHED' | 'PRIVATE';
 export type KBRoles = 'SOWNER' | 'SCONTRIBUTOR' | 'SMEMBER';

--- a/libs/sdk-core/src/lib/db/kb/kb.models.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.models.ts
@@ -3,6 +3,7 @@ import type { IResource, LinkField, Origin, Resource, UserMetadata } from '../re
 import type { FileMetadata, FileWithMetadata, UploadResponse, UploadStatus } from '../upload';
 import type { Search, SearchOptions } from '../search';
 import type { Chat } from '../search/chat.models';
+import { IErrorResponse } from '../../models';
 
 export type KBStates = 'PUBLISHED' | 'PRIVATE';
 export type KBRoles = 'SOWNER' | 'SCONTRIBUTOR' | 'SMEMBER';
@@ -85,13 +86,21 @@ export interface IKnowledgeBox extends IKnowledgeBoxCreation {
 
   chat(query: string, context?: Chat.ContextEntry[], features?: Chat.Features[]): Observable<Chat.Answer>;
 
-  find(query: string, features?: Search.Features[], options?: SearchOptions): Observable<Search.FindResults>;
+  find(
+    query: string,
+    features?: Search.Features[],
+    options?: SearchOptions,
+  ): Observable<Search.FindResults | IErrorResponse>;
 
-  search(query: string, features?: Search.Features[], options?: SearchOptions): Observable<Search.Results>;
+  search(
+    query: string,
+    features?: Search.Features[],
+    options?: SearchOptions,
+  ): Observable<Search.Results | IErrorResponse>;
 
-  catalog(query: string, options?: SearchOptions): Observable<Search.Results>;
+  catalog(query: string, options?: SearchOptions): Observable<Search.Results | IErrorResponse>;
 
-  suggest(query: string): Observable<Search.Suggestions>;
+  suggest(query: string): Observable<Search.Suggestions | IErrorResponse>;
 
   feedback(answerId: string, good: boolean): Observable<void>;
 

--- a/libs/sdk-core/src/lib/db/kb/kb.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.ts
@@ -21,16 +21,14 @@ import {
   ServiceAccount,
   ServiceAccountCreation,
 } from './kb.models';
-import type { INuclia } from '../../models';
-import { IErrorResponse } from '../../models';
+import type { IErrorResponse, INuclia } from '../../models';
 import type { ICreateResource, IResource, LinkField, Origin, UserMetadata } from '../resource';
 import { Resource } from '../resource';
 import type { UploadResponse } from '../upload';
 import { batchUpload, FileMetadata, FileWithMetadata, upload, UploadStatus } from '../upload';
-import { catalog, find, Search, search, SearchOptions } from '../search';
+import type { Chat } from '../search';
+import { catalog, chat, find, Search, search, SearchOptions } from '../search';
 import { Training } from '../training';
-import { chat } from '../search/chat';
-import type { Chat } from '../search/chat.models';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface KnowledgeBox extends IKnowledgeBox {}

--- a/libs/sdk-core/src/lib/db/resource/resource.ts
+++ b/libs/sdk-core/src/lib/db/resource/resource.ts
@@ -1,7 +1,7 @@
 import { forkJoin, Observable, tap } from 'rxjs';
 import type { UploadResponse } from '../upload';
 import { batchUpload, FileMetadata, FileWithMetadata, upload, UploadStatus } from '../upload';
-import type { INuclia } from '../../models';
+import type { IErrorResponse, INuclia } from '../../models';
 import type {
   Classification,
   CloudLink,
@@ -262,7 +262,11 @@ export class Resource extends ReadableResource implements IResource {
     return batchUpload(this.nuclia, this.path, files, true);
   }
 
-  search(query: string, features: Search.ResourceFeatures[] = [], options?: SearchOptions): Observable<Search.Results> {
+  search(
+    query: string,
+    features: Search.ResourceFeatures[] = [],
+    options?: SearchOptions,
+  ): Observable<Search.Results | IErrorResponse> {
     return search(this.nuclia, this.kb, this.path, query, features, options, true);
   }
 

--- a/libs/sdk-core/src/lib/db/search/search.models.ts
+++ b/libs/sdk-core/src/lib/db/search/search.models.ts
@@ -71,7 +71,7 @@ export namespace Search {
   }
 
   export interface FindResults {
-    error?: boolean;
+    type: 'findResults';
     resources?: { [id: string]: FindResource };
     shards?: string[];
     next_page: boolean;
@@ -114,7 +114,7 @@ export namespace Search {
   }
 
   export interface Results {
-    error?: boolean;
+    type: 'searchResults';
     resources?: { [id: string]: IResource };
     sentences?: Sentences;
     paragraphs?: Paragraphs;
@@ -141,7 +141,7 @@ export namespace Search {
   }
 
   export interface Suggestions {
-    error?: boolean;
+    type: 'suggestions';
     paragraphs?: Paragraphs;
   }
 

--- a/libs/sdk-core/src/lib/models.ts
+++ b/libs/sdk-core/src/lib/models.ts
@@ -136,3 +136,9 @@ export interface NucliaOptions {
 export type PromiseMapper<T> = {
   [K in keyof T]: T[K] extends (...args: infer A) => Observable<infer V> ? (...args: A) => Promise<V> : T[K];
 };
+
+export interface IErrorResponse {
+  status: number;
+  detail: string;
+  type: 'error';
+}

--- a/libs/search-widget/public/i18n/ca.json
+++ b/libs/search-widget/public/i18n/ca.json
@@ -25,6 +25,7 @@
 	"entities.title": "Insights",
 	"entities.work_of_art": "Obres",
 	"error.audio-loading": "S'ha produït un error en carregar el fitxer d'àudio.",
+	"error.feature-blocked": "La funció de cerca no està permesa en aquest moment.",
 	"error.processing": "Aquest recurs encara no s'ha processat completament",
 	"error.search": "Ups! Alguna cosa ha anat malament!",
 	"error.search-beta": "Sort que t'hem avisat que encara estem en beta! 🙃",

--- a/libs/search-widget/public/i18n/en.json
+++ b/libs/search-widget/public/i18n/en.json
@@ -26,6 +26,7 @@
 	"entities.title": "Insights",
 	"entities.work_of_art": "Art",
 	"error.audio-loading": "An error occurred while loading the audio file.",
+	"error.feature-blocked": "The search feature is not allowed at the moment.",
 	"error.processing": "This resource is not fully processed yet",
 	"error.search": "Oops! Something is wrong right now!",
 	"error.search-beta": "Luckily we told you it's a beta! 🙃",

--- a/libs/search-widget/public/i18n/es.json
+++ b/libs/search-widget/public/i18n/es.json
@@ -25,6 +25,7 @@
 	"entities.title": "Insights",
 	"entities.work_of_art": "Obras",
 	"error.audio-loading": "Ocurrió un error al cargar el archivo de audio.",
+	"error.feature-blocked": "La función de búsqueda no está permitida en este momento.",
 	"error.processing": "Este recurso aún no se ha procesado por completo",
 	"error.search": "¡Cáspita, algo ha ido mal!",
 	"error.search-beta": "Suerte que te hemos avisado que aún estamos en beta! 🙃",

--- a/libs/search-widget/public/i18n/fr.json
+++ b/libs/search-widget/public/i18n/fr.json
@@ -23,6 +23,7 @@
 	"entities.title": "Insights",
 	"entities.work_of_art": "Œuvres",
 	"error.audio-loading": "Une erreur s'est produite lors du chargement du fichier audio.",
+	"error.feature-blocked": "La fonction de recherche n'est pas autorisée pour le moment.",
 	"error.processing": "Le traitement de cette ressource n'est pas complet",
 	"error.search": "Oups! quelque chose ne va pas!",
 	"error.search-beta": "Heureusement qu'on vous a dit que c'est une beta ! 🙃",

--- a/libs/search-widget/src/components/suggestions/Suggestions.scss
+++ b/libs/search-widget/src/components/suggestions/Suggestions.scss
@@ -1,6 +1,9 @@
 .sw-suggestions {
   --suggestion-side-padding: var(--rhythm-3);
 
+  .error-message {
+    padding: 0 var(--rhythm-2);
+  }
   section {
     padding: var(--rhythm-2) var(--suggestion-side-padding);
   }

--- a/libs/search-widget/src/components/suggestions/Suggestions.svelte
+++ b/libs/search-widget/src/components/suggestions/Suggestions.svelte
@@ -5,7 +5,7 @@
   import { getExternalUrl, goToUrl, isYoutubeUrl } from '../../core/utils';
   import { _ } from '../../core/i18n';
   import { NO_RESULTS } from '../../core/models';
-  import { suggestionsHasError, suggestions } from '../../core/stores/suggestions.store';
+  import { suggestionsHasError, suggestions, suggestionError } from '../../core/stores/suggestions.store';
   import { navigateToLink } from '../../core/stores/widget.store';
   import Label from '../../common/label/Label.svelte';
   import { map, switchMap, take } from 'rxjs';
@@ -55,9 +55,13 @@
 
 <div class="sw-suggestions">
   {#if $suggestionsHasError}
-    <div>
-      <strong>{$_('error.search')}</strong>
-      <span>{$_('error.search-beta')}</span>
+    <div class="error-message">
+      {#if $suggestionError.status === 402}
+        <p>{$_('error.feature-blocked')}</p>
+      {:else}
+        <strong>{$_('error.search')}</strong>
+        <span>{$_('error.search-beta')}</span>
+      {/if}
     </div>
   {:else}
     {#if labels.length > 0}

--- a/libs/search-widget/src/core/api.ts
+++ b/libs/search-widget/src/core/api.ts
@@ -6,17 +6,15 @@ import {
   IResource,
   KBStates,
   LabelSets,
-  NucliaOptions,
-  SearchOptions,
-  TokenAnnotation,
-} from '@nuclia/core';
-import {
   Nuclia,
+  NucliaOptions,
   Resource,
   ResourceField,
   ResourceFieldProperties,
   ResourceProperties,
   Search,
+  SearchOptions,
+  TokenAnnotation,
   WritableKnowledgeBox,
 } from '@nuclia/core';
 import type { Observable } from 'rxjs';
@@ -25,9 +23,9 @@ import type { EntityGroup, WidgetOptions } from './models';
 import { generatedEntitiesColor, getCDN } from './utils';
 import { _ } from './i18n';
 import type { Annotation } from './stores/annotation.store';
-import { suggestionsHasError } from './stores/suggestions.store';
+import { suggestionError } from './stores/suggestions.store';
 import { NucliaPrediction } from '@nuclia/prediction';
-import { hasSearchError, searchOptions } from './stores/search.store';
+import { searchError, searchOptions } from './stores/search.store';
 import { hasViewerSearchError } from './stores/viewer-search.store';
 
 let nucliaApi: Nuclia | null;
@@ -71,10 +69,10 @@ export const search = (query: string, options: SearchOptions) => {
   }
   return nucliaApi.knowledgeBox.find(query, SEARCH_MODE, options).pipe(
     filter((res) => {
-      if (res.error) {
-        hasSearchError.set(true);
+      if (res.type === 'error') {
+        searchError.set(res);
       }
-      return !res.error;
+      return res.type === 'findResults';
     }),
   );
 };
@@ -131,10 +129,10 @@ export const suggest = (query: string) => {
 
   return nucliaApi.knowledgeBox.suggest(query, true).pipe(
     filter((res) => {
-      if (res.error) {
-        suggestionsHasError.set(true);
+      if (res.type === 'error') {
+        suggestionError.set(res);
       }
-      return !res.error;
+      return res.type === 'suggestions';
     }),
   );
 };

--- a/libs/search-widget/src/core/api.ts
+++ b/libs/search-widget/src/core/api.ts
@@ -114,11 +114,12 @@ export const searchInResource = (
     .search(query, features, options)
     .pipe(
       filter((res) => {
-        if (res.error) {
+        if (res.type === 'error') {
           hasViewerSearchError.set(true);
         }
-        return !res.error;
+        return res.type === 'searchResults';
       }),
+      map((res) => res as Search.Results),
     );
 };
 

--- a/libs/search-widget/src/core/models.ts
+++ b/libs/search-widget/src/core/models.ts
@@ -10,6 +10,7 @@ import type {
 } from '@nuclia/core';
 
 export const NO_RESULTS: Search.FindResults = {
+  type: 'findResults',
   resources: {} as { [id: string]: Search.FindResource },
   total: 0,
   page_number: 0,
@@ -19,6 +20,7 @@ export const NO_RESULTS: Search.FindResults = {
 };
 
 export const NO_SUGGESTION_RESULTS: Search.Results = {
+  type: 'searchResults',
   resources: {} as { [id: string]: Search.FindResource },
 };
 

--- a/libs/search-widget/src/core/stores/search.store.ts
+++ b/libs/search-widget/src/core/stores/search.store.ts
@@ -5,6 +5,7 @@ import {
   FIELD_TYPE,
   getDataKeyFromFieldType,
   getFilterFromLabel,
+  IErrorResponse,
   SHORT_FIELD_TYPE,
   shortToLongFieldType,
 } from '@nuclia/core';
@@ -17,7 +18,7 @@ interface SearchState {
   filters: string[];
   options: SearchOptions;
   results: Search.FindResults;
-  hasError: boolean;
+  error?: IErrorResponse;
   displayedResource: DisplayedResource | null;
   pending: boolean;
 }
@@ -27,7 +28,6 @@ export const searchState = new SvelteState<SearchState>({
   filters: [],
   options: { inTitleOnly: false, highlight: true, page_number: 0 },
   results: NO_RESULTS,
-  hasError: false,
   displayedResource: null,
   pending: false,
 });
@@ -56,11 +56,12 @@ export const searchResults = searchState.writer<Search.FindResults, { results: S
   }),
 );
 
-export const hasSearchError = searchState.writer<boolean>(
-  (state) => state.hasError,
-  (state, hasError) => ({
+export const hasSearchError = searchState.reader<boolean>((state) => !!state.error);
+export const searchError = searchState.writer<IErrorResponse | undefined>(
+  (state) => state.error,
+  (state, error) => ({
     ...state,
-    hasError,
+    error,
     pending: false,
   }),
 );

--- a/libs/search-widget/src/core/stores/suggestions.store.ts
+++ b/libs/search-widget/src/core/stores/suggestions.store.ts
@@ -1,5 +1,5 @@
 import { SvelteState } from '../state-lib';
-import type { Classification, Search } from '@nuclia/core';
+import type { Classification, IErrorResponse, Search } from '@nuclia/core';
 import { NO_SUGGESTION_RESULTS } from '../models';
 import { combineLatest, map, Observable, Subject } from 'rxjs';
 
@@ -11,7 +11,7 @@ export type Suggestions = {
 interface SuggestionState {
   typeAhead: string;
   suggestions: Suggestions;
-  hasError: boolean;
+  error?: IErrorResponse;
 }
 
 export const suggestionState = new SvelteState<SuggestionState>({
@@ -19,7 +19,6 @@ export const suggestionState = new SvelteState<SuggestionState>({
   suggestions: {
     results: NO_SUGGESTION_RESULTS,
   },
-  hasError: false,
 });
 
 export const triggerSuggestions = new Subject<void>();
@@ -41,13 +40,14 @@ export const suggestions = suggestionState.writer<Suggestions>(
   }),
 );
 
-export const suggestionsHasError = suggestionState.writer<boolean>(
-  (state) => state.hasError,
-  (state, hasError) => ({
+export const suggestionError = suggestionState.writer<IErrorResponse | undefined>(
+  (state) => state.error,
+  (state, error) => ({
     ...state,
-    hasError,
+    error,
   }),
 );
+export const suggestionsHasError = suggestionState.reader<boolean>((state) => !!state.error);
 
 export const suggestedParagraphs: Observable<Search.Paragraph[]> = suggestionState.reader<Search.Paragraph[]>(
   (state) => state.suggestions.results.paragraphs?.results || [],

--- a/libs/search-widget/src/tiles/base-tile/BaseTile.svelte
+++ b/libs/search-widget/src/tiles/base-tile/BaseTile.svelte
@@ -56,7 +56,6 @@
   const dispatch = createEventDispatcher();
   const unsubscribeAll = new Subject();
   const resizeEvent = new Subject();
-  const closeButtonWidth = 48;
   const findInPlaceholderPrefix = 'tile.find-in-';
 
   let innerWidth = window.innerWidth;
@@ -226,7 +225,7 @@
 
   const setHeaderActionWidth = () => {
     if (expanded) {
-      headerActionsWidth = isMobile ? closeButtonWidth : resultNavigatorWidth + closeButtonWidth;
+      headerActionsWidth = isMobile ? 0 : resultNavigatorWidth;
     }
   };
 

--- a/libs/search-widget/src/tiles/base-tile/header/TileHeader.svelte
+++ b/libs/search-widget/src/tiles/base-tile/header/TileHeader.svelte
@@ -17,6 +17,7 @@
 
   const dispatch = createEventDispatcher();
 
+  const buttonWidth = 40;
   let menuItems: WidgetAction[] = [];
 
   let menuButton: HTMLElement | undefined;
@@ -24,6 +25,7 @@
   let displayMenu = false;
 
   $: hasMenu = menuItems.length > 0;
+  $: actionsWidth = headerActionsWidth + (hasMenu ? buttonWidth * 2 : buttonWidth);
 
   onMount(() => {
     menuItems = getWidgetActions();
@@ -70,7 +72,7 @@
 <header
   class="sw-tile-header"
   class:expanded
-  style:--header-actions-width={`${headerActionsWidth}px`}>
+  style:--header-actions-width={`${actionsWidth}px`}>
   <div class:header-title={expanded}>
     <div class="doc-type-container">
       <DocTypeIndicator type={typeIndicator} />

--- a/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
@@ -17,6 +17,7 @@
     triggerSearch,
     hasMore,
     loadMore,
+    searchError,
   } from '../../core/stores/search.store';
   import Tile from '../../tiles/Tile.svelte';
   import InfiniteScroll from '../../common/infinite-scroll/InfiniteScroll.svelte';
@@ -67,8 +68,12 @@
   {#if $showResults && !$isEmptySearchQuery}
     {#if $hasSearchError}
       <div class="error">
-        <strong>{$_('error.search')}</strong>
-        <span>{$_('error.search-beta')}</span>
+        {#if $searchError.status === 402}
+          <strong>{$_('error.feature-blocked')}</strong>
+        {:else}
+          <strong>{$_('error.search')}</strong>
+          <span>{$_('error.search-beta')}</span>
+        {/if}
       </div>
     {:else if !$pendingResults && $smartResults.length === 0}
       <strong>{$_('results.empty')}</strong>

--- a/libs/search-widget/widget.babel
+++ b/libs/search-widget/widget.babel
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<babeledit_project be_version="4.0.1" version="1.3">
+<babeledit_project be_version="4.0.3" version="1.3">
 	<!--
 
     BabelEdit project file
@@ -663,6 +663,30 @@
 						<children>
 							<concept_node>
 								<name>audio-loading</name>
+								<description/>
+								<comment/>
+								<default_text/>
+								<translations>
+									<translation>
+										<language>ca-ES</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>es-ES</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>fr-FR</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
+								<name>feature-blocked</name>
 								<description/>
 								<comment/>
 								<default_text/>


### PR DESCRIPTION
- Prevent resource title to overlap header actions
- [sc-4882] and [sc-4639]: better error state management
  - If http error 402, display proper message on search widget
  - Refactor search endpoints (search, find, catalog, suggest) and states to use a common `IErrorResponse` interface and return error status and detail