### PR TITLE
Fix [sc-7197]: prevent loading resources twice

### DIFF
--- a/libs/common/src/lib/resources/resource-list/resource-list.component.ts
+++ b/libs/common/src/lib/resources/resource-list/resource-list.component.ts
@@ -158,13 +158,6 @@ export class ResourceListComponent implements OnInit, OnDestroy {
   ngOnInit(): void {
     this.uploadService.initStatusCount();
     this.getResources().subscribe(() => this.cdr.markForCheck());
-    this.sdk.refreshing
-      .pipe(
-        takeUntil(this.unsubscribeAll),
-        tap(() => (this.refreshing = true)),
-        switchMap(() => this.getResources()),
-      )
-      .subscribe(() => this.cdr.markForCheck());
 
     // Reset resource list when query is empty (without forcing user to hit enter)
     this.searchForm.controls.query.valueChanges


### PR DESCRIPTION
We used to refresh the resource list when `this.sdk.refreshing` event was triggered, but since the refactoring we made on resource list this call is redundant and was duplicating the first page of result when there were several pages.