### PR TITLE
Add data-cy allowing to get rid of cypress-xpath

### DIFF
--- a/apps/dashboard/src/app/account/account-kbs/account-kbs.component.html
+++ b/apps/dashboard/src/app/account/account-kbs/account-kbs.component.html
@@ -16,6 +16,7 @@
       *ngFor="let kb of knowledgeBoxes">
       <a
         class="account-kb-title"
+        [attr.data-cy]="kb.title + '-link'"
         [class.disabled]="!kb.role_on_kb || !account.can_manage_account"
         [routerLink]="kb.role_on_kb ? getKbUrl(account.slug, kb.slug!) : null">
         {{ kb.title }}
@@ -68,6 +69,7 @@
             icon="trash"
             kind="destructive"
             iconAndText
+            [attr.data-cy]="kb.title + '-delete'"
             (click)="deleteKb(kb)">
             {{ 'generic.delete' | translate }}
           </pa-button>

--- a/apps/dashboard/src/app/account/account-nua/account-nua.component.html
+++ b/apps/dashboard/src/app/account/account-nua/account-nua.component.html
@@ -51,6 +51,7 @@
         </pa-button>
         <pa-button
           (click)="deleteClient(client.client_id)"
+          [attr.data-cy]="client.title + '-delete'"
           aspect="basic"
           icon="trash"
           size="small"


### PR DESCRIPTION
cypress-xpath package is deprecated, so we need to remove it from our cypress deps. To do so we need a way to access easily the NUA key and KB deletion buttons.