### PR TITLE
[sc-6469]: Fix back to accounts button

### DIFF
--- a/app.babel
+++ b/app.babel
@@ -4600,6 +4600,26 @@
 						</translations>
 					</concept_node>
 					<concept_node>
+						<name>error.creating-kb</name>
+						<description/>
+						<comment/>
+						<default_text/>
+						<translations>
+							<translation>
+								<language>ca-ES</language>
+								<approved>false</approved>
+							</translation>
+							<translation>
+								<language>en-US</language>
+								<approved>false</approved>
+							</translation>
+							<translation>
+								<language>es-ES</language>
+								<approved>false</approved>
+							</translation>
+						</translations>
+					</concept_node>
+					<concept_node>
 						<name>error.deleting-resource</name>
 						<description/>
 						<comment/>

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -216,6 +216,7 @@
 	"empty.title": "No hem trobat cap resultat :(",
 	"entities.law": "Legal",
 	"entities.quantity": "Quantitats i mesures",
+	"error.creating-kb": "S'ha produït un error en crear el quadre de coneixement",
 	"error.deleting-resource": "No s'ha pogut suprimir el recurs",
 	"error.deleting-resources": "No s'ha pogut suprimir {{count}} recursos",
 	"error.reprocessing-resource": "No s'ha pogut tornar a processar el recurs",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -228,6 +228,7 @@
 	"empty.title": "No results.",
 	"entities.law": "Legal",
 	"entities.quantity": "Quantities and measures",
+	"error.creating-kb": "An error occurred while creating the Knowledge Box",
 	"error.deleting-resource": "Deleting the resource failed",
 	"error.deleting-resources": "Deletion failed for {{count}} resources",
 	"error.reprocessing-resource": "Reprocessing the resource failed",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -216,6 +216,7 @@
 	"empty.title": "No hemos encontrado ningún resultado :(",
 	"entities.law": "Legal",
 	"entities.quantity": "Cantidades y medidas",
+	"error.creating-kb": "Ocurrió un error al crear el cuadro de conocimiento",
 	"error.deleting-resource": "Error al eliminar el recurso",
 	"error.deleting-resources": "Error al eliminar {{count}} recursos",
 	"error.reprocessing-resource": "Error al reprocesar el recurso",

--- a/libs/common/src/lib/select-account-kb/select-kb/select-kb.component.html
+++ b/libs/common/src/lib/select-account-kb/select-kb/select-kb.component.html
@@ -68,28 +68,20 @@
 
   <div class="select-kb-footer">
     <pa-button
-      *ngIf="(standalone && !addKb) || (canAddKb | async) === true"
+      *ngIf="!addKb && (standalone || (canAddKb | async) === true)"
       (click)="toggleForm()">
       {{ 'stash.create' | translate }}
-    </pa-button>
-
-    <pa-button
-      *ngIf="!addKb && !standalone"
-      kind="inverted"
-      (click)="back()">
-      {{ 'generic.back_to_accounts' | translate }}
     </pa-button>
 
     <ng-container *ngIf="addKb">
       <pa-button
         aspect="basic"
-        [disabled]="kbName.pristine"
         (click)="toggleForm()">
         {{ 'generic.cancel' | translate }}
       </pa-button>
 
       <pa-button
-        [disabled]="kbName.invalid"
+        [disabled]="kbName.invalid || creatingKb"
         (click)="save()">
         {{ 'generic.save' | translate }}
       </pa-button>

--- a/libs/common/src/lib/select-account-kb/select-kb/select-kb.component.ts
+++ b/libs/common/src/lib/select-account-kb/select-kb/select-kb.component.ts
@@ -36,6 +36,7 @@ export class SelectKbComponent implements OnInit, OnDestroy {
   errorMessages: IErrorMessages = { sluggable: 'stash.kb_name_invalid' } as IErrorMessages;
 
   standalone = this.environment.standalone;
+  creatingKb = false;
 
   constructor(
     private navigation: NavigationService,
@@ -107,19 +108,24 @@ export class SelectKbComponent implements OnInit, OnDestroy {
   save() {
     if (this.kbName.invalid || !this.kbName.value) return;
 
+    this.creatingKb = true;
+    this.kbName.disable();
     const kbSlug = STFUtils.generateSlug(this.kbName.value);
     const kbData = {
       slug: kbSlug,
       zone: this.account!.zone,
       title: this.kbName.value,
     };
-    this.sdk.nuclia.db.createKnowledgeBox(this.account!.slug, kbData).subscribe((kb) => {
-      this.router.navigate([this.navigation.getKbUrl(this.account!.slug, this.standalone ? kb.id : kbSlug)]);
+    this.sdk.nuclia.db.createKnowledgeBox(this.account!.slug, kbData).subscribe({
+      next: (kb) => {
+        this.router.navigate([this.navigation.getKbUrl(this.account!.slug, this.standalone ? kb.id : kbSlug)]);
+      },
+      error: () => {
+        this.toast.error('error.creating-kb');
+        this.creatingKb = false;
+        this.kbName.enable();
+      },
     });
-  }
-
-  back() {
-    this.router.navigate(['/select-account-kb']);
   }
 
   goToAccountManage() {

--- a/libs/common/src/lib/select-account-kb/utils.ts
+++ b/libs/common/src/lib/select-account-kb/utils.ts
@@ -23,10 +23,10 @@ export const selectAnimations = [
           width: '100%',
         }),
       ]),
-      query(':enter', [style({ transform: 'translateX(100%)', opacity: 0 })]),
+      query(':enter', [style({ transform: 'translateX(100%)', opacity: 0 })], { optional: true }),
       group([
-        query(':leave', [animate(duration, style({ transform: 'translateX(-100%)', opacity: 0 }))]),
-        query(':enter', [animate(duration, style({ transform: 'translateX(0)', opacity: 1 }))]),
+        query(':leave', [animate(duration, style({ transform: 'translateX(-100%)', opacity: 0 }))], { optional: true }),
+        query(':enter', [animate(duration, style({ transform: 'translateX(0)', opacity: 1 }))], { optional: true }),
       ]),
     ]),
     transition('true => false', [


### PR DESCRIPTION
- Remove `Back to accounts` button from the footer, as we have already a `Back` button in the header
- Fix Back behavior to display the list of accounts properly (was probably broken when we upgraded to ng16)
- Fix KB creation form from kb selection footer:
  - hide "create kb" button once we click on it
  - always enable cancel button
  - disabled the form during creation to prevent multiple clicks while creation is in progress
  - add error toast if creation fails