### PR TITLE
Fix [sc-5497]: Escape dot in resource search

### DIFF
--- a/libs/common/src/lib/resources/resource-list/resource-list.component.html
+++ b/libs/common/src/lib/resources/resource-list/resource-list.component.html
@@ -147,7 +147,7 @@
     </ng-container>
 
     <div
-      *ngIf="isMainView && emptyKb && !standalone"
+      *ngIf="isMainView && emptyKb && !query && !standalone"
       class="empty-kb">
       <p>
         <strong>{{ 'resource.empty' | translate }}</strong>

--- a/libs/common/src/lib/resources/resource-list/resource-list.component.html
+++ b/libs/common/src/lib/resources/resource-list/resource-list.component.html
@@ -147,7 +147,7 @@
     </ng-container>
 
     <div
-      *ngIf="isMainView && emptyKb && !query && !standalone"
+      *ngIf="isMainView && emptyKb && !query && !isFiltering && !standalone"
       class="empty-kb">
       <p>
         <strong>{{ 'resource.empty' | translate }}</strong>

--- a/libs/common/src/lib/resources/resource-list/resource-list.component.ts
+++ b/libs/common/src/lib/resources/resource-list/resource-list.component.ts
@@ -332,7 +332,7 @@ export class ResourceListComponent implements OnInit, OnDestroy {
   }
 
   private _getResources(replaceData = false, filters: string[] = []): Observable<Search.Results> {
-    const query = (this.searchForm.value.query || '').trim();
+    const query = (this.searchForm.value.query || '').trim().replace('.', '\\.');
     const hasQuery = query.length > 0;
     const titleOnly = this.searchForm.value.searchIn === 'title';
     if (replaceData) {


### PR DESCRIPTION
and don't show "empty kb – import sample dataset" when there is a query