### PR TITLE
[sc-7168] Unify titles in dashboard pages

### DIFF
--- a/apps/dashboard/src/app/account/account-kbs/account-kbs.component.html
+++ b/apps/dashboard/src/app/account/account-kbs/account-kbs.component.html
@@ -6,7 +6,7 @@
 <div
   *ngIf="zones && account && knowledgeBoxes"
   class="account-kbs">
-  <h2>{{ 'account.related_kbs' | translate }}</h2>
+  <h1>{{ 'account.related_kbs' | translate }}</h1>
 
   <p>{{ 'account.kb-description' | translate }}</p>
 

--- a/apps/dashboard/src/app/account/account-manage/account-manage.component.html
+++ b/apps/dashboard/src/app/account/account-manage/account-manage.component.html
@@ -3,7 +3,7 @@
     class="section"
     id="account">
     <div class="section-container">
-      <h2>{{ 'account.manage' | translate }}</h2>
+      <h1>{{ 'account.manage' | translate }}</h1>
       <form
         [formGroup]="accountForm"
         (ngSubmit)="saveAccount()">
@@ -19,6 +19,18 @@
           readonly>
           {{ 'generic.slug' | translate }}
         </pa-input>
+        <pa-select
+          *ngIf="zones"
+          readonly
+          [formControl]="zone"
+          help="account.zone_description"
+          [label]="'generic.zone' | translate">
+          <pa-option
+            *ngFor="let zone of zones"
+            [value]="zone.id">
+            {{ zone.title }}
+          </pa-option>
+        </pa-select>
         <pa-input
           id="account-title"
           formControlName="title"
@@ -52,33 +64,10 @@
     </div>
   </div>
 
-  <div
-    class="section"
-    id="config">
-    <div class="section-container">
-      <h2>{{ 'account.config' | translate }}</h2>
-
-      <div
-        class="field-container"
-        *ngIf="zones">
-        <pa-select
-          [formControl]="zone"
-          help="account.zone_description"
-          [label]="'generic.zone' | translate">
-          <pa-option
-            *ngFor="let zone of zones"
-            [value]="zone.id">
-            {{ zone.title }}
-          </pa-option>
-        </pa-select>
-      </div>
-    </div>
-  </div>
-
   <div class="section">
     <div class="section-container">
       <div class="dangerous-zone">
-        <h3 class="title-s">{{ 'account.delete_account' | translate }}</h3>
+        <h3>{{ 'account.delete_account' | translate }}</h3>
         <div *ngIf="(cannotDeleteAccount | async) === false">
           <p>{{ 'account.delete_account_warning_1' | translate: { account: account?.title || '' } }}</p>
           <ul>

--- a/apps/dashboard/src/app/account/account-manage/account-manage.component.scss
+++ b/apps/dashboard/src/app/account/account-manage/account-manage.component.scss
@@ -3,10 +3,9 @@
 .container {
   padding: rhythm(9) var(--app-layout-margin-right) rhythm(8) 5%;
 }
