### PR TITLE
[sc-6131] Refresh configuration form once account changes are saved

### DIFF
--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.ts
@@ -99,6 +99,7 @@ export class ConfigurationComponent implements OnInit, OnDestroy {
           next: (updatedAccount) => {
             this.store.setAccountDetails(updatedAccount);
             this.accountBackup = { ...updatedAccount };
+            this.patchConfigForm(updatedAccount);
             this.isSaving = false;
             this.configForm.markAsPristine();
             this.cdr.markForCheck();


### PR DESCRIPTION
When the user set 0 `max_dedicated_processors` for an account that has dedicated processors ENABLED, the rule to take in consideration is that an account with enabled dedicated processors must have at least 1 max dedicated processor. On the server side this value is automatically coerced to 1 to comply with the rule.