### PR TITLE
[sc-6139] Search results: display one tile by field

### DIFF
--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.5.0 (unreleased)
+
+### Breaking changes
+- Remove `Search.SmartParagraph` interface as it's not used anymore
+- Rename `Search.SmartResult` interface to `Search.FieldResult` as `Smart` prefix doesn't make sense anymore
+
 # 1.4.0 (2023-06-23)
 
 ### Breaking change

--- a/libs/sdk-core/src/lib/db/search/search.models.ts
+++ b/libs/sdk-core/src/lib/db/search/search.models.ts
@@ -136,14 +136,10 @@ export namespace Search {
     next_page: boolean;
   }
 
-  export interface SmartResult extends IResource {
+  export interface FieldResult extends IResource {
     paragraphs?: FindParagraph[];
     field?: FieldId;
     fieldData?: IFieldData;
-  }
-
-  export interface SmartParagraph extends Paragraph {
-    sentences?: Sentence[];
   }
 
   export interface Suggestions {

--- a/libs/search-widget/src/components/answer/Answer.svelte
+++ b/libs/search-widget/src/components/answer/Answer.svelte
@@ -18,7 +18,7 @@
   $: text = answer.text?.replace(NEWLINE, '<br>') || '';
   $: isMobile = isMobileViewport(innerWidth);
 
-  const sources = getSortedResults(answer.sources?.resources);
+  const sources = getSortedResults(Object.values(answer.sources?.resources));
 </script>
 
 <svelte:window bind:innerWidth />

--- a/libs/search-widget/src/core/api.ts
+++ b/libs/search-widget/src/core/api.ts
@@ -103,7 +103,7 @@ export const getAnswer = (query: string, chat?: Chat.Entry[], options?: BaseSear
     return acc;
   }, [] as Chat.ContextEntry[]);
 
-  return nucliaApi.knowledgeBox.chat(query, context, CHAT_MODE, options).pipe();
+  return nucliaApi.knowledgeBox.chat(query, context, CHAT_MODE, options);
 };
 
 export const sendFeedback = (answer: Chat.Answer, approved: boolean) => {

--- a/libs/search-widget/src/core/models.ts
+++ b/libs/search-widget/src/core/models.ts
@@ -9,14 +9,27 @@ import type {
   WidgetFeatures,
 } from '@nuclia/core';
 
-export const NO_RESULTS: Search.FindResults = {
+export interface FindResultsAsList extends Omit<Search.FindResults, 'resources'> {
+  resultList: Search.FieldResult[];
+}
+
+const EMPTY_FIND_RESULTS: Omit<Search.FindResults, 'resources'> = {
   type: 'findResults',
-  resources: {} as { [id: string]: Search.FindResource },
   total: 0,
   page_number: 0,
   next_page: false,
   page_size: 0,
   query: '',
+};
+
+export const NO_RESULTS: Search.FindResults = {
+  ...EMPTY_FIND_RESULTS,
+  resources: {},
+};
+
+export const NO_RESULT_LIST: FindResultsAsList = {
+  ...EMPTY_FIND_RESULTS,
+  resultList: [],
 };
 
 export const NO_SUGGESTION_RESULTS: Search.Suggestions = {

--- a/libs/search-widget/src/core/search-bar.ts
+++ b/libs/search-widget/src/core/search-bar.ts
@@ -79,6 +79,9 @@ export const setupTriggerSearch = (
                       }),
                       filter((res) => res.type !== 'error'),
                       map((res) => res as Chat.Answer),
+                      // Chat is emitting several times until the answer is complete, but the result sources doesn't change while answer is incomplete
+                      // So we make sure to emit only when results are changing, preventing to write in the state several times while loading the answer
+                      distinctUntilChanged((previous, current) => previous.sources === current.sources),
                       map((res) => ({
                         results: res.sources,
                         append: false,
@@ -86,11 +89,6 @@ export const setupTriggerSearch = (
                         loadingMore: false,
                         options: currentOptions,
                       })),
-                      // Chat is emitting several times until the answer is complete, but the result sources doesn't change while answer is incomplete
-                      // So we make sure to emit only when results are changing, preventing to write in the state several times while loading the answer
-                      distinctUntilChanged(
-                        (previous, current) => JSON.stringify(previous.results) === JSON.stringify(current.results),
-                      ),
                     );
                   } else {
                     return search(query, currentOptions).pipe(

--- a/libs/search-widget/src/core/search-bar.ts
+++ b/libs/search-widget/src/core/search-bar.ts
@@ -86,6 +86,11 @@ export const setupTriggerSearch = (
                         loadingMore: false,
                         options: currentOptions,
                       })),
+                      // Chat is emitting several times until the answer is complete, but the result sources doesn't change while answer is incomplete
+                      // So we make sure to emit only when results are changing, preventing to write in the state several times while loading the answer
+                      distinctUntilChanged(
+                        (previous, current) => JSON.stringify(previous.results) === JSON.stringify(current.results),
+                      ),
                     );
                   } else {
                     return search(query, currentOptions).pipe(

--- a/libs/search-widget/src/core/stores/search.store.ts
+++ b/libs/search-widget/src/core/stores/search.store.ts
@@ -99,11 +99,11 @@ export const searchResults = searchState.writer<
   (state) => state.results,
   (state, params) => {
     const sortedResults = getSortedResults(Object.values(params.results.resources || {}));
+    const { resources, ...results } = params.results;
     return {
       ...state,
       results: {
-        ...params.results,
-        resources: undefined,
+        ...results,
         resultList: params.append ? state.results.resultList.concat(sortedResults) : sortedResults,
       },
       pending: false,
@@ -452,10 +452,5 @@ export function getSortedResults(resources: Search.FindResource[]): Search.Field
 }
 
 export function getResultUniqueKey(result: Search.FieldResult): string {
-  const key = `${(result.paragraphs || []).reduce((acc, curr) => `${acc}${acc.length > 0 ? '__' : ''}${curr.id}`, '')}`;
-  if (!allKeys.includes(key)) {
-    allKeys.push(key);
-  }
-  return key;
+  return `${(result.paragraphs || []).reduce((acc, curr) => `${acc}${acc.length > 0 ? '__' : ''}${curr.id}`, '')}`;
 }
-const allKeys: string[] = [];

--- a/libs/search-widget/src/tiles/AudioTile.svelte
+++ b/libs/search-widget/src/tiles/AudioTile.svelte
@@ -7,7 +7,7 @@
   import { getFieldUrl } from '../core/stores/viewer.store';
   import MediaTile from './base-tile/MediaTile.svelte';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
 
   let mediaLoading = true;
   let mediaTime = 0;

--- a/libs/search-widget/src/tiles/ConversationTile.svelte
+++ b/libs/search-widget/src/tiles/ConversationTile.svelte
@@ -6,7 +6,7 @@
   import BaseTile from './base-tile/BaseTile.svelte';
   import Thumbnail from '../common/thumbnail/Thumbnail.svelte';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
   let thumbnailLoaded = false;
   let selectedParagraph: WidgetParagraph | undefined;
 

--- a/libs/search-widget/src/tiles/ImageTile.svelte
+++ b/libs/search-widget/src/tiles/ImageTile.svelte
@@ -8,7 +8,7 @@
   import ImageViewer from './viewers/ImageViewer.svelte';
   import Thumbnail from '../common/thumbnail/Thumbnail.svelte';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
 
   let thumbnailLoaded = false;
   let imageUrl: Observable<string>;

--- a/libs/search-widget/src/tiles/PdfTile.svelte
+++ b/libs/search-widget/src/tiles/PdfTile.svelte
@@ -9,7 +9,7 @@
   import DocumentTile from './base-tile/DocumentTile.svelte';
   import { isMobileViewport } from '../common/utils';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
 
   const pdfStyle = getPdfJsStyle();
   const pdfJsBaseUrl = getPdfJsBaseUrl();

--- a/libs/search-widget/src/tiles/SpreadsheetTile.svelte
+++ b/libs/search-widget/src/tiles/SpreadsheetTile.svelte
@@ -6,7 +6,7 @@
   import SpreadsheetViewer from './viewers/SpreadsheetViewer.svelte';
   import Thumbnail from '../common/thumbnail/Thumbnail.svelte';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
   let thumbnailLoaded = false;
 </script>
 

--- a/libs/search-widget/src/tiles/TextTile.svelte
+++ b/libs/search-widget/src/tiles/TextTile.svelte
@@ -9,7 +9,7 @@
   import { fieldData } from '../core/stores/viewer.store';
   import { map } from 'rxjs';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
 
   let selectedParagraph: WidgetParagraph | undefined;
 

--- a/libs/search-widget/src/tiles/Tile.svelte
+++ b/libs/search-widget/src/tiles/Tile.svelte
@@ -9,7 +9,7 @@
   import ConversationTile from './ConversationTile.svelte';
   import TextTile from './TextTile.svelte';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
 
   const SpreadsheetContentTypes = [
     'text/csv',

--- a/libs/search-widget/src/tiles/VideoTile.svelte
+++ b/libs/search-widget/src/tiles/VideoTile.svelte
@@ -8,7 +8,7 @@
   import { getFileUrls } from '../core/api';
   import MediaTile from './base-tile/MediaTile.svelte';
 
-  export let result: Search.SmartResult = { id: '' } as Search.SmartResult;
+  export let result: Search.FieldResult;
 
   let mediaLoading = true;
   let mediaTime = 0;

--- a/libs/search-widget/src/tiles/base-tile/BaseTile.svelte
+++ b/libs/search-widget/src/tiles/base-tile/BaseTile.svelte
@@ -44,11 +44,10 @@
   import SearchResultNavigator from './header/SearchResultNavigator.svelte';
   import { _ } from '../../core/i18n';
   import KnowledgeGraphPanel from '../../components/knowledge-graph/KnowledgeGraphPanel.svelte';
-  import KnowledgeGraph from '../../components/knowledge-graph/KnowledgeGraph.svelte';
   import { graphQuery } from '../../core/stores/graph.store';
   import D3Loader from '../../components/knowledge-graph/D3Loader.svelte';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
   export let previewKind: PreviewKind;
   export let typeIndicator: string;
   export let thumbnailLoaded = false;

--- a/libs/search-widget/src/tiles/base-tile/DocumentTile.svelte
+++ b/libs/search-widget/src/tiles/base-tile/DocumentTile.svelte
@@ -4,7 +4,7 @@
   import Thumbnail from '../../common/thumbnail/Thumbnail.svelte';
   import BaseTile from './BaseTile.svelte';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
   export let fallbackThumbnail;
   export let previewKind: PreviewKind;
 

--- a/libs/search-widget/src/tiles/base-tile/MediaTile.svelte
+++ b/libs/search-widget/src/tiles/base-tile/MediaTile.svelte
@@ -8,7 +8,7 @@
   import type { Observable } from 'rxjs';
   import { getFieldUrl } from '../../core/stores/viewer.store';
 
-  export let result: Search.SmartResult;
+  export let result: Search.FieldResult;
   export let fallbackThumbnail;
   export let previewKind: PreviewKind.VIDEO | PreviewKind.AUDIO | PreviewKind.YOUTUBE;
   export let mediaLoading = true;

--- a/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
@@ -10,6 +10,7 @@
   import globalCss from '../../common/_global.scss?inline';
   import {
     entityRelations,
+    getSmartResultUniqueKey,
     getTrackingDataAfterResultsReceived,
     hasMore,
     hasPartialResults,
@@ -76,11 +77,6 @@
   }
 
   const onLoadMore = () => loadMore.set();
-  const getResultKey = (result: Search.SmartResult) =>
-    result.id +
-    result.field?.field_type +
-    result.field?.field_id +
-    (result.paragraphs || []).reduce((acc, curr) => acc + curr.id, '');
 </script>
 
 <svelte:element this="style">{@html globalCss}</svelte:element>
@@ -113,7 +109,7 @@
             <InitialAnswer />
           {/if}
           <div class="search-results">
-            {#each $smartResults as result, i (getResultKey(result))}
+            {#each $smartResults as result, i (getSmartResultUniqueKey(result))}
               <Tile {result} />
               {#if i === $smartResults.length - 1}
                 <div

--- a/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
@@ -10,7 +10,7 @@
   import globalCss from '../../common/_global.scss?inline';
   import {
     entityRelations,
-    getSmartResultUniqueKey,
+    getResultUniqueKey,
     getTrackingDataAfterResultsReceived,
     hasMore,
     hasPartialResults,
@@ -20,7 +20,7 @@
     pendingResults,
     searchError,
     showResults,
-    smartResults,
+    resultList,
     trackingReset,
   } from '../../core/stores/search.store';
   import Tile from '../../tiles/Tile.svelte';
@@ -40,13 +40,13 @@
 
   const showLoading = pendingResults.pipe(debounceTime(1500));
 
-  const tileResult: Observable<Search.SmartResult | null> = combineLatest([
+  const tileResult: Observable<Search.FieldResult | null> = combineLatest([
     fieldFullId.pipe(distinctUntilChanged()),
     fieldData.pipe(distinctUntilChanged()),
     resourceTitle.pipe(distinctUntilChanged()),
   ]).pipe(
     map(([fullId, data, title]) =>
-      fullId && data ? ({ id: fullId.resourceId, field: fullId, fieldData: data, title } as Search.SmartResult) : null,
+      fullId && data ? ({ id: fullId.resourceId, field: fullId, fieldData: data, title } as Search.FieldResult) : null,
     ),
   );
 
@@ -58,7 +58,7 @@
   let svgSprite;
 
   onMount(() => {
-    if (pendingResults.getValue() || smartResults.getValue().length > 0) {
+    if (pendingResults.getValue() || resultList.getValue().length > 0) {
       showResults.set(true);
     }
     loadFonts();
@@ -93,7 +93,7 @@
           <strong>{$_('error.search')}</strong>
         {/if}
       </div>
-    {:else if !$pendingResults && $smartResults.length === 0 && !$onlyAnswers}
+    {:else if !$pendingResults && $resultList.length === 0 && !$onlyAnswers}
       <strong>{$_('results.empty')}</strong>
     {:else}
       {#if $hasPartialResults}
@@ -109,9 +109,9 @@
             <InitialAnswer />
           {/if}
           <div class="search-results">
-            {#each $smartResults as result, i (getSmartResultUniqueKey(result))}
+            {#each $resultList as result, i (getResultUniqueKey(result))}
               <Tile {result} />
-              {#if i === $smartResults.length - 1}
+              {#if i === $resultList.length - 1}
                 <div
                   class="results-end"
                   use:renderingDone />

--- a/libs/search-widget/src/widgets/viewer-widget/ViewerWidget.svelte
+++ b/libs/search-widget/src/widgets/viewer-widget/ViewerWidget.svelte
@@ -58,7 +58,7 @@
     onClosePreview();
   }
 
-  const tileResult: Observable<Search.SmartResult | null> = combineLatest([
+  const tileResult: Observable<Search.FieldResult | null> = combineLatest([
     fieldFullId.pipe(distinctUntilChanged()),
     fieldData.pipe(distinctUntilChanged()),
     resourceTitle.pipe(distinctUntilChanged()),


### PR DESCRIPTION
- Update `getSortedResults` to return one SmartResult entry by field
- Update the state to store the resources coming from the results as a list in `resourceList` so we can concatenate them when loading more
- Don't show duplicated results
- Store resultList in the state
  - Rename search models without `smart` prefix
  - Refactor search state to store results as a list of sorted `FieldResults`
- Fix generative answer bug which was writing in the state a lot while the answer was streaming