### PR TITLE
Fix [sc-8085] don't call /versions on dashboard

### DIFF
--- a/apps/nucliadb-admin/src/app/home/home-page.component.ts
+++ b/apps/nucliadb-admin/src/app/home/home-page.component.ts
@@ -1,4 +1,4 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
 import { StandaloneService } from '@flaps/common';
 
 @Component({
@@ -7,10 +7,14 @@ import { StandaloneService } from '@flaps/common';
   styleUrls: ['./home-page.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class HomePageComponent {
+export class HomePageComponent implements OnInit {
   hasValidKey = this.standaloneService.hasValidKey;
   errorMessage = this.standaloneService.errorMessage;
   version = this.standaloneService.version;
 
   constructor(private standaloneService: StandaloneService) {}
+
+  ngOnInit() {
+    this.standaloneService.checkVersions();
+  }
 }


### PR DESCRIPTION
Also fix [sc-7934]: don't display a warning toast when only the .post version changed.