### PR TITLE
[sc-6029] [sc-6044] manage chat endpoint errors

### DIFF
--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### Breaking change
 - `setField` method replaces `addField` and `updateField` which were identical.
+- Manage errors on chat endpoint:
+  - `KnowledgeBox.chat` method returns `IErrorResponse` on error
+  - Add `type` property to `FindResults` model
 
 ### Improvements
-- Manage properly 529 status (service overloaded) on chat endpoint
 - Add `getEntityFromFilter` and `getFilterFromEntity` functions
 - Add `autofilters` property to `FindResults` model
 

--- a/libs/sdk-core/src/lib/db/kb/kb.models.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.models.ts
@@ -84,7 +84,11 @@ export interface IKnowledgeBox extends IKnowledgeBoxCreation {
 
   getResourceBySlug(slug: string, show?: ResourceProperties[], extracted?: ExtractedDataTypes[]): Observable<IResource>;
 
-  chat(query: string, context?: Chat.ContextEntry[], features?: Chat.Features[]): Observable<Chat.Answer>;
+  chat(
+    query: string,
+    context?: Chat.ContextEntry[],
+    features?: Chat.Features[],
+  ): Observable<Chat.Answer | IErrorResponse>;
 
   find(
     query: string,

--- a/libs/sdk-core/src/lib/db/kb/kb.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.ts
@@ -155,7 +155,7 @@ export class KnowledgeBox implements IKnowledgeBox {
     context?: Chat.ContextEntry[],
     features?: Chat.Features[],
     options?: BaseSearchOptions,
-  ): Observable<Chat.Answer> {
+  ): Observable<Chat.Answer | IErrorResponse> {
     return chat(this.nuclia, this.path, query, context, features, options);
   }
 

--- a/libs/sdk-core/src/lib/db/search/chat.models.ts
+++ b/libs/sdk-core/src/lib/db/search/chat.models.ts
@@ -13,11 +13,11 @@ export namespace Chat {
   }
 
   export interface Answer {
+    type: 'answer';
     text: string;
     id: string;
     sources?: Search.FindResults;
     incomplete?: boolean;
-    overloaded?: boolean;
   }
 
   export enum Author {

--- a/libs/sdk-core/src/lib/models.ts
+++ b/libs/sdk-core/src/lib/models.ts
@@ -83,10 +83,7 @@ export interface IRest {
   getZoneSlug(zoneId: string): Observable<string>;
   getFullUrl(path: string): string;
   getObjectURL(path: string): Observable<string>;
-  getStream(
-    path: string,
-    body: any,
-  ): Observable<{ data: Uint8Array; incomplete: boolean; headers: Headers; status: number }>;
+  getStream(path: string, body: any): Observable<{ data: Uint8Array; incomplete: boolean; headers: Headers }>;
 }
 
 export interface IDb {

--- a/libs/search-widget/public/i18n/ca.json
+++ b/libs/search-widget/public/i18n/ca.json
@@ -25,6 +25,7 @@
 	"entities.time": "Temps",
 	"entities.title": "Insights",
 	"entities.work_of_art": "Obres",
+	"error.answer-feature-blocked": "La funcionalitat de respostes no està permesa en aquest moment.",
 	"error.audio-loading": "S'ha produït un error en carregar el fitxer d'àudio.",
 	"error.feature-blocked": "La funció de cerca no està permesa en aquest moment.",
 	"error.partial-results": "Ho sentim, el sistema està sobrecarregat i només podria proporcionar un resultat parcial.",

--- a/libs/search-widget/public/i18n/en.json
+++ b/libs/search-widget/public/i18n/en.json
@@ -26,6 +26,7 @@
 	"entities.time": "Time",
 	"entities.title": "Insights",
 	"entities.work_of_art": "Art",
+	"error.answer-feature-blocked": "Answers feature is not allowed at the moment.",
 	"error.audio-loading": "An error occurred while loading the audio file.",
 	"error.feature-blocked": "Search feature is not allowed at the moment.",
 	"error.partial-results": "Sorry, the system is overloaded and could only provide a partial result.",

--- a/libs/search-widget/public/i18n/es.json
+++ b/libs/search-widget/public/i18n/es.json
@@ -25,6 +25,7 @@
 	"entities.time": "Tiempo",
 	"entities.title": "Insights",
 	"entities.work_of_art": "Obras",
+	"error.answer-feature-blocked": "La funcionalidad de respuestas no está permitida en este momento.",
 	"error.audio-loading": "Ocurrió un error al cargar el archivo de audio.",
 	"error.feature-blocked": "La función de búsqueda no está permitida en este momento.",
 	"error.partial-results": "Lo sentimos, el sistema está sobrecargado y solo pudo proporcionar un resultado parcial.",

--- a/libs/search-widget/public/i18n/fr.json
+++ b/libs/search-widget/public/i18n/fr.json
@@ -23,6 +23,7 @@
 	"entities.time": "Temps",
 	"entities.title": "Insights",
 	"entities.work_of_art": "Œuvres",
+	"error.answer-feature-blocked": "La fonctionnalité de réponses n'est pas autorisée pour le moment.",
 	"error.audio-loading": "Une erreur s'est produite lors du chargement du fichier audio.",
 	"error.feature-blocked": "La fonction de recherche n'est pas autorisée pour le moment.",
 	"error.partial-results": "Désolé, le système est surchargé et n'a pu fournir qu'un résultat partiel.",

--- a/libs/search-widget/src/components/answer/InitialAnswer.svelte
+++ b/libs/search-widget/src/components/answer/InitialAnswer.svelte
@@ -21,10 +21,16 @@
   }
 </script>
 
-{#if $firstAnswer.text || !!$chatError}
+{#if $firstAnswer.text || $chatError}
   <div class="sw-initial-answer">
-    {#if $isServiceOverloaded}
-      {$_('error.service-overloaded')}
+    {#if $chatError}
+      {#if $isServiceOverloaded}
+        {$_('error.service-overloaded')}
+      {:else if $chatError.status === 402}
+        {$_('error.answer-feature-blocked')}
+      {:else}
+        {$_('error.search')}
+      {/if}
     {:else}
       <div class="container">
         <div class="answer">

--- a/libs/search-widget/src/core/api.ts
+++ b/libs/search-widget/src/core/api.ts
@@ -95,13 +95,7 @@ export const getAnswer = (query: string, chat?: Chat.Entry[], options?: BaseSear
     return acc;
   }, [] as Chat.ContextEntry[]);
 
-  return nucliaApi.knowledgeBox.chat(query, context, [Chat.Features.PARAGRAPHS], options).pipe(
-    tap((res) => {
-      if (res.overloaded) {
-        chatError.set({ type: 'error', status: 529, detail: 'Service overloaded' });
-      }
-    }),
-  );
+  return nucliaApi.knowledgeBox.chat(query, context, [Chat.Features.PARAGRAPHS], options).pipe();
 };
 
 export const sendFeedback = (answer: Chat.Answer, approved: boolean) => {

--- a/libs/search-widget/src/core/stores/answers.store.ts
+++ b/libs/search-widget/src/core/stores/answers.store.ts
@@ -1,5 +1,6 @@
 import type { Chat, IErrorResponse } from '@nuclia/core';
 import { SvelteState } from '../state-lib';
+import { showResults } from './search.store';
 
 interface AnswerState {
   chat: Chat.Entry[];
@@ -9,7 +10,7 @@ interface AnswerState {
   isStreaming: boolean;
 }
 
-const EMPTY_ANSWER = { text: '', id: '' };
+const EMPTY_ANSWER = { type: 'answer' as const, text: '', id: '' };
 export const answerState = new SvelteState<AnswerState>({
   chat: [],
   currentQuestion: '',
@@ -30,11 +31,14 @@ export const currentQuestion = answerState.writer<string, { question: string; re
 
 export const currentAnswer = answerState.writer<Chat.Answer, Partial<Chat.Answer>>(
   (state) => state.currentAnswer,
-  (state, value) => ({
-    ...state,
-    currentAnswer: { ...state.currentAnswer, ...value },
-    isStreaming: true,
-  }),
+  (state, value) => {
+    showResults.set(true);
+    return {
+      ...state,
+      currentAnswer: { ...state.currentAnswer, ...value },
+      isStreaming: true,
+    };
+  },
 );
 
 export const firstAnswer = answerState.reader((state) =>
@@ -71,5 +75,11 @@ export const isStreaming = answerState.reader((state) => state.isStreaming);
 export const isServiceOverloaded = answerState.reader<boolean>((state) => !!state.error && state.error.status === 529);
 export const chatError = answerState.writer<IErrorResponse | undefined>(
   (state) => state.error,
-  (state, error) => ({ ...state, error }),
+  (state, error) => {
+    showResults.set(true);
+    return {
+      ...state,
+      error,
+    };
+  },
 );

--- a/libs/search-widget/src/core/stores/search.store.ts
+++ b/libs/search-widget/src/core/stores/search.store.ts
@@ -104,6 +104,7 @@ export const searchError = searchState.writer<IErrorResponse | undefined>(
     ...state,
     error,
     pending: false,
+    showResults: true,
   }),
 );
 

--- a/libs/search-widget/widget.babel
+++ b/libs/search-widget/widget.babel
@@ -686,6 +686,30 @@
 						<name>error</name>
 						<children>
 							<concept_node>
+								<name>answer-feature-blocked</name>
+								<description/>
+								<comment/>
+								<default_text/>
+								<translations>
+									<translation>
+										<language>ca-ES</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>en-US</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>es-ES</language>
+										<approved>false</approved>
+									</translation>
+									<translation>
+										<language>fr-FR</language>
+										<approved>false</approved>
+									</translation>
+								</translations>
+							</concept_node>
+							<concept_node>
 								<name>audio-loading</name>
 								<description/>
 								<comment/>


### PR DESCRIPTION
- `chat` method from the sdk returns a `IErrorResponse` like `find` and `search` methods
- Display chat errors on search widget