### PR TITLE
[sc-5763] adjust manager app to address latest features

### DIFF
--- a/apps/dashboard/src/app/account/account-home/account-home.component.ts
+++ b/apps/dashboard/src/app/account/account-home/account-home.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { SDKService, StateService, STFTrackingService } from '@flaps/core';
-import { Account, StatsPeriod, StatsRange, StatsType } from '@nuclia/core';
+import { StatsPeriod, StatsRange, StatsType } from '@nuclia/core';
 import {
   BehaviorSubject,
   catchError,
@@ -47,20 +47,7 @@ export class AccountHomeComponent {
   );
 
   processedView: BehaviorSubject<ProcessedViewType> = new BehaviorSubject<ProcessedViewType>(StatsType.CHARS);
-  processedThreshold: Observable<number> = combineLatest([this.account, this.processedView]).pipe(
-    filter(([account]) => !!account),
-    map(([account, statsType]) => {
-      const limits = (account as Account).limits.processing;
-      switch (statsType) {
-        case StatsType.CHARS:
-          return limits.monthly_limit_chars_processed;
-        case StatsType.MEDIA_SECONDS:
-          return limits.monthly_limit_media_seconds_processed;
-        case StatsType.DOCS_NO_MEDIA:
-          return limits.monthly_limit_non_media_files_processed;
-      }
-    }),
-  );
+  processedThreshold: Observable<number> = of(0);
 
   kb = this.sdk.currentKb;
   kbs = this.sdk.kbList;

--- a/apps/dashboard/src/app/account/billing/billing.models.ts
+++ b/apps/dashboard/src/app/account/billing/billing.models.ts
@@ -74,25 +74,9 @@ export interface StripeSubscription {
   error?: { code: string; decline_code: string };
 }
 
-export enum SubsciptionError {
+export enum SubscriptionError {
   INVALID_ADDRESS = 'customer_tax_location_invalid',
   PAYMENT_METHOD_NOT_ATTACHED = 'payment_method_not_attached',
-}
-
-export interface AccountTypeDefaults {
-  max_kbs: number;
-  max_dedicated_processors: number;
-  max_trial_days: number;
-  monthly_limit_paragraphs_processed: number;
-  monthly_limit_docs_no_media_processed: number;
-  monthly_limit_media_seconds_processed: number;
-  monthly_limit_paragraphs_stored: number;
-  monthly_limit_hosted_searches_performed: number;
-  monthly_limit_hosted_answers_generated: number;
-  monthly_limit_self_hosted_searches_performed: number;
-  monthly_limit_self_hosted_answers_generated: number;
-  upload_limit_max_media_file_size: number;
-  upload_limit_max_non_media_file_size: number;
 }
 
 export interface InvoiceItem {

--- a/apps/dashboard/src/app/account/billing/billing.service.ts
+++ b/apps/dashboard/src/app/account/billing/billing.service.ts
@@ -3,7 +3,6 @@ import { SDKService } from '@flaps/core';
 import { BehaviorSubject, catchError, map, Observable, of, switchMap, take } from 'rxjs';
 import { AccountTypes } from '@nuclia/core';
 import {
-  AccountTypeDefaults,
   AccountUsage,
   BillingDetails,
   Currency,
@@ -129,10 +128,6 @@ export class BillingService {
         }, {} as { [key in AccountTypes]: Prices });
       }),
     );
