### PR TITLE
[sc-7111] Improve upload data page

### DIFF
--- a/libs/common/src/lib/resources/resource-list/resource-list.component.html
+++ b/libs/common/src/lib/resources/resource-list/resource-list.component.html
@@ -166,13 +166,13 @@
     </ng-container>
 
     <div
-      *ngIf="isMainView && emptyKb && !query && !isFiltering && !standalone && (isMonoLingual | async) === false"
+      *ngIf="isMainView && emptyKb && !query && !isFiltering && !standalone"
       class="empty-kb"
       data-cy="empty-kb">
       <p>
         <strong>{{ 'resource.empty' | translate }}</strong>
       </p>
-      <ng-container *ngIf="neverGotData | async">
+      <ng-container *ngIf="(neverGotData | async) && (isMonoLingual | async) === false">
         <p>{{ 'resource.empty_import' | translate }}</p>
         <stf-dataset-selector (imported)="onDatasetImport($event)"></stf-dataset-selector>
       </ng-container>

--- a/libs/common/src/lib/upload/upload-data/upload-data.component.html
+++ b/libs/common/src/lib/upload/upload-data/upload-data.component.html
@@ -31,21 +31,13 @@
         <span class="title-xs">Nuclia Desktop.</span>
         {{ 'stash.upload.desktop.description' | translate }}
       </p>
-      <div class="desktop-actions">
-        <pa-button
-          icon="download"
-          iconAndText
-          (click)="downloadDesktop()">
-          {{ 'stash.upload.desktop.download' | translate }}
-        </pa-button>
-        <div class="body-m">or</div>
-        <pa-button
-          icon="square-arrow"
-          iconAndText
-          (click)="openDesktop()">
-          {{ 'stash.upload.desktop.open' | translate }}
-        </pa-button>
-      </div>
+      <pa-button
+        class="desktop-button"
+        (click)="openDesktop()">
+        <img
+          src="assets/logos/nuclia-desktop-white.svg"
+          alt="Nuclia Desktop" />
+      </pa-button>
 
       <div class="sources-container">
         <stf-desktop-sources showDetails></stf-desktop-sources>

--- a/libs/common/src/lib/upload/upload-data/upload-data.component.scss
+++ b/libs/common/src/lib/upload/upload-data/upload-data.component.scss
@@ -22,10 +22,13 @@
         margin-bottom: rhythm(2);
       }
 
-      .desktop-actions {
-        align-items: center;
-        display: flex;
-        gap: rhythm(2);
+      .desktop-button {
+        img {
+          width: rhythm(20);
+        }
+        ::ng-deep .pa-button-label {
+          display: flex;
+        }
       }
 
       .sources-container {

--- a/libs/common/src/lib/upload/upload-data/upload-data.component.ts
+++ b/libs/common/src/lib/upload/upload-data/upload-data.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { getDesktopAppUrl, getDesktopPlatform, RELEASE_URL } from '../../utils';
+import { openDesktop } from '../../utils';
 import { UploadDialogService, UploadType } from '../../resources';
 import { filter } from 'rxjs';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -24,18 +24,7 @@ export class UploadDataComponent {
       .subscribe(() => this.router.navigate(['../resources'], { relativeTo: this.route }));
   }
 
-  downloadDesktop() {
-    const platform = getDesktopPlatform();
-    if (platform) {
-      getDesktopAppUrl(platform).subscribe((url) => {
-        window.open(url || RELEASE_URL);
-      });
-    } else {
-      window.open(RELEASE_URL);
-    }
-  }
-
   openDesktop() {
-    window.open('nuclia-desktop://index.html');
+    openDesktop();
   }
 }

--- a/libs/common/src/lib/utils/desktop.ts
+++ b/libs/common/src/lib/utils/desktop.ts
@@ -1,4 +1,4 @@
-import { from, map, Observable, switchMap } from 'rxjs';
+import { from, map, Observable, switchMap, timer } from 'rxjs';
 import { fromFetch } from 'rxjs/fetch';
 
 export const RELEASE_URL = 'https://github.com/nuclia/frontend/releases/latest';
@@ -36,4 +36,33 @@ export function getDesktopAppUrl(platform: 'mac' | 'win' | 'linux'): Observable<
       return asset?.browser_download_url || null;
     }),
   );
+}
+
+export function openDesktop() {
+  let appInstalled = false;
+
+  const onBlur = () => {
+    // A blur event indicates that the application is installed
+    appInstalled = true;
+  };
+  window.addEventListener('blur', onBlur);
+
+  timer(400).subscribe(() => {
+    if (!appInstalled) {
+      downloadDesktop();
+    }
+    window.removeEventListener('blur', onBlur);
+  });
+  window.location.href = 'nuclia-desktop://';
+}
+
+function downloadDesktop() {
+  const platform = getDesktopPlatform();
+  if (platform) {
+    getDesktopAppUrl(platform).subscribe((url) => {
+      window.open(url || RELEASE_URL);
+    });
+  } else {
+    window.open(RELEASE_URL);
+  }
 }


### PR DESCRIPTION
- Fix no dataset import on empty monolingual: monolingual KB doesn't support dataset import, but they should display a message when they are empty
- Move `openDesktop` function from resource-list to `utils/desktop.ts`
- Back to only one NucliaDesktop button in Upload data page