### PR TITLE
[sc-4459] Add an icon to copy the code on hint component

### DIFF
--- a/apps/dashboard/src/app/account/account-nua/client-dialog/client-dialog.component.html
+++ b/apps/dashboard/src/app/account/account-nua/client-dialog/client-dialog.component.html
@@ -28,6 +28,7 @@
 
       <div class="webhook-hint">
         <ncom-hint
+          learnMore="https://docs.nuclia.dev/docs/understanding/intro#use-a-webhook"
           noMaxWidth
           label="Learn more about webhooks">
           <p>
@@ -35,11 +36,6 @@
             <code>POST</code>
             call to this URL, sending the result as payload.
           </p>
-          <a
-            href="https://docs.nuclia.dev/docs/understanding/intro#use-a-webhook"
-            target="_new">
-            Learn more
-          </a>
         </ncom-hint>
       </div>
 

--- a/apps/dashboard/src/app/knowledge-box/service-access/service-access.component.html
+++ b/apps/dashboard/src/app/knowledge-box/service-access/service-access.component.html
@@ -99,7 +99,9 @@
       </div>
     </div>
   </div>
-  <ncom-hint label="How to use your service access token in the API">
+  <ncom-hint
+    label="How to use your service access token in the API"
+    learnMore="https://docs.nuclia.dev/docs/quick-start/push#api-push-contents-using-the-api">
     <p>
       The service access token can be used on any call to the API. It goes in the
       <code>X-STF-Serviceaccount</code>
@@ -107,16 +109,11 @@
       <code>Authorization</code>
       header
     </p>
-    <pre><code class="highlight">curl $$KB_URL$$/upload \
+    <pre><code>curl $$KB_URL$$/upload \
  -X POST \
  -H "content-type: video/mp4"
  -H "x-language: fr"
  -H "X-STF-Serviceaccount: Bearer YOUR-SERVICE-ACCESS-TOKEN" \
  -T /path/to/file.mp4</code></pre>
-    <a
-      href="https://docs.nuclia.dev/docs/quick-start/push#api-push-contents-using-the-api"
-      target="_new">
-      Learn more
-    </a>
   </ncom-hint>
 </div>

--- a/libs/common/src/lib/hint/hint.component.html
+++ b/libs/common/src/lib/hint/hint.component.html
@@ -1,7 +1,6 @@
 <div
   class="hint"
   #container
-  [class.inverted]="inverted"
   [style.max-width]="containerWidth">
   <pa-expander card>
     <pa-expander-header>
@@ -11,10 +10,27 @@
       </div>
     </pa-expander-header>
     <pa-expander-body>
-      <div
-        class="hint-content"
-        #content>
-        <ng-content></ng-content>
+      <div class="hint-content">
+        <div #content>
+          <ng-content></ng-content>
+        </div>
+
+        <div class="hint-actions">
+          <a
+            *ngIf="learnMore"
+            [href]="learnMore"
+            target="_new"
+            class="body-m">
+            Learn more
+          </a>
+          <pa-button
+            *ngIf="clipboardSupported && hasCodeExample"
+            [icon]="copyIcon"
+            aspect="basic"
+            (click)="copyCode()">
+            Copy code
+          </pa-button>
+        </div>
       </div>
     </pa-expander-body>
   </pa-expander>

--- a/libs/common/src/lib/hint/hint.component.scss
+++ b/libs/common/src/lib/hint/hint.component.scss
@@ -2,12 +2,9 @@
 
 .hint {
   pre {
-    overflow: scroll;
     font-size: font-size(xs);
-  }
-
-  &.inverted {
-    background-color: $color-light-stronger;
+    margin-bottom: rhythm(0.5);
+    overflow: auto;
   }
 
   .hint-title {
@@ -19,6 +16,12 @@
   .hint-content {
     background-color: $color-neutral-lightest;
     padding: rhythm(2);
+  }
+
+  .hint-actions {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
   }
 
   pa-expander .pa-expander-header {

--- a/libs/common/src/lib/hint/hint.component.ts
+++ b/libs/common/src/lib/hint/hint.component.ts
@@ -37,8 +37,6 @@ export class HintComponent implements AfterContentInit, AfterViewInit, OnChanges
 
   @ViewChild('content') content?: ElementRef;
   @ViewChild('container') container?: ElementRef;
-  @ViewChild('codeExample') codeExample?: ElementRef;
-  @ViewChild('instructions') instructions?: ElementRef;
 
   clipboardSupported = !!(navigator.clipboard && navigator.clipboard.writeText);
   hasCodeExample = false;

--- a/libs/common/src/lib/hint/hint.module.ts
+++ b/libs/common/src/lib/hint/hint.module.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { PaExpanderModule, PaIconModule } from '@guillotinaweb/pastanaga-angular';
+import { PaButtonModule, PaExpanderModule, PaIconModule } from '@guillotinaweb/pastanaga-angular';
 import { HintComponent } from './hint.component';
 
 @NgModule({
-  imports: [CommonModule, PaIconModule, PaExpanderModule],
+  imports: [CommonModule, PaIconModule, PaExpanderModule, PaButtonModule],
   exports: [HintComponent],
   declarations: [HintComponent],
 })

--- a/libs/common/src/lib/resources/edit-resource/profile/profile.component.html
+++ b/libs/common/src/lib/resources/edit-resource/profile/profile.component.html
@@ -158,18 +158,13 @@
   <div class="right-panel-container">
     <ncom-hint
       label="How to modify a resource with the API"
-      inverted
+      learnMore="https://docs.nuclia.dev/docs/api#operation/Modify_Resource_kb__kbid__resource__rid__patch"
       [values]="hintValues | async">
-      <pre><code class="highlight">curl $$RESOURCE$$ \
- -X PATCH \
- -H "authorization: Bearer $$AUTH_TOKEN$$" \
- --data-raw '$$DATA$$'</code></pre>
-      <a
-        href="https://docs.nuclia.dev/docs/api#operation/Modify_Resource_kb__kbid__resource__rid__patch"
-        target="_new"
-        class="body-m">
-        Learn more
-      </a>
+      <pre><code>curl $$RESOURCE$$ \
+  -X PATCH \
+  -H "authorization: Bearer $$AUTH_TOKEN$$" \
+  --data-raw '$$DATA$$'</code>
+      </pre>
     </ncom-hint>
   </div>
 </div>

--- a/libs/common/src/lib/upload/upload-files/upload-files.component.html
+++ b/libs/common/src/lib/upload/upload-files/upload-files.component.html
@@ -82,10 +82,11 @@
 
     <ncom-hint
       noMaxWidth
+      learnMore="https://docs.nuclia.dev/docs/quick-start/push#api-push-contents-using-the-api"
       label="How to upload a file with the API">
-      <pre><code class="highlight">curl $$KB_URL$$/upload \
+      <pre><code>curl $$KB_URL$$/upload \
   -X POST \
-  -H "content-type: video/mp4"
+  -H "content-type: video/mp4" \
   -H "authorization: Bearer $$AUTH_TOKEN$$" \
   -T /path/to/your-video.mp4</code></pre>
       <p>
@@ -94,11 +95,6 @@
         <code>X-STF-Serviceaccount</code>
         header.
       </p>
-      <a
-        href="https://docs.nuclia.dev/docs/quick-start/push#api-push-contents-using-the-api"
-        target="_new">
-        Learn more
-      </a>
     </ncom-hint>
   </pa-modal-content>
   <pa-modal-footer>


### PR DESCRIPTION
Hint component refactoring so:
- it displays a copy button when there is some code (ie `pre>code` elements) present
- it has a new input `learnMore` to show a generic learn more link.
