### PR TITLE
Fix [sc-5861]: Prevent bad account selection

### DIFF
--- a/apps/desktop/src/app/account/account.component.ts
+++ b/apps/desktop/src/app/account/account.component.ts
@@ -1,7 +1,8 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { Router } from '@angular/router';
-import { SyncService } from '../sync/sync.service';
+import { ACCOUNT_KEY, SyncService } from '../sync/sync.service';
 import { SDKService } from '@flaps/core';
+import { catchError, of, tap } from 'rxjs';
 
 @Component({
   selector: 'nde-select-account',
@@ -10,11 +11,28 @@ import { SDKService } from '@flaps/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SelectAccountComponent {
-  accounts = this.sdk.nuclia.db.getAccounts();
+  accounts = this.sdk.nuclia.db.getAccounts().pipe(
+    tap((accounts) => {
+      if (accounts.length === 0) {
+        this.logout();
+      }
+    }),
+    catchError(() => {
+      this.logout();
+      return of([]);
+    }),
+  );
+
   constructor(private sdk: SDKService, private sync: SyncService, private router: Router) {}
 
   selectAccount(account: string) {
     this.sync.selectAccount(account);
+    this.router.navigate(['/']);
+  }
+
+  logout() {
+    localStorage.removeItem(ACCOUNT_KEY);
+    this.sdk.nuclia.auth.logout();
     this.router.navigate(['/']);
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuclia",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "license": "MIT",
   "author": "Nuclia.cloud",
   "description": "Nuclia frontend apps and libs",


### PR DESCRIPTION
In some corner cases happening only for people having several accounts on several environment (ie Stage and Prod), the Desktop ended up in a bad state where no account was selected. This PR is adding more checks and redirections to prevent this from happening.

Steps I followed to reproduce the bug:
1. in the browser, open and log in stage in a tab and nuclia.cloud (prod) in another tab
2. open Desktop app (the one I downloaded from Prod dashboard), log in, choose a prod account and then quit Desktop app
3. build Desktop locally and open it: 
  - the app logs in automatically without showing the select an account page
  - the current account won't show up on the top bar even if you have several accounts
  - if you try to add a connector, on the select destination step there will be no kb dropdown (so the flow is blocked on this step)

Before the fix, the only work around was to switch account by clicking on the avatar (in case you have several accounts). After the fix, the user is automatically redirected to select an account page.