### PR TITLE
[sc-7554] don't set more than one label when multiple is false

### DIFF
--- a/libs/common/src/lib/resources/edit-resource/classification/classification.helpers.ts
+++ b/libs/common/src/lib/resources/edit-resource/classification/classification.helpers.ts
@@ -1,0 +1,11 @@
+import { Classification } from '@nuclia/core';
+
+export function getClassificationFromSelection(selection: { [id: string]: boolean }): Classification[] {
+  return Object.entries(selection).reduce((selectedLabels, [id, selected]) => {
+    if (selected) {
+      const [labelset, label] = id.split('_');
+      selectedLabels.push({ label, labelset });
+    }
+    return selectedLabels;
+  }, [] as Classification[]);
+}

--- a/libs/common/src/lib/resources/edit-resource/classification/labels-expander/labels-expander.component.html
+++ b/libs/common/src/lib/resources/edit-resource/classification/labels-expander/labels-expander.component.html
@@ -5,7 +5,7 @@
       <pa-checkbox
         *ngFor="let label of labelset.value.labels"
         [value]="currentSelection[labelset.key + '_' + label.title]"
-        (valueChange)="updateSelection.emit({ selected: $event, labelset: labelset.key, label: label.title })">
+        (valueChange)="onSelection({ selected: $event, labelset: labelset.key, label: label.title })">
         {{ label.title }}
       </pa-checkbox>
     </div>

--- a/libs/common/src/lib/resources/edit-resource/classification/labels-expander/labels-expander.component.ts
+++ b/libs/common/src/lib/resources/edit-resource/classification/labels-expander/labels-expander.component.ts
@@ -11,5 +11,38 @@ export class LabelsExpanderComponent {
   @Input() currentSelection: { [id: string]: boolean } = {};
   @Input() labelSets?: LabelSets | null;
 
-  @Output() updateSelection = new EventEmitter<{ selected: boolean; labelset: string; label: string }>();
+  @Output() updateSelection = new EventEmitter<{ [id: string]: boolean }>();
+
+  onSelection(data: { labelset: string; label: string; selected: boolean }) {
+    if (!data.selected) {
+      this.updateSelection.emit({
+        ...this.currentSelection,
+        [`${data.labelset}_${data.label}`]: false,
+      });
+    } else if (this.labelSets) {
+      const labelSet = this.labelSets[data.labelset];
+      if (labelSet.multiple) {
+        this.updateSelection.emit({
+          ...this.currentSelection,
+          [`${data.labelset}_${data.label}`]: true,
+        });
+      } else {
+        // reset selected label of this label set
+        const newSelection: { [id: string]: boolean } = Object.entries(this.currentSelection).reduce(
+          (selection, [labelId, selected]) => {
+            const [key, label] = labelId.split('_');
+            if (key !== data.labelset) {
+              selection[labelId] = selected;
+            } else {
+              selection[labelId] = label === data.label;
+            }
+            return selection;
+          },
+          {} as { [id: string]: boolean },
+        );
+        newSelection[`${data.labelset}_${data.label}`] = true;
+        this.updateSelection.emit(newSelection);
+      }
+    }
+  }
 }

--- a/libs/common/src/lib/resources/edit-resource/classification/paragraph-classification/paragraph-classification.component.ts
+++ b/libs/common/src/lib/resources/edit-resource/classification/paragraph-classification/paragraph-classification.component.ts
@@ -7,6 +7,7 @@ import { LabelsService } from '../../../../label/labels.service';
 import { ParagraphWithTextAndClassifications } from '../../edit-resource.helpers';
 import { ParagraphClassificationService } from './paragraph-classification.service';
 import { takeUntil } from 'rxjs/operators';
