### PR TITLE
Fix [sc-3337]: add description on account kb list

### DIFF
--- a/app.babel
+++ b/app.babel
@@ -880,6 +880,26 @@
 						</translations>
 					</concept_node>
 					<concept_node>
+						<name>account.kb-description</name>
+						<description/>
+						<comment/>
+						<default_text/>
+						<translations>
+							<translation>
+								<language>ca-ES</language>
+								<approved>false</approved>
+							</translation>
+							<translation>
+								<language>en-US</language>
+								<approved>false</approved>
+							</translation>
+							<translation>
+								<language>es-ES</language>
+								<approved>false</approved>
+							</translation>
+						</translations>
+					</concept_node>
+					<concept_node>
 						<name>account.knowledgeboxes</name>
 						<description/>
 						<comment/>

--- a/app.babel
+++ b/app.babel
@@ -11040,6 +11040,26 @@
 						</translations>
 					</concept_node>
 					<concept_node>
+						<name>resource.field-classification.help</name>
+						<description/>
+						<comment/>
+						<default_text/>
+						<translations>
+							<translation>
+								<language>ca-ES</language>
+								<approved>false</approved>
+							</translation>
+							<translation>
+								<language>en-US</language>
+								<approved>false</approved>
+							</translation>
+							<translation>
+								<language>es-ES</language>
+								<approved>false</approved>
+							</translation>
+						</translations>
+					</concept_node>
+					<concept_node>
 						<name>resource.field-file</name>
 						<description/>
 						<comment/>

--- a/apps/dashboard/src/app/account/account-kbs/account-kbs.component.html
+++ b/apps/dashboard/src/app/account/account-kbs/account-kbs.component.html
@@ -8,6 +8,8 @@
   class="account-kbs">
   <h2>{{ 'account.related_kbs' | translate }}</h2>
 
+  <p>{{ 'account.kb-description' | translate }}</p>
+
   <div class="account-kbs-list">
     <div
       class="account-kb"

