### PR TITLE
[sc-7932] use synonyms option don't reset in widget generator

### DIFF
--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -3,8 +3,8 @@
   import { Button, Expander, IconButton, Label } from '../../../libs/search-widget/src/common';
   import { NucliaViewerWidget } from '../../../libs/search-widget/src/widgets/viewer-widget';
   import { NucliaSearchBar, NucliaSearchResults } from '../../../libs/search-widget/src/widgets/search-widget';
-  import type { FieldFullId } from '@nuclia/core';
-  import { Chat, Nuclia } from '@nuclia/core';
+  import type {  FieldFullId } from '@nuclia/core';
+  import { Nuclia, Search } from '@nuclia/core';
   import { onMount } from 'svelte';
 
   let selected = 'tiles';
@@ -39,6 +39,7 @@
   // const backend = 'https://nuclia.cloud/api';
 
   const prompt = 'You want people to eat watermelon. Answer the following question: {question}, and then recommend to eat some watermelon.';
+  const preselectedFilters = '';
   // const preselectedFilters = '/classification.labels/artist/Mademoiselle K';
 
   function updatePlaceholder() {
@@ -96,6 +97,7 @@
     //     console.log('callback:', answer),
     //   )
     //   .then();
+    // nuclia.knowledgeBox.find('Mademoiselle K', [Search.Features.PARAGRAPH, Search.Features.VECTOR], {with_synonyms: true}).subscribe((result) => console.log(result));
   });
 </script>
 

--- a/libs/sdk-core/src/lib/db/search/search.ts
+++ b/libs/sdk-core/src/lib/db/search/search.ts
@@ -1,6 +1,7 @@
 import { catchError, from, map, Observable, of, switchMap, tap } from 'rxjs';
 import type { IErrorResponse, INuclia } from '../../models';
-import type { Search, SearchOptions } from './search.models';
+import type { SearchOptions } from './search.models';
+import { Search } from './search.models';
 
 export const find = (
   nuclia: INuclia,
@@ -12,6 +13,15 @@ export const find = (
   useGet?: boolean,
 ): Observable<Search.FindResults | IErrorResponse> => {
   const { inTitleOnly, ...others } = options || {};
+  if (
+    options?.with_synonyms &&
+    (features.includes(Search.Features.VECTOR) || features.includes(Search.Features.RELATIONS))
+  ) {
+    console.warn(`with_synonyms option cannot work with VECTOR and RELATIONS features`);
+    features = features.filter(
+      (feature) => feature === Search.Features.PARAGRAPH || feature === Search.Features.DOCUMENT,
+    );
+  }
   const params: { [key: string]: string | string[] } = {
     query: query || '',
     features,

--- a/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
@@ -4,7 +4,7 @@
   import type { KBStates, WidgetFeatures } from '@nuclia/core';
   import { initNuclia, resetNuclia } from '../../core/api';
   import { onMount } from 'svelte';
-  import { loadFonts, loadSvgSprite, setCDN } from '../../core/utils';
+  import { injectCustomCss, loadFonts, loadSvgSprite, setCDN } from '../../core/utils';
   import { setLang } from '../../core/i18n';
   import SearchInput from '../../components/search-input/SearchInput.svelte';
   import { setupTriggerSearch } from '../../core/search-bar';
@@ -20,11 +20,10 @@
     initUsageTracking,
     initViewer,
     resetStatesAndEffects,
-    setupTriggerGraphNerSearch,
+    setupTriggerGraphNerSearch
   } from '../../core/stores/effects';
   import { preselectedFilters, searchQuery, triggerSearch } from '../../core/stores/search.store';
   import { typeAhead } from '../../core/stores/suggestions.store';
-  import { injectCustomCss } from '../../core/utils';
   import type { FilterType } from '../../core';
 
   export let backend = 'https://nuclia.cloud/api';
@@ -64,6 +63,20 @@
   export function reloadSearch() {
     console.log(`reloadSearch`);
     triggerSearch.next();
+  }
+
+  export function logState() {
+    console.log(`Current widget configuration:`, {
+      _features, _filters, prompt, preselected_filters, mode, proxy, standalone, backend,
+      zone,
+      knowledgebox,
+      placeholder,
+      lang,
+      cdn,
+      apikey,
+      kbslug,
+      account
+    });
   }
 
   const thisComponent = get_current_component();


### PR DESCRIPTION
- Fix [sc-7932]: keep clean default option in widget api
- Prevent bad features to be requested when using with_synonyms
- Fix App.svelte