### PR TITLE
Fix widget inputs to warn only on mandatory ones

### DIFF
--- a/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
@@ -24,12 +24,12 @@
   import { suggestionState, typeAhead } from '../../core/stores/suggestions.store';
 
   export let backend = 'https://nuclia.cloud/api';
-  export let zone = '';
-  export let knowledgebox = '';
+  export let zone = 'europe-1';
+  export let knowledgebox;
   export let placeholder = '';
   export let lang = '';
-  export let cdn;
-  export let apikey;
+  export let cdn = '';
+  export let apikey = '';
   export let kbslug = '';
   export let account = '';
   export let client = 'widget';


### PR DESCRIPTION
- Provide `europe-1` as default `zone`
- Make `knowledgebox` mandatory (will warn on the console if not provided)
- Make `cdn` and `apikey` optional (no warning on the console when not provided)