### PR TITLE
Billing email address change to support for now

### DIFF
--- a/apps/dashboard/src/app/account/billing/calculator/calculator.component.html
+++ b/apps/dashboard/src/app/account/billing/calculator/calculator.component.html
@@ -52,7 +52,7 @@
         </div>
         <div
           class="contact"
-          [innerHTML]="'billing.self_hosted' | translate: { url: 'mailto:billing@nuclia.com' }"></div>
+          [innerHTML]="'billing.self_hosted' | translate: { url: 'mailto:support@nuclia.com' }"></div>
       </div>
     </form>
   </pa-modal-content>

--- a/apps/dashboard/src/app/account/billing/checkout/checkout.component.ts
+++ b/apps/dashboard/src/app/account/billing/checkout/checkout.component.ts
@@ -405,7 +405,7 @@ export class CheckoutComponent implements OnDestroy, OnInit {
         ? this.translate.instant(message)
         : this.translate.instant('generic.error.oops') +
             '<br>' +
-            this.translate.instant('billing.assistance', { url: 'mailto:billing@nuclia.com' }),
+            this.translate.instant('billing.assistance', { url: 'support@nuclia.com' }),
     );
   }
 

--- a/apps/dashboard/src/app/account/billing/checkout/checkout.component.ts
+++ b/apps/dashboard/src/app/account/billing/checkout/checkout.component.ts
@@ -405,7 +405,7 @@ export class CheckoutComponent implements OnDestroy, OnInit {
         ? this.translate.instant(message)
         : this.translate.instant('generic.error.oops') +
             '<br>' +
-            this.translate.instant('billing.assistance', { url: 'support@nuclia.com' }),
+            this.translate.instant('billing.assistance', { url: 'mailto:support@nuclia.com' }),
     );
   }
 

--- a/apps/dashboard/src/app/account/billing/subscriptions/subscriptions.component.ts
+++ b/apps/dashboard/src/app/account/billing/subscriptions/subscriptions.component.ts
@@ -63,7 +63,7 @@ export class SubscriptionsComponent {
   }
 
   contact() {
-    this.window.location.href = 'mailto:billing@nuclia.com';
+    this.window.location.href = 'mailto:support@nuclia.com';
   }
 
   cancel() {


### PR DESCRIPTION
Until cancellation flow is implemented, all cancelation emails should go to "support@nuclia.com" instead of "billing@..."