### PR TITLE
Add search results discriminator [sc-5104]

### DIFF
--- a/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
@@ -89,14 +89,16 @@
           {#if $isAnswerEnabled}
             <InitialAnswer />
           {/if}
-          {#each $smartResults as result, i (getResultKey(result))}
-            <Tile {result} />
-            {#if i === $smartResults.length - 10}
-              <InfiniteScroll
-                hasMore={$hasMore}
-                on:loadMore={onLoadMore} />
-            {/if}
-          {/each}
+          <div class="search-results">
+            {#each $smartResults as result, i (getResultKey(result))}
+              <Tile {result} />
+              {#if i === $smartResults.length - 10}
+                <InfiniteScroll
+                  hasMore={$hasMore}
+                  on:loadMore={onLoadMore} />
+              {/if}
+            {/each}
+          </div>
         </div>
         {#if $entityRelations.length > 0}
           <InfoCard entityRelations={$entityRelations} />


### PR DESCRIPTION
For e2e, we need to be able to discriminate tiles from initial answer from those from the main search. To do so, we need to wrap the main search results in a div containing a selector (the class `.search-results`).