+import { getClassificationFromSelection } from '../classification.helpers';
 
 @Component({
   templateUrl: './paragraph-classification.component.html',
@@ -81,17 +82,9 @@ export class ParagraphClassificationComponent implements OnInit, OnDestroy {
     this.classificationService.cleanup();
   }
 
-  updateSelection(event: { selected: boolean; labelset: string; label: string }) {
-    const { selected, labelset, label } = event;
-    if (selected) {
-      this.currentLabels.next(this.currentLabels.value.concat([{ label, labelset }]));
-    } else {
-      this.currentLabels.next(
-        this.currentLabels.value.filter((item) => !(item.labelset === labelset && item.label === label)),
-      );
-    }
-    this.currentSelection[`${labelset}_${label}`] = selected;
-    this.cdr.detectChanges();
+  updateSelection(newSelection: { [id: string]: boolean }) {
+    this.currentLabels.next(getClassificationFromSelection(newSelection));
+    this.currentSelection = newSelection;
   }
 
   cleanUpLabels() {

--- a/libs/common/src/lib/resources/edit-resource/classification/resource-classification.component.ts
+++ b/libs/common/src/lib/resources/edit-resource/classification/resource-classification.component.ts
@@ -1,6 +1,6 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy, OnInit } from '@angular/core';
 import { Classification, LabelSets, Resource } from '@nuclia/core';
-import { BehaviorSubject, combineLatest, map, tap } from 'rxjs';
+import { BehaviorSubject, combineLatest, map, Observable, tap } from 'rxjs';
 import { SelectFirstFieldDirective } from '../select-first-field/select-first-field.directive';
 import { filter, takeUntil } from 'rxjs/operators';
 import { LabelsService } from '../../../label';
@@ -17,23 +17,16 @@ export class ResourceClassificationComponent extends SelectFirstFieldDirective i
   isAdminOrContrib = this.editResource.isAdminOrContrib;
 
   currentSelection: { [id: string]: boolean } = {};
-  resourceLabelSets = this.labelsService.resourceLabelSets.pipe(
+
+  private _resourceLabelSets = this.labelsService.resourceLabelSets.pipe(tap(() => this._hasLabelLoaded.next(true)));
+
+  resourceLabelSets = this._resourceLabelSets.pipe(
     filter((labelset) => !!labelset && Object.keys(labelset).length > 0),
     map((labelset) => labelset as LabelSets),
   );
   currentLabels: BehaviorSubject<Classification[]> = new BehaviorSubject<Classification[]>([]);
-  hasLabels = this.currentLabels.pipe(
-    map((labels) => {
-      this.currentSelection = labels.reduce(
-        (selection, classification) => {
-          selection[`${classification.labelset}_${classification.label}`] = true;
-          return selection;
-        },
-        {} as { [id: string]: boolean },
-      );
-      this.cdr.markForCheck();
-      return labels.length > 0;
-    }),
+  hasLabels: Observable<boolean> = this._resourceLabelSets.pipe(
+    map((labelSets) => !!labelSets && Object.keys(labelSets).length > 0),
   );
 
   private _hasLabelLoaded = new BehaviorSubject(false);
@@ -64,9 +57,18 @@ export class ResourceClassificationComponent extends SelectFirstFieldDirective i
         this._resourceClassificationLoaded.next(true);
         this.cdr.detectChanges();
       });
-    this.resourceLabelSets
+    this.currentLabels
       .pipe(
-        tap(() => this._hasLabelLoaded.next(true)),
+        tap((labels) => {
+          this.currentSelection = labels.reduce(
+            (selection, classification) => {
+              selection[`${classification.labelset}_${classification.label}`] = true;
+              return selection;
+            },
+            {} as { [id: string]: boolean },
+          );
+          this.cdr.markForCheck();
+        }),
         takeUntil(this.unsubscribeAll),
       )
       .subscribe();


### PR DESCRIPTION
- Fix resource classification page when no labels
  - When there is label set for resources, the information message was missing
  - When there are label set for resources but no label already on the resource, the warning saying "There is no label set for resources. You can add some in Classification page" was displayed on top of the label expander
- Do not allow to set more than one label when "multiple" is false