### PR TITLE
Fix resource classification loading

### DIFF
--- a/libs/common/src/lib/label/label-field/label-field.component.html
+++ b/libs/common/src/lib/label/label-field/label-field.component.html
@@ -1,5 +1,5 @@
 <div
-  *ngIf="hasLabels | async"
+  *ngIf="hasLabels$ | async"
   class="label-field"
   [class.small-button]="size === 'small'">
   <app-label-dropdown

--- a/libs/common/src/lib/resources/edit-resource/classification/paragraph-classification/paragraph-classification.component.ts
+++ b/libs/common/src/lib/resources/edit-resource/classification/paragraph-classification/paragraph-classification.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnIni
 import { ActivatedRoute } from '@angular/router';
 import { EditResourceService } from '../../edit-resource.service';
 import { combineLatest, filter, forkJoin, map, Observable, Subject, switchMap, take, tap } from 'rxjs';
-import { Classification, FieldId, LabelSetKind, LabelSets, Resource, Search } from '@nuclia/core';
+import { Classification, FieldId, LabelSets, Resource, Search } from '@nuclia/core';
 import { LabelsService } from '../../../../label/labels.service';
 import { ParagraphWithTextAndClassifications } from '../../edit-resource.helpers';
 import { ParagraphClassificationService } from './paragraph-classification.service';
@@ -29,7 +29,7 @@ export class ParagraphClassificationComponent implements OnInit, OnDestroy {
     }),
   );
 
-  availableLabels: Observable<LabelSets | null> = this.labelsService.getLabelsByKind(LabelSetKind.PARAGRAPHS);
+  availableLabels: Observable<LabelSets | null> = this.labelsService.paragraphLabelSets;
   hasLabels: Observable<boolean> = this.availableLabels.pipe(
     map((labels) => !!labels && Object.keys(labels).length > 0),
     tap(() => {

--- a/libs/common/src/lib/resources/edit-resource/classification/resource-classification.component.html
+++ b/libs/common/src/lib/resources/edit-resource/classification/resource-classification.component.html
@@ -1,21 +1,19 @@
 <div class="main-container">
-  <p *ngIf="noLabels; else labelSelector">
-    {{ 'resource.classification.no-resource-labelset' | translate }}
-    <a [routerLink]="(kbUrl | async) + '/label-sets'">{{ 'resource.classification-page-link' | translate }}</a>
-  </p>
-  <ng-template #labelSelector>
-    <div class="scrollable-area classification-container">
-      <app-label-field
-        [selection]="currentLabels"
-        [disabled]="(isAdminOrContrib | async) === false"
-        (noLabels)="noLabels = $event"
-        (selectionChange)="updateLabels($event)"></app-label-field>
-    </div>
-  </ng-template>
+  <div class="scrollable-area classification-container">
+    <p *ngIf="(isReady | async) && !hasLabels">
+      {{ 'resource.classification.no-resource-labelset' | translate }}
+      <a [routerLink]="(kbUrl | async) + '/label-sets'">{{ 'resource.classification-page-link' | translate }}</a>
+    </p>
+    <app-label-field
+      [selection]="currentLabels"
+      [disabled]="!hasLabels || (isAdminOrContrib | async) === false"
+      (hasLabels)="updateHasLabels($event)"
+      (selectionChange)="updateLabels($event)"></app-label-field>
+  </div>
 </div>
 
 <footer
-  *ngIf="!noLabels"
+  *ngIf="hasLabels"
   class="form-buttons">
   <pa-button
     kind="primary"

--- a/libs/common/src/lib/resources/resource-list/error-resources-table/error-resources-table.component.spec.ts
+++ b/libs/common/src/lib/resources/resource-list/error-resources-table/error-resources-table.component.spec.ts
@@ -35,7 +35,11 @@ describe('ErrorResourcesTableComponent', () => {
       ],
       providers: [
         MockProvider(SDKService, {
-          currentKb: of({ admin: true } as unknown as WritableKnowledgeBox),
+          currentKb: of({
+            admin: true,
+            catalog: jest.fn(() => of()),
+            search: jest.fn(() => of()),
+          } as unknown as WritableKnowledgeBox),
           isAdminOrContrib: of(true),
           nuclia: {
             options: {},

--- a/libs/common/src/lib/resources/resource-list/pending-resources-table/pending-resources-table.component.spec.ts
+++ b/libs/common/src/lib/resources/resource-list/pending-resources-table/pending-resources-table.component.spec.ts
@@ -34,7 +34,11 @@ describe('PendingResourcesTableComponent', () => {
       ],
       providers: [
         MockProvider(SDKService, {
-          currentKb: of({ admin: true } as unknown as WritableKnowledgeBox),
+          currentKb: of({
+            admin: true,
+            catalog: jest.fn(() => of()),
+            search: jest.fn(() => of()),
+          } as unknown as WritableKnowledgeBox),
           isAdminOrContrib: of(true),
           nuclia: {
             options: {},

--- a/libs/common/src/lib/resources/resource-list/processed-resource-table/processed-resource-table.component.spec.ts
+++ b/libs/common/src/lib/resources/resource-list/processed-resource-table/processed-resource-table.component.spec.ts
@@ -37,7 +37,11 @@ describe('ResourceTableComponent', () => {
       ],
       providers: [
         MockProvider(SDKService, {
-          currentKb: of({ admin: true } as unknown as WritableKnowledgeBox),
+          currentKb: of({
+            admin: true,
+            catalog: jest.fn(() => of()),
+            search: jest.fn(() => of()),
+          } as unknown as WritableKnowledgeBox),
           isAdminOrContrib: of(true),
           nuclia: {
             options: {},

--- a/libs/common/src/lib/resources/resource-list/resource-list.component.spec.ts
+++ b/libs/common/src/lib/resources/resource-list/resource-list.component.spec.ts
@@ -85,7 +85,7 @@ describe('ResourceListComponent', () => {
           stream: jest.fn(() => of('')),
         }),
         MockProvider(LabelsService, {
-          getLabelsByKind: jest.fn(() => of({})),
+          resourceLabelSets: of({}),
         }),
         MockProvider(UploadService, {
           statusCount: of({

--- a/libs/common/src/lib/resources/resource-list/resource-list.service.ts
+++ b/libs/common/src/lib/resources/resource-list/resource-list.service.ts
@@ -5,7 +5,6 @@ import { filter, map } from 'rxjs/operators';
 import { DEFAULT_PAGE_SIZE, DEFAULT_SORTING, ResourceWithLabels } from './resource-list.model';
 import {
   IResource,
-  LabelSetKind,
   LabelSets,
   ProcessingStatusResponse,
   Resource,
@@ -56,7 +55,7 @@ export class ResourceListService {
   private _emptyKb = new Subject<boolean>();
   emptyKb = this._emptyKb.asObservable();
 
-  labelSets: Observable<LabelSets> = this.labelService.getLabelsByKind(LabelSetKind.RESOURCES).pipe(
+  labelSets: Observable<LabelSets> = this.labelService.resourceLabelSets.pipe(
     filter((labelSets) => !!labelSets),
     map((labelSets) => labelSets as LabelSets),
   );


### PR DESCRIPTION
- add missing mark for check
- add isReady subject to resource classification page
- refactor labelField component to return hasLabel instead of noLabel
- refactor LabelsService replacing `getLabelsByKind` method by two properties: `resourceLabelSets` and `paragraphLabelSets` which emit only when labelSet is not null
- Fix tests (prevent error to be triggered and logged during unit tests)