### PR TITLE
do not break if kb cannot be accessed

### DIFF
--- a/apps/desktop/electron/src/service/nuclia-cloud.ts
+++ b/apps/desktop/electron/src/service/nuclia-cloud.ts
@@ -64,6 +64,7 @@ export class NucliaCloud {
             }),
           ),
         ),
+        catchError(() => of(undefined)),
         delay(500),
         switchMap((resource) => {
           if (!resource) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuclia",
-  "version": "2.7.2",
+  "version": "2.7.3",
   "license": "MIT",
   "author": "Nuclia.cloud",
   "description": "Nuclia frontend apps and libs",


### PR DESCRIPTION
the fix is not as ambitious as the story, it does not show any small icon next to the failing connector in the UI, but at least the server does not crash and the user can see a proper error message in the activity log