-  }
-
-  getAccountTypes(): Observable<{ [key in AccountTypes]: AccountTypeDefaults }> {
-    return this.sdk.nuclia.rest.get<{ [key in AccountTypes]: AccountTypeDefaults }>(`/configuration/account_types`);
   }
 
   getAccountUsage(): Observable<AccountUsage> {

--- a/apps/dashboard/src/app/account/billing/checkout/checkout.component.ts
+++ b/apps/dashboard/src/app/account/billing/checkout/checkout.component.ts
@@ -3,8 +3,8 @@ import {
   ChangeDetectorRef,
   Component,
   ElementRef,
-  OnInit,
   OnDestroy,
+  OnInit,
   ViewChild,
 } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
@@ -13,8 +13,8 @@ import { combineLatest, forkJoin, from, of, Subject } from 'rxjs';
 import {
   catchError,
   delay,
-  filter,
   distinctUntilChanged,
+  filter,
   map,
   shareReplay,
   switchMap,
@@ -26,7 +26,7 @@ import { TranslateService } from '@ngx-translate/core';
 import { IErrorMessages } from '@guillotinaweb/pastanaga-angular';
 import { injectScript, SDKService, StateService, UserService } from '@flaps/core';
 import { BillingService } from '../billing.service';
-import { StripeCustomer, SubsciptionError } from '../billing.models';
+import { StripeCustomer, SubscriptionError } from '../billing.models';
 import { COUNTRIES, REQUIRED_VAT_COUNTRIES } from '../utils';
 import { SisModalService, SisToastService } from '@nuclia/sistema';
 import { AccountTypes } from '@nuclia/core';
@@ -341,12 +341,12 @@ export class CheckoutComponent implements OnDestroy, OnInit {
             })
             .pipe(
               catchError((error) => {
-                if (error.body?.error_code === SubsciptionError.PAYMENT_METHOD_NOT_ATTACHED) {
+                if (error.body?.error_code === SubscriptionError.PAYMENT_METHOD_NOT_ATTACHED) {
                   this.editCard = true;
                   this.token = undefined;
                   this.paymentMethodId = undefined;
                   throw new Error('billing.invalid_card');
-                } else if (error.body?.error_code === SubsciptionError.INVALID_ADDRESS) {
+                } else if (error.body?.error_code === SubscriptionError.INVALID_ADDRESS) {
                   this.editCustomer = true;
                   throw new Error('billing.invalid_address');
                 }

--- a/apps/dashboard/src/app/account/billing/subscriptions/subscriptions.component.ts
+++ b/apps/dashboard/src/app/account/billing/subscriptions/subscriptions.component.ts
@@ -3,7 +3,7 @@ import { BillingService } from '../billing.service';
 import { CalculatorComponent } from '../calculator/calculator.component';
 import { forkJoin, shareReplay, take, tap } from 'rxjs';
 import { SisModalService } from '@nuclia/sistema';
-import { STFTrackingService } from '@flaps/core';
+import { AccountService, STFTrackingService } from '@flaps/core';
 import { COUNTRIES } from '../utils';
 import { Currency } from '../billing.models';
 import { WINDOW } from '@ng-web-apis/common';
@@ -22,7 +22,7 @@ export class SubscriptionsComponent {
     .sort((a, b) => a.name.localeCompare(b.name));
   currency?: Currency;
   prices = this.billing.getPrices().pipe(shareReplay());
-  accountTypesDefaults = this.billing.getAccountTypes().pipe(shareReplay());
+  accountTypesDefaults = this.accountService.getAccountTypes().pipe(shareReplay());
   isSubscribed = this.billing.isSubscribed;
 
   constructor(
@@ -30,6 +30,7 @@ export class SubscriptionsComponent {
     private modalService: SisModalService,
     private tracking: STFTrackingService,
     private cdr: ChangeDetectorRef,
+    private accountService: AccountService,
     @Inject(WINDOW) private window: Window,
   ) {
     forkJoin([this.billing.getCustomer(), this.billing.country.pipe(take(1))]).subscribe(([customer, country]) => {

--- a/apps/manager-v2/src/app/manage-accounts/account-details/account-details.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/account-details.component.html
@@ -27,6 +27,10 @@
         Type:
         <strong>{{ (account | async)?.type }}</strong>
       </div>
+      <div *ngIf="(account | async)?.type === 'stash-trial' && !!(account | async)?.trial_expiration_date">
+        Trial expiration date:
+        <strong>{{ (account | async)?.trial_expiration_date | date: 'yyyy-MM-dd' }}</strong>
+      </div>
       <div>
         Max kbs:
         <strong>{{ (account | async)?.stashes?.max_stashes }}</strong>

--- a/apps/manager-v2/src/app/manage-accounts/account-details/blocked-features/blocked-features.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/blocked-features/blocked-features.component.html
@@ -6,7 +6,7 @@
     *ngFor="let feature of blockedFeatures.controls | keyvalue"
     [formControlName]="feature.key"
     [value]="feature.value">
-    {{ feature.key }}
+    {{ feature.key | featureName }}
   </pa-checkbox>
   <nma-form-footer
     [disabled]="blockedFeatures.pristine || isSaving"

--- a/apps/manager-v2/src/app/manage-accounts/account-details/blocked-features/blocked-features.component.spec.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/blocked-features/blocked-features.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { BlockedFeaturesComponent } from './blocked-features.component';
-import { MockComponent, MockModule, MockProvider } from 'ng-mocks';
+import { MockComponent, MockModule, MockPipe, MockProvider } from 'ng-mocks';
 import { AccountDetailsStore } from '../account-details.store';
 import { AccountService } from '../../account.service';
 import { of } from 'rxjs';
@@ -8,6 +8,7 @@ import { ExtendedAccount } from '../../account.models';
 import { FormFooterComponent } from '../../form-footer/form-footer.component';
 import { ReactiveFormsModule } from '@angular/forms';
 import { PaTogglesModule } from '@guillotinaweb/pastanaga-angular';
+import { FeatureNamePipe } from './feature-name.pipe';
 
 describe('BlockedFeaturesComponent', () => {
   let component: BlockedFeaturesComponent;
@@ -16,7 +17,7 @@ describe('BlockedFeaturesComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MockModule(PaTogglesModule), MockModule(ReactiveFormsModule)],
-      declarations: [BlockedFeaturesComponent, MockComponent(FormFooterComponent)],
+      declarations: [BlockedFeaturesComponent, MockComponent(FormFooterComponent), MockPipe(FeatureNamePipe)],
       providers: [
         MockProvider(AccountDetailsStore, {
           getAccount: jest.fn(() => of({} as ExtendedAccount)),

--- a/apps/manager-v2/src/app/manage-accounts/account-details/blocked-features/blocked-features.component.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/blocked-features/blocked-features.component.ts
@@ -22,6 +22,11 @@ export class BlockedFeaturesComponent implements OnInit, OnDestroy {
     processing: new FormControl<boolean>(false, { nonNullable: true }),
     search: new FormControl<boolean>(false, { nonNullable: true }),
     generative: new FormControl<boolean>(false, { nonNullable: true }),
+    training: new FormControl<boolean>(false, { nonNullable: true }),
+    public_upload: new FormControl<boolean>(false, { nonNullable: true }),
+    public_processing: new FormControl<boolean>(false, { nonNullable: true }),
+    public_search: new FormControl<boolean>(false, { nonNullable: true }),
+    public_generative: new FormControl<boolean>(false, { nonNullable: true }),
   });
   isSaving = false;
 

--- a/apps/manager-v2/src/app/manage-accounts/account-details/blocked-features/feature-name.pipe.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/blocked-features/feature-name.pipe.ts
@@ -1,0 +1,8 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({ name: 'featureName' })
+export class FeatureNamePipe implements PipeTransform {
+  transform(value: string): string {
+    return value.replace('_', ' ');
+  }
+}

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
@@ -4,17 +4,6 @@
   (ngSubmit)="save()">
   <pa-input formControlName="email">Email</pa-input>
   <pa-select
-    label="Type"
-    formControlName="type">
-    <pa-option value="stash-trial">Trial</pa-option>
-    <pa-option value="stash-basic">Basic</pa-option>
-    <pa-option value="stash-team">Teams</pa-option>
-    <pa-option value="stash-enterprise">Enterprise</pa-option>
-    <pa-option value="stash-business">Business</pa-option>
-    <pa-option value="stash-developer">Developer</pa-option>
-    <pa-option value="stash-startup">Startup</pa-option>
-  </pa-select>
-  <pa-select
     label="Zone"
     formControlName="zone"
     readonly>
@@ -24,6 +13,28 @@
       {{ zone.title }}
     </pa-option>
   </pa-select>
+  <div class="account-type-container">
+    <pa-select
+      readonly
+      label="Account type"
+      help="ALL testing account MUST be Trial"
+      formControlName="type">
+      <pa-option value="stash-trial">Trial</pa-option>
+      <pa-option value="stash-basic">Basic</pa-option>
+      <pa-option value="stash-team">Teams</pa-option>
+      <pa-option value="stash-enterprise">Enterprise</pa-option>
+      <pa-option value="stash-business">Business</pa-option>
+      <pa-option value="stash-developer">Developer</pa-option>
+      <pa-option value="stash-startup">Startup</pa-option>
+    </pa-select>
+
+    <pa-button
+      *ngIf="configForm.controls.type.value === 'stash-trial' || configForm.controls.type.value === 'stash-enterprise'"
+      (click)="toggleAccountType()">
+      {{ configForm.controls.type.value === 'stash-trial' ? 'Upgrade to Enterprise' : 'Downgrade to Trial' }}
+    </pa-button>
+  </div>
+
   <pa-date-picker
     *ngIf="isTrial"
     label="Trial expiration date"

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
@@ -14,6 +14,11 @@
     <pa-option value="stash-developer">Developer</pa-option>
     <pa-option value="stash-startup">Startup</pa-option>
   </pa-select>
+
+  <pa-date-picker
+    *ngIf="isTrial"
+    label="Trial expiration date"
+    formControlName="trial_expiration_date"></pa-date-picker>
   <pa-input
     type="number"
     formControlName="kbs">

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
@@ -14,21 +14,6 @@
     <pa-option value="stash-developer">Developer</pa-option>
     <pa-option value="stash-startup">Startup</pa-option>
   </pa-select>
-
-  <pa-date-picker
-    *ngIf="isTrial"
-    label="Trial expiration date"
-    formControlName="trial_expiration_date"></pa-date-picker>
-  <pa-input
-    type="number"
-    formControlName="kbs">
-    Available knowledge boxes
-  </pa-input>
-  <pa-input
-    type="number"
-    formControlName="max_dedicated_processors">
-    Max dedicated processors
-  </pa-input>
   <pa-select
     label="Zone"
     formControlName="zone"
@@ -39,7 +24,49 @@
       {{ zone.title }}
     </pa-option>
   </pa-select>
+  <pa-date-picker
+    *ngIf="isTrial"
+    label="Trial expiration date"
+    formControlName="trial_expiration_date"></pa-date-picker>
+  <pa-input
+    type="number"
+    formControlName="max_dedicated_processors">
+    Max dedicated processors
+  </pa-input>
 
+  <div>
+    <label
+      class="title-xxs"
+      for="max-kbs">
+      Max knowledge boxes available
+    </label>
+    <div
+      class="radio-limit-container"
+      formGroupName="kbs">
+      <pa-radio-group
+        id="max-kbs"
+        formControlName="kbs_radio">
+        <pa-radio value="unlimited">Unlimited</pa-radio>
+        <pa-radio value="limit">Limit</pa-radio>
+      </pa-radio-group>
+      <div
+        *ngIf="configForm.controls.kbs.controls.kbs_radio.value === 'limit'"
+        class="limit-container">
+        <pa-input
+          type="number"
+          externalLabel
+          formControlName="max_kbs"></pa-input>
+        <pa-button
+          size="small"
+          icon="reload"
+          paTooltip="Reset to default"
+          aspect="basic"
+          (click)="resetMaxKbsToDefault()">
+          Reset to default
+        </pa-button>
+      </div>
+    </div>
+  </div>
   <nma-form-footer
     [disabled]="configForm.pristine || configForm.invalid || isSaving"
     (cancel)="reset()"></nma-form-footer>

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
@@ -6,6 +6,7 @@
   <pa-select
     label="Type"
     formControlName="type">
+    <pa-option value="stash-trial">Trial</pa-option>
     <pa-option value="stash-basic">Basic</pa-option>
     <pa-option value="stash-team">Teams</pa-option>
     <pa-option value="stash-enterprise">Enterprise</pa-option>

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
@@ -20,8 +20,8 @@
   </pa-input>
   <pa-input
     type="number"
-    formControlName="indexer_slow_replicas">
-    Replicas indexer slow
+    formControlName="max_dedicated_processors">
+    Max dedicated processors
   </pa-input>
   <pa-select
     label="Zone"

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.scss
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.scss
@@ -1,0 +1,18 @@
+@import 'variables';
+
+form {
+  gap: rhythm(3);
+}
+
+.account-type-container {
+  display: flex;
+  gap: rhythm(1);
+
+  pa-select {
+    flex: 1 0 auto;
+  }
+
+  pa-button {
+    margin-top: rhythm(0.5);
+  }
+}

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.spec.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.spec.ts
@@ -6,7 +6,7 @@ import { AccountService } from '../../account.service';
 import { SisToastService } from '@nuclia/sistema';
 import { of } from 'rxjs';
 import { ExtendedAccount } from '../../account.models';
-import { PaTextFieldModule } from '@guillotinaweb/pastanaga-angular';
+import { PaButtonModule, PaTextFieldModule, PaTogglesModule } from '@guillotinaweb/pastanaga-angular';
 import { ReactiveFormsModule } from '@angular/forms';
 import { FormFooterComponent } from '../../form-footer/form-footer.component';
 
@@ -16,7 +16,12 @@ describe('ConfigurationComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MockModule(PaTextFieldModule), MockModule(ReactiveFormsModule)],
+      imports: [
+        MockModule(PaButtonModule),
+        MockModule(ReactiveFormsModule),
+        MockModule(PaTextFieldModule),
+        MockModule(PaTogglesModule),
+      ],
       declarations: [ConfigurationComponent, MockComponent(FormFooterComponent)],
       providers: [
         MockProvider(AccountDetailsStore, {

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
@@ -22,9 +22,14 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
     kbs: new FormControl<number>(0, { nonNullable: true, validators: [Validators.required] }),
     max_dedicated_processors: new FormControl<number>(0, { nonNullable: true, validators: [Validators.required] }),
     zone: new FormControl<string>('', { nonNullable: true, validators: [Validators.required] }),
+    trial_expiration_date: new FormControl<string>(''),
   });
   zones = this.store.zones;
   isSaving = false;
+
+  get isTrial() {
+    return this.configForm.controls.type.value === 'stash-trial';
+  }
 
   constructor(
     private store: AccountDetailsStore,

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
@@ -11,6 +11,7 @@ import { AccountTypeDefaults } from '@flaps/core';
 
 @Component({
   templateUrl: './configuration.component.html',
+  styleUrls: ['configuration.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ConfigurationComponent implements OnInit, OnDestroy {
@@ -76,6 +77,7 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
             const rawValue = this.configForm.getRawValue();
             const payload: AccountPatchPayload = {
               ...rawValue,
+              trial_expiration_date: rawValue.trial_expiration_date ? rawValue.trial_expiration_date : null,
               kbs: rawValue.kbs.kbs_radio === 'limit' ? rawValue.kbs.max_kbs : -1,
             };
             return this.accountService
@@ -86,6 +88,7 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
         .subscribe({
           next: (updatedAccount) => {
             this.store.setAccountDetails(updatedAccount);
+            this.accountBackup = { ...updatedAccount };
             this.isSaving = false;
             this.configForm.markAsPristine();
             this.cdr.markForCheck();
@@ -111,6 +114,14 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
       return;
     }
     this.configForm.controls.kbs.controls.max_kbs.patchValue(this.defaultLimits.max_kbs);
+    this.configForm.controls.kbs.markAsDirty();
+  }
+
+  toggleAccountType() {
+    this.configForm.controls.type.patchValue(
+      this.configForm.controls.type.value === 'stash-trial' ? 'stash-enterprise' : 'stash-trial',
+    );
+    this.configForm.controls.type.markAsDirty();
   }
 
   private patchConfigForm(accountDetails: ExtendedAccount) {

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
@@ -2,11 +2,12 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnIni
 import { AccountDetailsStore } from '../account-details.store';
 import { AccountTypes } from '@nuclia/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { Subject, switchMap } from 'rxjs';
+import { Subject, switchMap, tap } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { ExtendedAccount } from '../../account.models';
+import { AccountPatchPayload, ExtendedAccount } from '../../account.models';
 import { AccountService } from '../../account.service';
 import { SisToastService } from '@nuclia/sistema';
+import { AccountTypeDefaults } from '@flaps/core';
 
 @Component({
   templateUrl: './configuration.component.html',
@@ -19,13 +20,21 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
   configForm = new FormGroup({
     email: new FormControl<string>('', { nonNullable: true, validators: [Validators.required] }),
     type: new FormControl<AccountTypes>('stash-trial', { nonNullable: true, validators: [Validators.required] }),
-    kbs: new FormControl<number>(0, { nonNullable: true, validators: [Validators.required] }),
+    kbs: new FormGroup({
+      kbs_radio: new FormControl<'limit' | 'unlimited'>('limit', {
+        nonNullable: true,
+        validators: [Validators.required],
+      }),
+      max_kbs: new FormControl<number>(0, { nonNullable: true, validators: [Validators.required] }),
+    }),
     max_dedicated_processors: new FormControl<number>(0, { nonNullable: true, validators: [Validators.required] }),
     zone: new FormControl<string>('', { nonNullable: true, validators: [Validators.required] }),
     trial_expiration_date: new FormControl<string>(''),
   });
   zones = this.store.zones;
   isSaving = false;
+
+  defaultLimits?: AccountTypeDefaults;
 
   get isTrial() {
     return this.configForm.controls.type.value === 'stash-trial';
@@ -41,12 +50,15 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.store
       .getAccount()
-      .pipe(takeUntil(this.unsubscribeAll))
-      .subscribe((accountDetails) => {
-        this.accountBackup = { ...accountDetails };
-        this.configForm.patchValue(accountDetails);
-        this.configForm.controls.kbs.patchValue(accountDetails.stashes.max_stashes);
-      });
+      .pipe(
+        tap((accountDetails) => {
+          this.accountBackup = { ...accountDetails };
+          this.patchConfigForm(accountDetails);
+        }),
+        switchMap((accountDetails) => this.accountService.getDefaultLimits(accountDetails.type)),
+        takeUntil(this.unsubscribeAll),
+      )
+      .subscribe((defaultLimits) => (this.defaultLimits = defaultLimits));
   }
 
   ngOnDestroy() {
@@ -60,11 +72,16 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
       this.store
         .getAccount()
         .pipe(
-          switchMap((account) =>
-            this.accountService
-              .updateAccount(account.id, this.configForm.getRawValue())
-              .pipe(switchMap(() => this.accountService.getAccount(account.id))),
-          ),
+          switchMap((account) => {
+            const rawValue = this.configForm.getRawValue();
+            const payload: AccountPatchPayload = {
+              ...rawValue,
+              kbs: rawValue.kbs.kbs_radio === 'limit' ? rawValue.kbs.max_kbs : -1,
+            };
+            return this.accountService
+              .updateAccount(account.id, payload)
+              .pipe(switchMap(() => this.accountService.getAccount(account.id)));
+          }),
         )
         .subscribe({
           next: (updatedAccount) => {
@@ -84,9 +101,23 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
 
   reset() {
     if (this.accountBackup) {
-      this.configForm.patchValue(this.accountBackup);
-      this.configForm.controls.kbs.patchValue(this.accountBackup.stashes.max_stashes);
+      this.patchConfigForm(this.accountBackup);
       this.configForm.markAsPristine();
     }
+  }
+
+  resetMaxKbsToDefault() {
+    if (!this.defaultLimits) {
+      return;
+    }
+    this.configForm.controls.kbs.controls.max_kbs.patchValue(this.defaultLimits.max_kbs);
+  }
+
+  private patchConfigForm(accountDetails: ExtendedAccount) {
+    this.configForm.patchValue(accountDetails);
+    this.configForm.controls.kbs.controls.kbs_radio.patchValue(
+      accountDetails.stashes.max_stashes === -1 ? 'unlimited' : 'limit',
+    );
+    this.configForm.controls.kbs.controls.max_kbs.patchValue(accountDetails.stashes.max_stashes);
   }
 }

--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
@@ -20,7 +20,7 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
     email: new FormControl<string>('', { nonNullable: true, validators: [Validators.required] }),
     type: new FormControl<AccountTypes>('stash-trial', { nonNullable: true, validators: [Validators.required] }),
     kbs: new FormControl<number>(0, { nonNullable: true, validators: [Validators.required] }),
-    indexer_slow_replicas: new FormControl<number>(0, { nonNullable: true, validators: [Validators.required] }),
+    max_dedicated_processors: new FormControl<number>(0, { nonNullable: true, validators: [Validators.required] }),
     zone: new FormControl<string>('', { nonNullable: true, validators: [Validators.required] }),
   });
   zones = this.store.zones;

--- a/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.html
@@ -1,29 +1,68 @@
-<form
-  [formGroup]="limitsForm"
-  (ngSubmit)="save()">
-  <section
-    formGroupName="upload"
-    *ngIf="(limitsForm.controls.upload.controls | keyvalue).length > 0">
-    <h3>Upload limits</h3>
-    <pa-input
-      type="number"
-      *ngFor="let limit of limitsForm.controls.upload.controls | keyvalue"
-      [formControlName]="limit.key">
-      {{ limit.key }}
-    </pa-input>
-  </section>
-  <section
-    formGroupName="usage"
-    *ngIf="(limitsForm.controls.usage.controls | keyvalue).length > 0">
-    <h3>Usage limits</h3>
-    <pa-input
-      type="number"
-      *ngFor="let limit of limitsForm.controls.usage.controls | keyvalue"
-      [formControlName]="limit.key">
-      {{ limit.key }}
-    </pa-input>
-  </section>
-  <nma-form-footer
-    [disabled]="limitsForm.pristine || limitsForm.invalid || isSaving"
-    (cancel)="reset()"></nma-form-footer>
-</form>
+<div class="limit-form">
+  <div class="reset-actions">
+    <pa-button
+      aspect="basic"
+      kind="primary"
+      [disabled]="isSaving"
+      (click)="resetAllToDefault()">
+      Reset all to default
+    </pa-button>
+    <pa-button
+      aspect="basic"
+      kind="destructive"
+      [disabled]="isSaving"
+      (click)="removeLimits()">
+      Remove limits
+    </pa-button>
+  </div>
+
+  <form
+    [formGroup]="limitsForm"
+    (ngSubmit)="save()">
+    <ng-container *ngFor="let group of limitsForm.controls | keyvalue">
+      <section
+        [formGroupName]="group.key"
+        *ngIf="(group.value.controls | keyvalue).length > 0">
+        <h3 style="text-transform: capitalize">{{ group.key }} limits</h3>
+        <div
+          *ngFor="let limit of group.value.controls | keyvalue"
+          [formGroupName]="limit.key">
+          <label
+            class="title-xxs"
+            [for]="'limit-group-' + limit.key">
+            {{ limit.key }}
+          </label>
+
+          <div class="radio-limit-container">
+            <pa-radio-group
+              [id]="'limit-group-' + limit.key"
+              [formControlName]="limit.key + '-radio'">
+              <pa-radio value="unlimited">Unlimited</pa-radio>
+              <pa-radio value="limit">Limit</pa-radio>
+            </pa-radio-group>
+            <div
+              *ngIf="getRadioValue(group.key, limit.key) === 'limit'"
+              class="limit-container">
+              <pa-input
+                type="number"
+                externalLabel
+                formControlName="limit"></pa-input>
+              <pa-button
+                size="small"
+                icon="reload"
+                paTooltip="Reset to default"
+                aspect="basic"
+                (click)="reset(group.key, limit.key)">
+                Reset to default
+              </pa-button>
+            </div>
+          </div>
+        </div>
+      </section>
+    </ng-container>
+
+    <nma-form-footer
+      [disabled]="limitsForm.pristine || limitsForm.invalid || isSaving"
+      (cancel)="cancel()"></nma-form-footer>
+  </form>
+</div>

--- a/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.html
@@ -2,18 +2,6 @@
   [formGroup]="limitsForm"
   (ngSubmit)="save()">
   <section
-    formGroupName="processing"
-    *ngIf="(limitsForm.controls.processing.controls | keyvalue).length > 0">
-    <h3>Processing limits</h3>
-    <pa-input
-      type="number"
-      *ngFor="let limit of limitsForm.controls.processing.controls | keyvalue"
-      [formControlName]="limit.key">
-      {{ limit.key }}
-    </pa-input>
-  </section>
-
-  <section
     formGroupName="upload"
     *ngIf="(limitsForm.controls.upload.controls | keyvalue).length > 0">
     <h3>Upload limits</h3>

--- a/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.scss
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.scss
@@ -10,16 +10,3 @@
     position: absolute;
   }
 }
-
-.radio-limit-container {
-  align-items: center;
-  display: flex;
-  justify-content: space-between;
-  height: rhythm(6);
-}
-
-.limit-container {
-  align-items: center;
-  display: flex;
-  gap: rhythm(1);
-}

--- a/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.scss
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.scss
@@ -1,0 +1,25 @@
+@import 'variables';
+
+.limit-form {
+  position: relative;
+
+  .reset-actions {
+    display: flex;
+    gap: rhythm(1);
+    left: rhythm(64);
+    position: absolute;
+  }
+}
+
+.radio-limit-container {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
+  height: rhythm(6);
+}
+
+.limit-container {
+  align-items: center;
+  display: flex;
+  gap: rhythm(1);
+}

--- a/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.spec.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.spec.ts
@@ -8,7 +8,7 @@ import { of } from 'rxjs';
 import { ExtendedAccount } from '../../account.models';
 import { FormFooterComponent } from '../../form-footer/form-footer.component';
 import { ReactiveFormsModule } from '@angular/forms';
-import { PaTextFieldModule } from '@guillotinaweb/pastanaga-angular';
+import { PaButtonModule, PaTextFieldModule, PaTogglesModule } from '@guillotinaweb/pastanaga-angular';
 
 describe('LimitsComponent', () => {
   let component: LimitsComponent;
@@ -16,7 +16,12 @@ describe('LimitsComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MockModule(PaTextFieldModule), MockModule(ReactiveFormsModule)],
+      imports: [
+        MockModule(PaButtonModule),
+        MockModule(ReactiveFormsModule),
+        MockModule(PaTextFieldModule),
+        MockModule(PaTogglesModule),
+      ],
       declarations: [LimitsComponent, MockComponent(FormFooterComponent)],
       providers: [
         MockProvider(AccountDetailsStore, {

--- a/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.ts
@@ -16,7 +16,6 @@ export class LimitsComponent implements OnInit, OnDestroy {
   private unsubscribeAll = new Subject<void>();
 
   limitsForm = new FormGroup({
-    processing: new FormGroup({}),
     upload: new FormGroup({}),
     usage: new FormGroup({}),
   });
@@ -34,12 +33,6 @@ export class LimitsComponent implements OnInit, OnDestroy {
       .getAccount()
       .pipe(takeUntil(this.unsubscribeAll))
       .subscribe((accountDetails) => {
-        Object.entries(accountDetails.limits.processing || {}).forEach(([key, limit]) => {
-          this.limitsForm.controls.processing.addControl(
-            key,
-            new FormControl<number>(limit, { nonNullable: true, validators: [Validators.required] }),
-          );
-        });
         Object.entries(accountDetails.limits.upload || {}).forEach(([key, limit]) => {
           this.limitsForm.controls.upload.addControl(
             key,
@@ -79,9 +72,6 @@ export class LimitsComponent implements OnInit, OnDestroy {
             this.isSaving = false;
             this.limitsForm.controls.upload.patchValue(updatedAccount.limits.upload);
             this.limitsForm.controls.usage.patchValue(updatedAccount.limits.usage);
-            if (updatedAccount.limits.processing) {
-              this.limitsForm.controls.processing.patchValue(updatedAccount.limits.processing);
-            }
             this.limitsForm.markAsPristine();
             this.cdr.markForCheck();
           },

--- a/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/limits/limits.component.ts
@@ -3,9 +3,11 @@ import { AccountDetailsStore } from '../account-details.store';
 import { AccountService } from '../../account.service';
 import { SisToastService } from '@nuclia/sistema';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { Subject, switchMap } from 'rxjs';
+import { Subject, switchMap, tap } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { AccountLimits } from '@nuclia/core';
+import { AccountLimitsPatchPayload } from '@nuclia/core';
+import { ExtendedAccount } from '../../account.models';
+import { AccountTypeDefaults } from '@flaps/core';
 
 @Component({
   templateUrl: './limits.component.html',
@@ -21,6 +23,8 @@ export class LimitsComponent implements OnInit, OnDestroy {
   });
   isSaving = false;
 
+  defaultLimits?: AccountTypeDefaults;
+
   constructor(
     private store: AccountDetailsStore,
     private accountService: AccountService,
@@ -31,22 +35,39 @@ export class LimitsComponent implements OnInit, OnDestroy {
   ngOnInit() {
     this.store
       .getAccount()
-      .pipe(takeUntil(this.unsubscribeAll))
-      .subscribe((accountDetails) => {
-        Object.entries(accountDetails.limits.upload || {}).forEach(([key, limit]) => {
-          this.limitsForm.controls.upload.addControl(
-            key,
-            new FormControl<number>(limit, { nonNullable: true, validators: [Validators.required] }),
-          );
-        });
-        Object.entries(accountDetails.limits.usage || {}).forEach(([key, limit]) => {
-          this.limitsForm.controls.usage.addControl(
-            key,
-            new FormControl<number>(limit, { nonNullable: true, validators: [Validators.required] }),
-          );
-        });
-        this.cdr.markForCheck();
-      });
+      .pipe(
+        tap((accountDetails) => {
+          Object.entries(accountDetails.limits.upload).forEach(([key, limit]) => {
+            const radioKey = `${key}-radio`;
+            this.limitsForm.controls.upload.addControl(
+              key,
+              new FormGroup({
+                [radioKey]: new FormControl<'limit' | 'unlimited'>(limit === -1 ? 'unlimited' : 'limit', {
+                  nonNullable: true,
+                  validators: [Validators.required],
+                }),
+                limit: new FormControl<number>(limit, { validators: [Validators.required] }),
+              }),
+            );
+          });
+          Object.entries(accountDetails.limits.usage).forEach(([key, limit]) => {
+            this.limitsForm.controls.usage.addControl(
+              key,
+              new FormGroup({
+                [`${key}-radio`]: new FormControl<'limit' | 'unlimited'>(limit === -1 ? 'unlimited' : 'limit', {
+                  nonNullable: true,
+                  validators: [Validators.required],
+                }),
+                limit: new FormControl<number>(limit, { validators: [Validators.required] }),
+              }),
+            );
+          });
+          this.cdr.markForCheck();
+        }),
+        switchMap((accountDetails) => this.accountService.getDefaultLimits(accountDetails.type)),
+        takeUntil(this.unsubscribeAll),
+      )
+      .subscribe((defaultLimits) => (this.defaultLimits = defaultLimits));
   }
 
   ngOnDestroy() {
@@ -54,37 +75,112 @@ export class LimitsComponent implements OnInit, OnDestroy {
     this.unsubscribeAll.complete();
   }
 
+  getRadioValue(groupKey: string, limitKey: string): 'limit' | 'unlimited' {
+    return groupKey === 'upload'
+      ? this.limitsForm.controls.upload.get(limitKey)?.get(`${limitKey}-radio`)?.value
+      : this.limitsForm.controls.usage.get(limitKey)?.get(`${limitKey}-radio`)?.value;
+  }
+
   save() {
     if (this.limitsForm.valid) {
       this.isSaving = true;
-      this.store
-        .getAccount()
-        .pipe(
-          switchMap((account) =>
-            this.accountService
-              .updateAccount(account.id, { limits: this.limitsForm.getRawValue() as AccountLimits })
-              .pipe(switchMap(() => this.accountService.getAccount(account.id))),
-          ),
-        )
-        .subscribe({
-          next: (updatedAccount) => {
-            this.store.setAccountDetails(updatedAccount);
-            this.isSaving = false;
-            this.limitsForm.controls.upload.patchValue(updatedAccount.limits.upload);
-            this.limitsForm.controls.usage.patchValue(updatedAccount.limits.usage);
-            this.limitsForm.markAsPristine();
-            this.cdr.markForCheck();
-          },
-          error: () => {
-            this.isSaving = false;
-            this.cdr.markForCheck();
-            this.toast.error('Updating limits failed');
-          },
-        });
+      const rawValues = this.limitsForm.getRawValue();
+      const payload: AccountLimitsPatchPayload = Object.entries(rawValues).reduce((data, [groupKey, limits]) => {
+        data[groupKey as 'usage' | 'upload'] = Object.entries(limits).reduce((value, [key, limitData]) => {
+          const limitAndRadio = limitData as any;
+          value[key] = limitAndRadio[key + '-radio'] === 'unlimited' ? -1 : (limitAndRadio['limit'] as number);
+          return value;
+        }, {} as { [key: string]: number }) as any;
+        return data;
+      }, {} as AccountLimitsPatchPayload);
+      this.updateLimits(payload);
     }
   }
 
-  reset() {
-    this.limitsForm.reset();
+  cancel() {
+    this.store.getAccount().subscribe((account) => this.updateForm(account));
+  }
+
+  reset(groupKey: string, limitKey: string) {
+    if (!this.defaultLimits || (groupKey !== 'usage' && groupKey !== 'upload')) {
+      return;
+    }
+    const defaultValue = (this.defaultLimits as any)[limitKey] as number;
+    const defaultLimit = {
+      limit: defaultValue,
+      [limitKey + '-radio']: defaultValue === -1 ? 'unlimited' : 'limit',
+    };
+    (this.limitsForm.controls[groupKey] as FormGroup).get(limitKey)?.patchValue(defaultLimit);
+  }
+
+  resetAllToDefault() {
+    const resetPayload = this.getLimitPayload(null);
+    this.updateLimits(resetPayload);
+  }
+
+  removeLimits() {
+    const noLimitPayload = this.getLimitPayload(-1);
+    this.updateLimits(noLimitPayload);
+  }
+
+  private getLimitPayload(value: -1 | null) {
+    const resetPayload: AccountLimitsPatchPayload = {
+      upload: {
+        upload_limit_max_media_file_size: value,
+        upload_limit_max_non_media_file_size: value,
+      },
+      usage: {
+        monthly_limit_docs_no_media_processed: value,
+        monthly_limit_hosted_answers_generated: value,
+        monthly_limit_hosted_searches_performed: value,
+        monthly_limit_media_seconds_processed: value,
+        monthly_limit_paragraphs_processed: value,
+        monthly_limit_paragraphs_stored: value,
+        monthly_limit_self_hosted_answers_generated: value,
+        monthly_limit_self_hosted_searches_performed: value,
+      },
+    };
+    return resetPayload;
+  }
+
+  private updateLimits(payload: AccountLimitsPatchPayload) {
+    this.isSaving = true;
+    this.store
+      .getAccount()
+      .pipe(
+        switchMap((account) =>
+          this.accountService
+            .updateAccount(account.id, { limits: payload })
+            .pipe(switchMap(() => this.accountService.getAccount(account.id))),
+        ),
+      )
+      .subscribe({
+        next: (updatedAccount: ExtendedAccount) => {
+          this.store.setAccountDetails(updatedAccount);
+          this.isSaving = false;
+          this.updateForm(updatedAccount);
+        },
+        error: () => {
+          this.isSaving = false;
+          this.cdr.markForCheck();
+          this.toast.error('Updating limits failed');
+        },
+      });
+  }
+
+  private updateForm(updatedAccount: ExtendedAccount) {
+    const newLimits = Object.entries(updatedAccount.limits).reduce((data, [groupKey, limits]) => {
+      data[groupKey] = Object.entries(limits as { [limitKey: string]: number }).reduce((values, [key, limit]) => {
+        values[key] = {
+          limit,
+          [`${key}-radio`]: limit === -1 ? 'unlimited' : 'limit',
+        };
+        return values;
+      }, {} as any);
+      return data;
+    }, {} as any);
+    this.limitsForm.patchValue(newLimits);
+    this.limitsForm.markAsPristine();
+    this.cdr.markForCheck();
   }
 }

--- a/apps/manager-v2/src/app/manage-accounts/account-list/account-list.component.spec.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-list/account-list.component.spec.ts
@@ -1,7 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { AccountListComponent } from './account-list.component';
 import { MockModule, MockProvider } from 'ng-mocks';
-import { PaTableModule, PaTextFieldModule } from '@guillotinaweb/pastanaga-angular';
+import { PaScrollModule, PaTableModule, PaTextFieldModule } from '@guillotinaweb/pastanaga-angular';
 import { AccountService } from '../account.service';
 import { of } from 'rxjs';
 import { SisModalService, SisToastService } from '@nuclia/sistema';
@@ -12,7 +12,7 @@ describe('AccountListComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MockModule(PaTextFieldModule), MockModule(PaTableModule)],
+      imports: [MockModule(PaScrollModule), MockModule(PaTableModule), MockModule(PaTextFieldModule)],
       declarations: [AccountListComponent],
       providers: [
         MockProvider(AccountService, {

--- a/apps/manager-v2/src/app/manage-accounts/account.models.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account.models.ts
@@ -1,4 +1,4 @@
-import { Account, AccountBlockingState, AccountConfig, AccountLimits, WelcomeUser } from '@nuclia/core';
+import { Account, AccountBlockingState, AccountConfig, AccountLimitsPatchPayload, WelcomeUser } from '@nuclia/core';
 import { Language, UserType } from '@flaps/core';
 
 export interface AccountSummary {
@@ -51,7 +51,7 @@ export interface AccountPatchPayload {
   max_dedicated_processors?: number;
   data?: object;
   blocking_state?: AccountBlockingState;
-  limits?: AccountLimits;
+  limits?: AccountLimitsPatchPayload;
 }
 
 export interface AccountKbList {

--- a/apps/manager-v2/src/app/manage-accounts/account.models.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account.models.ts
@@ -52,6 +52,7 @@ export interface AccountPatchPayload {
   data?: object;
   blocking_state?: AccountBlockingState;
   limits?: AccountLimitsPatchPayload;
+  trial_expiration_date?: string | null;
 }
 
 export interface AccountKbList {

--- a/apps/manager-v2/src/app/manage-accounts/account.models.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account.models.ts
@@ -48,7 +48,7 @@ export interface AccountPatchPayload {
   creator?: string;
   type?: string;
   kbs?: number;
-  indexer_slow_replicas?: number;
+  max_dedicated_processors?: number;
   data?: object;
   blocking_state?: AccountBlockingState;
   limits?: AccountLimits;

--- a/apps/manager-v2/src/app/manage-accounts/account.service.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
-import { SDKService } from '@flaps/core';
-import { Observable } from 'rxjs';
+import { AccountService as GlobalAccountService, AccountTypeDefaults, SDKService } from '@flaps/core';
+import { map, Observable } from 'rxjs';
 import {
   AccountPatchPayload,
   AccountSummary,
@@ -12,7 +12,7 @@ import {
   KbSummary,
   ZoneSummary,
 } from './account.models';
-import { AccountBlockingState } from '@nuclia/core';
+import { AccountBlockingState, AccountTypes } from '@nuclia/core';
 
 const ACCOUNTS_ENDPOINT = '/manage/@accounts';
 const ACCOUNT_ENDPOINT = '/manage/@account';
@@ -23,7 +23,13 @@ const KB_ENDPOINT = '@stashes';
   providedIn: 'root',
 })
 export class AccountService {
-  constructor(private sdk: SDKService) {}
+  private _accountTypes = this.globalAccount.getAccountTypes();
+
+  constructor(private sdk: SDKService, private globalAccount: GlobalAccountService) {}
+
+  getDefaultLimits(accountType: AccountTypes): Observable<AccountTypeDefaults> {
+    return this._accountTypes.pipe(map((accountTypes) => accountTypes[accountType]));
+  }
 
   getAccounts(): Observable<AccountSummary[]> {
     return this.sdk.nuclia.rest.get<AccountSummary[]>(ACCOUNTS_ENDPOINT);

--- a/apps/manager-v2/src/app/manage-accounts/manage-accounts.module.ts
+++ b/apps/manager-v2/src/app/manage-accounts/manage-accounts.module.ts
@@ -11,6 +11,7 @@ import {
   PaTableModule,
   PaTextFieldModule,
   PaTogglesModule,
+  PaTooltipModule,
 } from '@guillotinaweb/pastanaga-angular';
 import { AccountDetailsComponent } from './account-details/account-details.component';
 import { AccountListComponent } from './account-list/account-list.component';
@@ -85,6 +86,7 @@ const ROUTES: Routes = [
     PaPopupModule,
     PaDropdownModule,
     PaScrollModule,
+    PaTooltipModule,
   ],
   declarations: [
     ManageAccountsComponent,

--- a/apps/manager-v2/src/app/manage-accounts/manage-accounts.module.ts
+++ b/apps/manager-v2/src/app/manage-accounts/manage-accounts.module.ts
@@ -24,6 +24,7 @@ import { KbDetailsComponent } from './account-details/kb-details/kb-details.comp
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BlockedFeaturesComponent } from './account-details/blocked-features/blocked-features.component';
 import { FormFooterComponent } from './form-footer/form-footer.component';
+import { FeatureNamePipe } from './account-details/blocked-features/feature-name.pipe';
 
 const ROUTES: Routes = [
   {
@@ -101,6 +102,7 @@ const ROUTES: Routes = [
     KbDetailsComponent,
     BlockedFeaturesComponent,
     FormFooterComponent,
+    FeatureNamePipe,
   ],
 })
 export class ManageAccountsModule {}

--- a/apps/manager-v2/src/app/manage-accounts/manage-accounts.module.ts
+++ b/apps/manager-v2/src/app/manage-accounts/manage-accounts.module.ts
@@ -4,6 +4,7 @@ import { ManageAccountsComponent } from './manage-accounts.component';
 import { RouterModule, Routes } from '@angular/router';
 import {
   PaButtonModule,
+  PaDatePickerModule,
   PaDropdownModule,
   PaIconModule,
   PaPopupModule,
@@ -87,6 +88,7 @@ const ROUTES: Routes = [
     PaDropdownModule,
     PaScrollModule,
     PaTooltipModule,
+    PaDatePickerModule,
   ],
   declarations: [
     ManageAccountsComponent,

--- a/apps/manager-v2/src/app/manage-users/user-list/user-list.component.spec.ts
+++ b/apps/manager-v2/src/app/manage-users/user-list/user-list.component.spec.ts
@@ -5,7 +5,13 @@ import { RouterTestingModule } from '@angular/router/testing';
 import { SisModalService, SisToastService } from '@nuclia/sistema';
 import { UserService } from '../user.service';
 import { of } from 'rxjs';
-import { PaButtonModule, PaIconModule, PaTableModule, PaTextFieldModule } from '@guillotinaweb/pastanaga-angular';
+import {
+  PaButtonModule,
+  PaIconModule,
+  PaScrollModule,
+  PaTableModule,
+  PaTextFieldModule,
+} from '@guillotinaweb/pastanaga-angular';
 
 describe('UserListComponent', () => {
   let component: UserListComponent;
@@ -17,6 +23,7 @@ describe('UserListComponent', () => {
         RouterTestingModule,
         MockModule(PaButtonModule),
         MockModule(PaIconModule),
+        MockModule(PaScrollModule),
         MockModule(PaTableModule),
         MockModule(PaTextFieldModule),
       ],

--- a/apps/manager-v2/src/styles.scss
+++ b/apps/manager-v2/src/styles.scss
@@ -104,6 +104,19 @@ form section {
   gap: rhythm(2);
   max-width: rhythm(64);
 
+  .radio-limit-container {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+    height: rhythm(6);
+  }
+
+  .limit-container {
+    align-items: center;
+    display: flex;
+    gap: rhythm(1);
+  }
+
   footer {
     display: flex;
     gap: rhythm(2);

--- a/libs/core/src/lib/api/account.service.ts
+++ b/libs/core/src/lib/api/account.service.ts
@@ -1,0 +1,16 @@
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs';
+import { AccountTypes } from '@nuclia/core';
+import { AccountTypeDefaults } from '../models';
+import { SDKService } from './sdk.service';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class AccountService {
+  constructor(private sdk: SDKService) {}
+
+  getAccountTypes(): Observable<{ [key in AccountTypes]: AccountTypeDefaults }> {
+    return this.sdk.nuclia.rest.get<{ [key in AccountTypes]: AccountTypeDefaults }>(`/configuration/account_types`);
+  }
+}

--- a/libs/core/src/lib/api/index.ts
+++ b/libs/core/src/lib/api/index.ts
@@ -1,3 +1,4 @@
+export * from './account.service';
 export * from './deprecated-api.service';
 export * from './sdk.service';
 export * from './sso.service';

--- a/libs/core/src/lib/models/account.model.ts
+++ b/libs/core/src/lib/models/account.model.ts
@@ -26,3 +26,19 @@ export interface AccountModification {
 export interface AccountStatus {
   available: boolean;
 }
+
+export interface AccountTypeDefaults {
+  max_kbs: number;
+  max_dedicated_processors: number;
+  max_trial_days: number;
+  monthly_limit_paragraphs_processed: number;
+  monthly_limit_docs_no_media_processed: number;
+  monthly_limit_media_seconds_processed: number;
+  monthly_limit_paragraphs_stored: number;
+  monthly_limit_hosted_searches_performed: number;
+  monthly_limit_hosted_answers_generated: number;
+  monthly_limit_self_hosted_searches_performed: number;
+  monthly_limit_self_hosted_answers_generated: number;
+  upload_limit_max_media_file_size: number;
+  upload_limit_max_non_media_file_size: number;
+}

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 1.3.3 (unreleased)
+
+### Improvements
+- Update `AccountLimits` model and create `AccountLimitsPatchPayload` model
+
 # 1.3.2 (2023-05-24)
 
 ### Improvements

--- a/libs/sdk-core/src/lib/db/db.models.ts
+++ b/libs/sdk-core/src/lib/db/db.models.ts
@@ -40,16 +40,30 @@ export interface AccountLimits {
     upload_limit_max_non_media_file_size: number;
   };
   usage: {
-    monthly_limit_chars_processed: number;
     monthly_limit_docs_no_media_processed: number;
     monthly_limit_hosted_answers_generated: number;
     monthly_limit_hosted_searches_performed: number;
     monthly_limit_media_seconds_processed: number;
-    monthly_limit_non_media_files_processed: number;
     monthly_limit_paragraphs_processed: number;
     monthly_limit_paragraphs_stored: number;
     monthly_limit_self_hosted_answers_generated: number;
     monthly_limit_self_hosted_searches_performed: number;
+  };
+}
+export interface AccountLimitsPatchPayload {
+  upload: {
+    upload_limit_max_media_file_size: number | null;
+    upload_limit_max_non_media_file_size: number | null;
+  };
+  usage: {
+    monthly_limit_docs_no_media_processed: number | null;
+    monthly_limit_hosted_answers_generated: number | null;
+    monthly_limit_hosted_searches_performed: number | null;
+    monthly_limit_media_seconds_processed: number | null;
+    monthly_limit_paragraphs_processed: number | null;
+    monthly_limit_paragraphs_stored: number | null;
+    monthly_limit_self_hosted_answers_generated: number | null;
+    monthly_limit_self_hosted_searches_performed: number | null;
   };
 }
 

--- a/libs/sdk-core/src/lib/db/db.models.ts
+++ b/libs/sdk-core/src/lib/db/db.models.ts
@@ -30,7 +30,7 @@ export interface Account {
 
 export interface AccountConfig {
   g_speech_to_text: boolean;
-  indexer_slow_replicas: number;
+  indexer_slow_replicas: number; // Deprecated, use max_dedicated_processors instead
   max_dedicated_processors: number;
 }
 

--- a/libs/sdk-core/src/lib/db/db.models.ts
+++ b/libs/sdk-core/src/lib/db/db.models.ts
@@ -35,18 +35,6 @@ export interface AccountConfig {
 }
 
 export interface AccountLimits {
-  processing: {
-    monthly_limit_chars_processed: number;
-    monthly_limit_docs_no_media_processed: number;
-    monthly_limit_hosted_answers_generated: number;
-    monthly_limit_hosted_searches_performed: number;
-    monthly_limit_media_seconds_processed: number;
-    monthly_limit_non_media_files_processed: number;
-    monthly_limit_paragraphs_processed: number;
-    monthly_limit_paragraphs_stored: number;
-    monthly_limit_self_hosted_answers_generated: number;
-    monthly_limit_self_hosted_searches_performed: number;
-  };
   upload: {
     upload_limit_max_media_file_size: number;
     upload_limit_max_non_media_file_size: number;

--- a/mrs.developer.json
+++ b/mrs.developer.json
@@ -4,6 +4,6 @@
     "https": "https://github.com/plone/pastanaga-angular.git",
     "path": "/projects/pastanaga-angular/src",
     "package": "@guillotinaweb/pastanaga-angular",
-    "tag": "2.61.8"
+    "tag": "2.61.9"
   }
 }

--- a/mrs.developer.json
+++ b/mrs.developer.json
@@ -4,6 +4,6 @@
     "https": "https://github.com/plone/pastanaga-angular.git",
     "path": "/projects/pastanaga-angular/src",
     "package": "@guillotinaweb/pastanaga-angular",
-    "tag": "2.61.5"
+    "tag": "2.61.7"
   }
 }

--- a/mrs.developer.json
+++ b/mrs.developer.json
@@ -4,6 +4,6 @@
     "https": "https://github.com/plone/pastanaga-angular.git",
     "path": "/projects/pastanaga-angular/src",
     "package": "@guillotinaweb/pastanaga-angular",
-    "tag": "2.61.7"
+    "tag": "2.61.8"
   }
 }


### PR DESCRIPTION
- Field indexer_slow_replicas has been deprecated and should be replaced for the max_dedicated_processors field
- it would be necessary to review that all those fields corresponding to numerical values ​​must be sent as integers instead of being sent as strings
- Limits fields `monthly_limit_chars_processed` and `monthly_limit_non_media_files_processed` are no longer needed, so both could be removed from the limits form
- rethink and implement a different way to set the limits in the limits form (can be `number > 0`,` -1` or `null`)
- provide an option to reset all limits to default values OR unlimited? (this will probably what Eudald uses the most)
- add and manage optional `trial_expiration_date` on account details that can be updated.
- The amount of blocked features has been extended due to the need to perform more granular blocking operations, UI must be updated accordingly
- A TRIAL account should be upgradable to ENTERPRISE, and enterprise can be downgraded to trial. No other changes allowed
- `max_kbs` as same behaviour as limits: 3 possible values (`-1` for unlimited, `null` for default value, and `number > 0` for specified limit).