### PR TITLE
[sc-5786] mkv are not identified as media files

### DIFF
--- a/libs/common/src/lib/upload/upload-files/upload-files.component.ts
+++ b/libs/common/src/lib/upload/upload-files/upload-files.component.ts
@@ -67,9 +67,15 @@ export class UploadFilesComponent {
   }
 
   addFiles(filesOrFileList: File[] | FileList) {
-    const files = Array.from(filesOrFileList).filter(
-      (file) => !FILES_TO_IGNORE.includes(file.name) && !PATTERNS_TO_IGNORE.some((pattern) => file.name.match(pattern)),
-    );
+    const files = Array.from(filesOrFileList)
+      .filter(
+        (file) =>
+          !FILES_TO_IGNORE.includes(file.name) && !PATTERNS_TO_IGNORE.some((pattern) => file.name.match(pattern)),
+      )
+      .map((file) => {
+        // Some file types (like .mkv) are not recognized by some browsers
+        return file.type ? file : new File([file], file.name, { type: (mime as any).getType(file.name) });
+      });
     const mediaFiles = this.getFilesByType(files, true);
     const nonMediaFiles = this.getFilesByType(files, false);
 
@@ -98,8 +104,7 @@ export class UploadFilesComponent {
 
   getFilesByType(files: File[], mediaFile: boolean): File[] {
     return files.filter((file) => {
-      const mimeType = file.type || (mime as any).getType(file.name);
-      const type = mimeType?.split('/')[0];
+      const type = file.type?.split('/')[0];
       const isMediaFile = type === 'audio' || type === 'video' || type === 'image';
       return mediaFile ? isMediaFile : !isMediaFile;
     });

--- a/libs/search-widget/src/core/stores/viewer.store.ts
+++ b/libs/search-widget/src/core/stores/viewer.store.ts
@@ -1,6 +1,6 @@
 import type { MediaWidgetParagraph, PreviewKind } from '../models';
 import { SvelteState } from '../state-lib';
-import type { FieldFullId, IFieldData, ResourceField } from '@nuclia/core';
+import type { CloudLink, FieldFullId, IFieldData, ResourceField } from '@nuclia/core';
 import { FIELD_TYPE, FileFieldData, LinkFieldData, sliceUnicode } from '@nuclia/core';
 import { getFileUrls } from '../api';
 import type { Observable } from 'rxjs';
@@ -127,9 +127,13 @@ export function getMediaTranscripts(
   );
 }
 
-export function getFileFieldContentType(): Observable<string> {
+export function getPlayableVideo(): Observable<CloudLink | undefined> {
   return viewerState.store.pipe(
-    filter((state) => !!state.fieldFullId && state.fieldFullId.field_type === FIELD_TYPE.file && !!state.fieldData),
-    map((state) => (state.fieldData as FileFieldData).value?.file?.content_type || ''),
+    filter((state) => !!state.fieldData?.extracted),
+    map(
+      (state) =>
+        (state.fieldData as FileFieldData)?.extracted?.file?.file_generated?.['video.mpd'] ||
+        (state.fieldData as FileFieldData)?.value?.file,
+    ),
   );
 }


### PR DESCRIPTION
Fixes:
- Properly recognize mkv files on file upload. (e.g. macOS doesn't recognize them)
- Make mkv fields playable in the search widget