--- a/apps/dashboard/src/app/account/account-kbs/account-kbs.component.scss
+++ b/apps/dashboard/src/app/account/account-kbs/account-kbs.component.scss
@@ -3,11 +3,11 @@
 .account-kbs {
   padding: 70px var(--app-layout-margin-right) 60px 5%;
   h2 {
-    margin: 0 0 36px 0;
-    font-weight: var(--stf-font-weight-bold);
+    margin: 0 0 rhythm(1) 0;
   }
 
   .account-kbs-list {
+    margin-top: rhythm(5);
     max-width: 1024px;
 
     pa-button:not(:last-child) {

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -528,6 +528,7 @@
 	"resource.field-annotation.help": "Seleccioneu una família per destacar i anotar les entitats corresponents",
 	"resource.field-annotation.select-family-before": "Seleccioneu una família perquè pugueu afegir/editar/eliminar anotacions",
 	"resource.field-classification": "Classificació de paràgrafs",
+	"resource.field-classification.help": "Trieu una etiqueta i seleccioneu els paràgrafs sobre els quals voleu que s'apliqui",
 	"resource.field-file": "Camp de Fitxer",
 	"resource.field-file.dropzone": "Deixeu anar el vostre fitxer aquí o feu clic per seleccionar-lo",
 	"resource.field-file.dropzone-label": "Per substituir el fitxer actual <strong>{{filename}}</strong>, deixeu anar el fitxer o feu clic a continuació per seleccionar-lo",

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -35,6 +35,7 @@
 	"account.generate_key": "Generar un nou codi",
 	"account.home": "Tauler de control del compte",
 	"account.invited_user": "L'usuari {{user}} ha rebut un correu amb una invitació a participar en aquest compte",
+	"account.kb-description": "Un Knowledge Box és una col·lecció de contingut en què cerca Nuclia. Alguns motors de cerca l'anomenen \"índex\" o \"corpus\". En la majoria dels casos, només necessiteu un Knowledge Box per a la vostra aplicació.",
 	"account.knowledgeboxes": "Caixes de coneixement",
 	"account.licence": "Llicència",
 	"account.logo": "Imatge de la caixa",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -550,6 +550,7 @@
 	"resource.field-annotation.help": "Select a family to highlight and annotate the corresponding entities",
 	"resource.field-annotation.select-family-before": "Select a family so you can add/edit/remove annotations",
 	"resource.field-classification": "Paragraphs classification",
+	"resource.field-classification.help": "Choose a label and then select the paragraphs on which you want it to be applied",
 	"resource.field-file": "File Field",
 	"resource.field-file.dropzone": "Drop your file here or click to select it",
 	"resource.field-file.dropzone-label": "To replace current file <strong>{{filename}}</strong>, drop your file or click below to select it",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -42,6 +42,7 @@
 	"account.generate_key": "Generate a new key",
 	"account.home": "Account dashboard",
 	"account.invited_user": "We have sent an invitation email to {{user}} to join this account",
+	"account.kb-description": "A Knowledge Box is a collection of content that Nuclia searches on. Some search engines call it an \"index\" or \"corpus\".  In most cases, you only need one Knowledge Box for your application.",
 	"account.knowledgeboxes": "Knowledge boxes",
 	"account.licence": "License",
 	"account.logo": "Box image",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -528,6 +528,7 @@
 	"resource.field-annotation.help": "Seleccione una familia para resaltar y anotar las entidades correspondientes",
 	"resource.field-annotation.select-family-before": "Seleccione una familia para que pueda agregar/editar/eliminar anotaciones",
 	"resource.field-classification": "Clasificación de párrafos",
+	"resource.field-classification.help": "Elija una etiqueta y luego seleccione los párrafos en los que desea que se aplique",
 	"resource.field-file": "Campo de Archivo",
 	"resource.field-file.dropzone": "Suelte su archivo aquí o haga clic para seleccionarlo",
 	"resource.field-file.dropzone-label": "Para reemplazar el archivo actual <strong>{{filename}}</strong>, suelte su archivo o haga clic a continuación para seleccionarlo",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -35,6 +35,7 @@
 	"account.generate_key": "Generar un nuevo código",
 	"account.home": "Panel de cuenta",
 	"account.invited_user": "Hemos enviado un correo a {{user}} invitándolo en esta cuenta",
+	"account.kb-description": "Una caja de conocimiento es una colección de contenido en la que Nuclia busca. Algunos motores de búsqueda lo llaman \"índice\" o \"corpus\". En la mayoría de los casos, solo necesita un Knowledge Box para su aplicación.",
 	"account.knowledgeboxes": "Cajas de conocimiento",
 	"account.licence": "Licencia",
 	"account.logo": "Imagen de la caja",

--- a/libs/common/src/lib/resources/edit-resource/classification/paragraph-classification/paragraph-classification.component.html
+++ b/libs/common/src/lib/resources/edit-resource/classification/paragraph-classification/paragraph-classification.component.html
@@ -54,6 +54,14 @@
       <div
         class="right-panel-container"
         *ngIf="(hasLabels | async) === true">
+        <div class="help">
+          <pa-icon
+            name="info"
+            size="small"></pa-icon>
+          <p>
+            {{ 'resource.field-classification.help' | translate }}
+          </p>
+        </div>
         <div class="label-selection-container">
           <app-label-dropdown
             [labelSets]="availableLabels | async"

--- a/libs/common/src/lib/resources/edit-resource/classification/paragraph-classification/paragraph-classification.component.scss
+++ b/libs/common/src/lib/resources/edit-resource/classification/paragraph-classification/paragraph-classification.component.scss
@@ -50,3 +50,10 @@ $padding-bottom-header: rhythm(3);
   flex-direction: column;
   gap: rhythm(3);
 }
+
+.right-panel-container {
+  .help {
+    display: flex;
+    gap: rhythm(0.5);
+  }
+}


### PR DESCRIPTION
Fix:
- https://app.shortcut.com/flaps/story/3337/description-for-account-s-knowledge-boxes
- https://app.shortcut.com/flaps/story/4918/add-a-small-description-about-how-to-use-paragraph-classification