### PR TITLE
[sc 5444] Search widget permalink is erasing url anchor

### DIFF
--- a/apps/manager-v2/src/app/manage-accounts/account-details/account-details.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/account-details.component.html
@@ -15,7 +15,9 @@
     <div class="account-info">
       <div>
         Id:
-        <strong>{{ (account | async)?.id }}</strong>
+        <small>
+          <strong>{{ (account | async)?.id }}</strong>
+        </small>
       </div>
       <div>
         State:

--- a/libs/common/src/lib/search/search.component.ts
+++ b/libs/common/src/lib/search/search.component.ts
@@ -45,9 +45,6 @@ export class SearchComponent implements OnInit, OnDestroy {
       let featureList = !hasLabels
         ? DEFAULT_FEATURES_LIST.filter((feature) => feature !== 'filter')
         : DEFAULT_FEATURES_LIST;
-      if (this.sdk.nuclia.options.standalone) {
-        featureList = featureList.filter((feature) => feature !== 'permalink');
-      }
 
       let features = featureList.join(',');
       if (hasClassifier) {

--- a/libs/search-widget/src/core/stores/effects.ts
+++ b/libs/search-widget/src/core/stores/effects.ts
@@ -23,7 +23,7 @@ import { isSpeechEnabled, widgetFeatures, widgetMode } from './widget.store';
 import { isPopupSearchOpen } from './modal.store';
 import type { Chat, Classification, FieldFullId, IErrorResponse, Search } from '@nuclia/core';
 import { getFieldTypeFromString } from '@nuclia/core';
-import { formatQueryKey, updateQueryParams } from '../utils';
+import { formatQueryKey, getUrlParams, updateQueryParams } from '../utils';
 import { isEmptySearchQuery, labelFilters, searchFilters, searchQuery, triggerSearch } from './search.store';
 import { fieldData, fieldFullId } from './viewer.store';
 import { chat, currentAnswer, currentQuestion, isSpeechOn, lastSpeakableFullAnswer } from './answers.store';
@@ -169,7 +169,7 @@ export function activatePermalinks() {
         switchMap(() => combineLatest([searchQuery, searchFilters, labelFilters]).pipe(take(1))),
       )
       .subscribe(([query, filters, labelFilters]) => {
-        const urlParams = new URLSearchParams(window.location.search);
+        const urlParams = getUrlParams();
         urlParams.set(queryKey, query);
         urlParams.delete(filterKey);
         urlParams.delete(titleOnlyKey);
@@ -190,7 +190,7 @@ export function activatePermalinks() {
         filter((isEmpty) => isEmpty),
       ),
     ).subscribe(() => {
-      const urlParams = new URLSearchParams(window.location.search);
+      const urlParams = getUrlParams();
       urlParams.delete(queryKey);
       urlParams.delete(filterKey);
       urlParams.delete(titleOnlyKey);
@@ -204,7 +204,7 @@ export function activatePermalinks() {
       )
       .subscribe((fullId) => {
         const previewId = `${fullId?.resourceId}|${fullId?.field_type}|${fullId?.field_id}`;
-        const urlParams = new URLSearchParams(window.location.search);
+        const urlParams = getUrlParams();
         urlParams.set(previewKey, previewId);
         updateQueryParams(urlParams);
       }),
@@ -215,7 +215,7 @@ export function activatePermalinks() {
         filter((fullId) => !fullId),
       )
       .subscribe(() => {
-        const urlParams = new URLSearchParams(window.location.search);
+        const urlParams = getUrlParams();
         urlParams.delete(previewKey);
         updateQueryParams(urlParams);
       }),
@@ -228,7 +228,7 @@ export function activatePermalinks() {
  * Check URL params and set store from them
  */
 function initStoreFromUrlParams() {
-  const urlParams = new URLSearchParams(window.location.search);
+  const urlParams = getUrlParams();
   // Search store
   const query = urlParams.get(queryKey);
   const titleOnly = urlParams.get(titleOnlyKey) === 'true';

--- a/libs/search-widget/src/core/utils.ts
+++ b/libs/search-widget/src/core/utils.ts
@@ -74,9 +74,18 @@ export const formatQueryKey = (key: string): string => {
 
 export const updateQueryParams = (urlParams: URLSearchParams) => {
   const params = urlParams.toString();
-  const url = params ? `${location.pathname}?${params}` : location.pathname;
+  const baseUrl = `${location.pathname}${location.hash.split('?')[0]}`;
+  const url = params ? `${baseUrl}?${params}` : baseUrl;
   history.replaceState(null, '', url);
 };
+
+export function getUrlParams(): URLSearchParams {
+  const params =
+    window.location.hash && window.location.hash.includes('?')
+      ? window.location.hash.slice(window.location.hash.indexOf('?'))
+      : window.location.search;
+  return new URLSearchParams(params);
+}
 
 /**
  * Coerces a value (usually a string coming from a prop) to a boolean.


### PR DESCRIPTION
- When there is an anchor it includes the query params and `location.search` is empty, so we created `getUrlParams` function which get the params from the hash or the search depending on which one is present. We also updated `updateQueryParams` function to keep the hash part on the URL.
- Small fix on [sc-5464]: Prevent account id to be wrapped on 2 lines