-h2 {
-  margin: 0 0 rhythm(4) 0;
+h1 {
+  margin-bottom: rhythm(4);
 }
-
 .section {
   border-bottom: 1px solid $color-neutral-light;
   padding: rhythm(7) 0;
@@ -26,7 +25,7 @@ h2 {
 .section-container .field-container {
   display: flex;
   flex-direction: column;
-  gap: rhythm(2);
+  gap: rhythm(3);
 }
 
 .account-form-cta {

--- a/apps/dashboard/src/app/account/account-nua/account-nua.component.html
+++ b/apps/dashboard/src/app/account/account-nua/account-nua.component.html
@@ -1,5 +1,5 @@
 <div class="account-nua">
-  <h2>{{ 'account.nua_keys' | translate }}</h2>
+  <h1>{{ 'account.nua_keys' | translate }}</h1>
   <div class="warning">
     <pa-icon name="warning"></pa-icon>
     {{ 'stash.service_access_description' | translate }}

--- a/apps/dashboard/src/app/account/account-users/account-users.component.html
+++ b/apps/dashboard/src/app/account/account-users/account-users.component.html
@@ -1,7 +1,7 @@
 <div
   class="account-users"
   *ngIf="users">
-  <h2>{{ 'account.users' | translate }}</h2>
+  <h1>{{ 'account.users' | translate }}</h1>
 
   <div class="mb-28">
     <div class="users-amount">

--- a/apps/dashboard/src/app/activity/activity-download.component.html
+++ b/apps/dashboard/src/app/activity/activity-download.component.html
@@ -1,5 +1,5 @@
 <div class="activity-download">
-  <h2 class="display-s">{{ 'stash.side.activity' | translate }}</h2>
+  <h1>{{ 'stash.side.activity' | translate }}</h1>
   <pa-tabs
     class="primary-tabs"
     noSlider

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-keys/knowledge-box-keys.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-keys/knowledge-box-keys.component.html
@@ -1,5 +1,5 @@
 <div class="knowledge-box-keys">
-  <h2>{{ 'stash.service_access' | translate }}</h2>
+  <h1>{{ 'stash.service_access' | translate }}</h1>
   <div class="warning">{{ 'stash.service_access_description' | translate }}</div>
   <app-service-access></app-service-access>
 </div>

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-training/knowledge-box-training.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-training/knowledge-box-training.component.html
@@ -1,5 +1,5 @@
 <div class="knowledge-box-training">
-  <h2>{{ 'stash.side.trainings' | translate }}</h2>
+  <h1>{{ 'stash.side.trainings' | translate }}</h1>
   <div
     *ngIf="cannotTrain | async"
     class="warning">

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-training/training-history/training-history.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-training/training-history/training-history.component.html
@@ -5,7 +5,7 @@
     text="stash.side.trainings">
     {{ 'stash.side.trainings' | translate }}
   </nsi-back-button>
-  <h2>{{ 'training.history' | translate }}</h2>
+  <h1>{{ 'training.history' | translate }}</h1>
 
   <pa-infinite-scroll
     *ngIf="executions$ | async as executions"

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -72,7 +72,7 @@
 	"account.public": "Públic",
 	"account.related_kbs": "Knowledge Box relacionats amb l’Account",
 	"account.replace_config": "Reemplaçar configuració",
-	"account.settings": "Preferències de l’Account",
+	"account.settings": "Gestió del compte",
 	"account.speech_to_text_description": "Nuclia ofereix models millorats de veu a text. L'ús d'aquests models requereix un càlcul més elevat i suposen un cost addicional. Marqueu la casella de selecció  si voleu utilitzar els models millorats.",
 	"account.stash.add": "Afegir caixa coneixement",
 	"account.stash.delete": "Borrar",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -72,7 +72,7 @@
 	"account.public": "Public",
 	"account.related_kbs": "Account’s Knowledge Boxes",
 	"account.replace_config": "Replace settings",
-	"account.settings": "Account preferences",
+	"account.settings": "Account management",
 	"account.speech_to_text": "Speech-to-text",
 	"account.speech_to_text_description": "Nuclia offers enhanced speech-to-text models. Using these models require more computation and an associated extra cost. Check the following checkbox if you want to use the enhanced models.",
 	"account.stash.add": "Add knowledge box",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -72,7 +72,7 @@
 	"account.public": "Público",
 	"account.related_kbs": "Cajas de conocimiento de la cuenta",
 	"account.replace_config": "Reemplazar configuración",
-	"account.settings": "Preferencias de la cuenta",
+	"account.settings": "Gestión de la cuenta",
 	"account.speech_to_text_description": "Nuclia ofrece modelos mejorados de voz a texto. El uso de estos modelos requiere un cómputo mayor y tienen un costo extra. Marque la siguiente casilla de verificación si desea utilizar los modelos mejorados.",
 	"account.stash.add": "Añadir caja de conocimiento",
 	"account.stash.delete": "Borrar",

--- a/libs/common/src/assets/i18n/fr.json
+++ b/libs/common/src/assets/i18n/fr.json
@@ -72,7 +72,7 @@
 	"account.public": "Public",
 	"account.related_kbs": "Boîtes de connaissances du compte",
 	"account.replace_config": "Remplacer les paramètres",
-	"account.settings": "Préférences du compte",
+	"account.settings": "Gestion du compte",
 	"account.speech_to_text": "De la parole au texte",
 	"account.speech_to_text_description": "Nuclia propose des modèles de synthèse vocale améliorés. L'utilisation de ces modèles nécessite plus de calculs et un coût supplémentaire associé. Cochez la case suivante si vous souhaitez utiliser les modèles améliorés.",
 	"account.stash.add": "Ajouter une boîte à connaissances",

--- a/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.component.html
+++ b/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.component.html
@@ -2,7 +2,7 @@
   class="knowledge-box-settings"
   *ngIf="kb && account">
   <div class="section">
-    <h2>{{ 'stash.profile' | translate }}</h2>
+    <h1>{{ 'stash.profile' | translate }}</h1>
 
     <form
       *ngIf="kbForm"

--- a/libs/common/src/lib/widgets/widget-generator.component.html
+++ b/libs/common/src/lib/widgets/widget-generator.component.html
@@ -1,7 +1,7 @@
 <div class="widget-generator">
-  <h2>
+  <h1>
     {{ 'stash.widgets.title' | translate }}
-  </h2>
+  </h1>
 
   <div
     class="warning"


### PR DESCRIPTION
and improve account management page:
- move zone field in the Manage account form and make it readonly
- delete account settings section
- update page name in the navbar to be "Account management" instead of "Account preferences"