### PR TITLE
[sc-5872] patch expiration date only when account is trial

### DIFF
--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
@@ -36,7 +36,7 @@
   </div>
 
   <pa-date-picker
-    *ngIf="isTrial"
+    *ngIf="canModifyTrialExpiration"
     label="Trial expiration date"
     formControlName="trial_expiration_date"></pa-date-picker>
   <pa-input


### PR DESCRIPTION
- When modifying an account in the manage, the `trial_expiration_date` param is only included in the payload if the current account is trial.
- `trial_expiration_date` is not included in the payload when downgrading from enterprise to trial account.