### PR TITLE
Fix [sc-8060]: no need for shareReplay on home page

### DIFF
--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.ts
@@ -26,8 +26,9 @@ export class KnowledgeBoxHomeComponent {
   protected readonly openDesktop = openDesktop;
 
   locale: Observable<string> = this.app.currentLocale;
-  account = this.sdk.currentAccount.pipe(shareReplay());
-  currentKb = this.sdk.currentKb.pipe(shareReplay());
+  account = this.sdk.currentAccount;
+  currentKb = this.sdk.currentKb;
+
   configuration = this.currentKb.pipe(switchMap((kb) => kb.getConfiguration()));
   endpoint = this.currentKb.pipe(map((kb) => kb.fullpath));
   uid = this.currentKb.pipe(map((kb) => kb.id));


### PR DESCRIPTION
SDK `currentAccount` and `currentKb` are already `BehaviorSubject` and `ReplaySubject` so we don't need to use `shareReplay` on top of that.

Now copy button is working properly whenever we switch KB.