### PR TITLE
[sc-8106] render the resource title as a link in resources

### DIFF
--- a/libs/common/src/lib/resources/resource-list/error-resources-table/error-resources-table.component.html
+++ b/libs/common/src/lib/resources/resource-list/error-resources-table/error-resources-table.component.html
@@ -88,34 +88,7 @@
           <pa-table-cell
             clickable
             (click)="onClickTitle(row.resource)">
-            <div class="title-with-icon">
-              @if (row.resource.icon | mimeIcon; as icon) {
-                <pa-icon [name]="icon"></pa-icon>
-              }
-              <div class="title-and-description">
-                <div
-                  class="body-s"
-                  data-cy="resource-title">
-                  {{ row.resource.title }}
-                </div>
-                @if (row.description) {
-                  <small
-                    class="body-xs"
-                    data-cy="resource-description">
-                    {{ row.description }}
-                  </small>
-                }
-              </div>
-              <div class="title-status">
-                @if (row.resource.metadata?.status === 'PENDING') {
-                  <pa-icon name="clock-dash"></pa-icon>
-                } @else if (row.resource.metadata?.status === 'ERROR') {
-                  <pa-icon
-                    class="error"
-                    name="warning"></pa-icon>
-                }
-              </div>
-            </div>
+            <stf-title-cell [row]="row"></stf-title-cell>
           </pa-table-cell>
 
           <pa-table-cell center>

--- a/libs/common/src/lib/resources/resource-list/error-resources-table/error-resources-table.component.html
+++ b/libs/common/src/lib/resources/resource-list/error-resources-table/error-resources-table.component.html
@@ -1,59 +1,61 @@
-<div
-  data-cy="spinner"
-  class="loading-shade"
-  *ngIf="isLoading">
-  <nsi-spinner></nsi-spinner>
-</div>
+@if (isLoading) {
+  <div
+    data-cy="spinner"
+    class="loading-shade">
+    <nsi-spinner></nsi-spinner>
+  </div>
+}
 
 <div class="resource-table-header">
-  <div
-    class="resource-bulk-actions"
-    *ngIf="(isAdminOrContrib | async) && selection.length > 0">
-    {{ 'resource.selected_count' | translate: { num: allErrorsSelected ? (errorCount | async) : selection.length } }}
+  @if ((isAdminOrContrib | async) && selection.length > 0) {
+    <div class="resource-bulk-actions">
+      {{ 'resource.selected_count' | translate: { num: allErrorsSelected ? (errorCount | async) : selection.length } }}
 
-    <ng-container *ngIf="selection.length > 0">
-      <pa-button
-        kind="destructive"
-        aspect="basic"
-        size="small"
-        [disabled]="bulkAction.inProgress"
-        (click)="bulkDelete()">
-        {{ 'generic.delete' | translate }}
-      </pa-button>
-      <pa-button
-        aspect="basic"
-        size="small"
-        [disabled]="bulkAction.inProgress"
-        (click)="bulkReprocess()">
-        {{ (selection.length === 1 ? 'generic.reindex' : 'generic.reindex-plural') | translate }}
-      </pa-button>
-      <ng-container
-        *ngIf="
+      @if (selection.length > 0) {
+        <pa-button
+          kind="destructive"
+          aspect="basic"
+          size="small"
+          [disabled]="bulkAction.inProgress"
+          (click)="bulkDelete()">
+          {{ 'generic.delete' | translate }}
+        </pa-button>
+        <pa-button
+          aspect="basic"
+          size="small"
+          [disabled]="bulkAction.inProgress"
+          (click)="bulkReprocess()">
+          {{ (selection.length === 1 ? 'generic.reindex' : 'generic.reindex-plural') | translate }}
+        </pa-button>
+
+        @if (
           (allSelected | async) === true && ((errorCount | async) || 0) > selection.length && !bulkAction.inProgress
-        ">
-        <pa-button
-          aspect="basic"
-          kind="primary"
-          *ngIf="!allErrorsSelected"
-          (click)="selectAllErrors()">
-          {{ 'resource.select-all-failures' | translate: { count: errorCount | async } }}
-        </pa-button>
-        <pa-button
-          aspect="basic"
-          kind="primary"
-          *ngIf="allErrorsSelected"
-          (click)="clearSelection()">
-          {{ 'generic.clear-selection' | translate }}
-        </pa-button>
-      </ng-container>
-      <div
-        class="body-m"
-        *ngIf="bulkAction.inProgress">
-        {{ bulkAction.label | translate }}
-        {{ bulkAction.done }} / {{ bulkAction.total }}
-      </div>
-    </ng-container>
-  </div>
+        ) {
+          @if (allErrorsSelected) {
+            <pa-button
+              aspect="basic"
+              kind="primary"
+              (click)="clearSelection()">
+              {{ 'generic.clear-selection' | translate }}
+            </pa-button>
+          } @else {
+            <pa-button
+              aspect="basic"
+              kind="primary"
+              (click)="selectAllErrors()">
+              {{ 'resource.select-all-failures' | translate: { count: errorCount | async } }}
+            </pa-button>
+          }
+        }
+        @if (bulkAction.inProgress) {
+          <div class="body-m">
+            {{ bulkAction.label | translate }}
+            {{ bulkAction.done }} / {{ bulkAction.total }}
+          </div>
+        }
+      }
+    </div>
+  }
 </div>
 
 <div class="table-container">
@@ -62,75 +64,89 @@
       <pa-table-sortable-header
         [cells]="headerCells | async"
         (sort)="sortBy($event)">
-        <pa-table-cell
-          header
-          *ngIf="isAdminOrContrib | async">
-          <pa-checkbox
-            [value]="allSelected | async"
-            [paTooltip]="((allSelected | async) === true ? 'generic.deselect_all' : 'generic.select_all') | translate"
-            [disabled]="bulkAction.inProgress"
-            (change)="toggleAll()"></pa-checkbox>
-        </pa-table-cell>
+        @if (isAdminOrContrib | async) {
+          <pa-table-cell header>
+            <pa-checkbox
+              [value]="allSelected | async"
+              [paTooltip]="((allSelected | async) === true ? 'generic.deselect_all' : 'generic.select_all') | translate"
+              [disabled]="bulkAction.inProgress"
+              (change)="toggleAll()"></pa-checkbox>
+          </pa-table-cell>
+        }
       </pa-table-sortable-header>
 
-      <pa-table-row *ngFor="let row of data | async; trackBy: trackById">
-        <pa-table-cell *ngIf="isAdminOrContrib | async">
-          <pa-checkbox
-            [value]="selection.includes(row.resource.id)"
-            (change)="toggleSelection(row.resource.id)"></pa-checkbox>
-        </pa-table-cell>
-        <pa-table-cell
-          clickable
-          (click)="onClickTitle(row.resource)">
-          <div class="title-with-icon">
-            <pa-icon
-              *ngIf="row.resource.icon | mimeIcon as icon"
-              [name]="icon"></pa-icon>
-            <div class="title-and-description">
-              <div class="body-s">{{ row.resource.title }}</div>
-              <small *ngIf="row.description">{{ row.description }}</small>
-            </div>
-            <div class="title-status">
-              <pa-icon
-                *ngIf="row.resource.metadata?.status === 'PENDING'"
-                name="clock-dash"></pa-icon>
-              <pa-icon
-                class="error"
-                *ngIf="row.resource.metadata?.status === 'ERROR'"
-                name="warning"></pa-icon>
-            </div>
-          </div>
-        </pa-table-cell>
+      @for (row of data | async; track row.resource.id) {
+        <pa-table-row>
+          @if (isAdminOrContrib | async) {
+            <pa-table-cell>
+              <pa-checkbox
+                [value]="selection.includes(row.resource.id)"
+                (change)="toggleSelection(row.resource.id)"></pa-checkbox>
+            </pa-table-cell>
+          }
 
-        <pa-table-cell center>
-          <span class="body-s">{{ row.resource.created | formatDate: { default: true } }}</span>
-        </pa-table-cell>
-        <pa-table-cell-menu *ngIf="isAdminOrContrib | async">
-          <pa-button
-            icon="more-vertical"
-            aspect="basic"
-            size="small"
-            paTooltip="generic.actions"
-            [disabled]="bulkAction.inProgress"
-            [paPopup]="menu">
-            {{ 'generic.actions' | translate }}
-          </pa-button>
-          <pa-dropdown #menu>
-            <pa-option
-              [disabled]="!(isAdminOrContrib | async)"
-              (selectOption)="triggerAction(row.resource, 'reprocess')">
-              {{ 'generic.reindex' | translate }}
-            </pa-option>
-            <pa-separator></pa-separator>
-            <pa-option
-              destructive
-              [disabled]="!(isAdminOrContrib | async)"
-              (selectOption)="triggerAction(row.resource, 'delete')">
-              {{ 'generic.delete' | translate }}
-            </pa-option>
-          </pa-dropdown>
-        </pa-table-cell-menu>
-      </pa-table-row>
+          <pa-table-cell
+            clickable
+            (click)="onClickTitle(row.resource)">
+            <div class="title-with-icon">
+              @if (row.resource.icon | mimeIcon; as icon) {
+                <pa-icon [name]="icon"></pa-icon>
+              }
+              <div class="title-and-description">
+                <div
+                  class="body-s"
+                  data-cy="resource-title">
+                  {{ row.resource.title }}
+                </div>
+                @if (row.description) {
+                  <small
+                    class="body-xs"
+                    data-cy="resource-description">
+                    {{ row.description }}
+                  </small>
+                }
+              </div>
+              <div class="title-status">
+                @if (row.resource.metadata?.status === 'PENDING') {
+                  <pa-icon name="clock-dash"></pa-icon>
+                } @else if (row.resource.metadata?.status === 'ERROR') {
+                  <pa-icon
+                    class="error"
+                    name="warning"></pa-icon>
+                }
+              </div>
+            </div>
+          </pa-table-cell>
+
+          <pa-table-cell center>
+            <span class="body-s">{{ row.resource.created | formatDate: { default: true } }}</span>
+          </pa-table-cell>
+          @if (isAdminOrContrib | async) {
+            <pa-table-cell-menu>
+              <pa-button
+                icon="more-vertical"
+                aspect="basic"
+                size="small"
+                paTooltip="generic.actions"
+                [disabled]="bulkAction.inProgress"
+                [paPopup]="menu">
+                {{ 'generic.actions' | translate }}
+              </pa-button>
+              <pa-dropdown #menu>
+                <pa-option (selectOption)="triggerAction(row.resource, 'reprocess')">
+                  {{ 'generic.reindex' | translate }}
+                </pa-option>
+                <pa-separator></pa-separator>
+                <pa-option
+                  destructive
+                  (selectOption)="triggerAction(row.resource, 'delete')">
+                  {{ 'generic.delete' | translate }}
+                </pa-option>
+              </pa-dropdown>
+            </pa-table-cell-menu>
+          }
+        </pa-table-row>
+      }
     </pa-table>
   </pa-infinite-scroll>
 </div>

--- a/libs/common/src/lib/resources/resource-list/pending-resources-table/pending-resources-table.component.html
+++ b/libs/common/src/lib/resources/resource-list/pending-resources-table/pending-resources-table.component.html
@@ -1,41 +1,42 @@
-<div
-  data-cy="spinner"
-  class="loading-shade"
-  *ngIf="isLoading">
-  <nsi-spinner></nsi-spinner>
-</div>
+@if (isLoading) {
+  <div
+    data-cy="spinner"
+    class="loading-shade">
+    <nsi-spinner></nsi-spinner>
+  </div>
+}
 
 <div class="resource-table-header">
-  <div
-    class="resource-bulk-actions"
-    *ngIf="(isAdminOrContrib | async) && selection.length > 0">
-    {{ 'resource.selected_count' | translate: { num: selection.length } }}
+  @if ((isAdminOrContrib | async) && selection.length > 0) {
+    <div class="resource-bulk-actions">
+      {{ 'resource.selected_count' | translate: { num: selection.length } }}
 
-    <ng-container *ngIf="selection.length > 0">
-      <pa-button
-        data-cy="delete-selection"
-        kind="destructive"
-        aspect="basic"
-        size="small"
-        [disabled]="bulkAction.inProgress"
-        (click)="bulkDelete()">
-        {{ 'generic.delete' | translate }}
-      </pa-button>
-      <pa-button
-        aspect="basic"
-        size="small"
-        [disabled]="bulkAction.inProgress"
-        (click)="bulkReprocess()">
-        {{ (selection.length === 1 ? 'generic.reindex' : 'generic.reindex-plural') | translate }}
-      </pa-button>
-      <div
-        class="body-m"
-        *ngIf="bulkAction.inProgress">
-        {{ bulkAction.label | translate }}
-        {{ bulkAction.done }} / {{ bulkAction.total }}
-      </div>
-    </ng-container>
-  </div>
+      @if (selection.length > 0) {
+        <pa-button
+          data-cy="delete-selection"
+          kind="destructive"
+          aspect="basic"
+          size="small"
+          [disabled]="bulkAction.inProgress"
+          (click)="bulkDelete()">
+          {{ 'generic.delete' | translate }}
+        </pa-button>
+        <pa-button
+          aspect="basic"
+          size="small"
+          [disabled]="bulkAction.inProgress"
+          (click)="bulkReprocess()">
+          {{ (selection.length === 1 ? 'generic.reindex' : 'generic.reindex-plural') | translate }}
+        </pa-button>
+        @if (bulkAction.inProgress) {
+          <div class="body-m">
+            {{ bulkAction.label | translate }}
+            {{ bulkAction.done }} / {{ bulkAction.total }}
+          </div>
+        }
+      }
+    </div>
+  }
 </div>
 
 <div class="table-container">
@@ -44,79 +45,91 @@
       <pa-table-sortable-header
         [cells]="headerCells | async"
         (sort)="sortBy($event)">
-        <pa-table-cell
-          header
-          *ngIf="isAdminOrContrib | async">
-          <pa-checkbox
-            data-cy="select-all"
-            [value]="allSelected | async"
-            [paTooltip]="((allSelected | async) === true ? 'generic.deselect_all' : 'generic.select_all') | translate"
-            [disabled]="bulkAction.inProgress"
-            (change)="toggleAll()"></pa-checkbox>
-        </pa-table-cell>
+        @if (isAdminOrContrib | async) {
+          <pa-table-cell header>
+            <pa-checkbox
+              data-cy="select-all"
+              [value]="allSelected | async"
+              [paTooltip]="((allSelected | async) === true ? 'generic.deselect_all' : 'generic.select_all') | translate"
+              [disabled]="bulkAction.inProgress"
+              (change)="toggleAll()"></pa-checkbox>
+          </pa-table-cell>
+        }
       </pa-table-sortable-header>
 
-      <pa-table-row *ngFor="let row of data | async; trackBy: trackById">
-        <pa-table-cell *ngIf="isAdminOrContrib | async">
-          <pa-checkbox
-            [value]="selection.includes(row.resource.id)"
-            (change)="toggleSelection(row.resource.id)"></pa-checkbox>
-        </pa-table-cell>
-        <pa-table-cell
-          clickable
-          (click)="onClickTitle(row.resource)">
-          <div class="title-with-icon">
-            <pa-icon
-              *ngIf="row.resource.icon | mimeIcon as icon"
-              [name]="icon"></pa-icon>
-            <div class="title-and-description">
-              <div class="body-s">{{ row.resource.title }}</div>
-              <small *ngIf="row.description">{{ row.description }}</small>
+      @for (row of data | async; track row.resource.id) {
+        <pa-table-row>
+          <pa-table-cell *ngIf="isAdminOrContrib | async">
+            <pa-checkbox
+              [value]="selection.includes(row.resource.id)"
+              (change)="toggleSelection(row.resource.id)"></pa-checkbox>
+          </pa-table-cell>
+          <pa-table-cell
+            clickable
+            (click)="onClickTitle(row.resource)">
+            <div class="title-with-icon">
+              @if (row.resource.icon | mimeIcon; as icon) {
+                <pa-icon [name]="icon"></pa-icon>
+              }
+              <div class="title-and-description">
+                <div
+                  class="body-s"
+                  data-cy="resource-title">
+                  {{ row.resource.title }}
+                </div>
+                @if (row.description) {
+                  <small
+                    class="body-xs"
+                    data-cy="resource-description">
+                    {{ row.description }}
+                  </small>
+                }
+              </div>
+              <div class="title-status">
+                @if (row.resource.metadata?.status === 'PENDING') {
+                  <pa-icon name="clock-dash"></pa-icon>
+                } @else if (row.resource.metadata?.status === 'ERROR') {
+                  <pa-icon
+                    class="error"
+                    name="warning"></pa-icon>
+                }
+              </div>
             </div>
-            <div class="title-status">
-              <pa-icon
-                *ngIf="row.resource.metadata?.status === 'PENDING'"
-                name="clock-dash"></pa-icon>
-              <pa-icon
-                class="error"
-                *ngIf="row.resource.metadata?.status === 'ERROR'"
-                name="warning"></pa-icon>
-            </div>
-          </div>
-        </pa-table-cell>
+          </pa-table-cell>
 
-        <pa-table-cell center>
-          <span class="body-s">{{ row.resource.created | formatDate: { default: true } }}</span>
-        </pa-table-cell>
-        <pa-table-cell>
-          <span class="body-s">{{ row.status }}</span>
-        </pa-table-cell>
-        <pa-table-cell-menu *ngIf="isAdminOrContrib | async">
-          <pa-button
-            icon="more-vertical"
-            aspect="basic"
-            size="small"
-            paTooltip="generic.actions"
-            [disabled]="bulkAction.inProgress"
-            [paPopup]="menu">
-            {{ 'generic.actions' | translate }}
-          </pa-button>
-          <pa-dropdown #menu>
-            <pa-option
-              [disabled]="!(isAdminOrContrib | async)"
-              (selectOption)="triggerAction(row.resource, 'reprocess')">
-              {{ 'generic.reindex' | translate }}
-            </pa-option>
-            <pa-separator></pa-separator>
-            <pa-option
-              destructive
-              [disabled]="!(isAdminOrContrib | async)"
-              (selectOption)="triggerAction(row.resource, 'delete')">
-              {{ 'generic.delete' | translate }}
-            </pa-option>
-          </pa-dropdown>
-        </pa-table-cell-menu>
-      </pa-table-row>
+          <pa-table-cell center>
+            <span class="body-s">{{ row.resource.created | formatDate: { default: true } }}</span>
+          </pa-table-cell>
+          <pa-table-cell>
+            <span class="body-s">{{ row.status }}</span>
+          </pa-table-cell>
+
+          @if (isAdminOrContrib | async) {
+            <pa-table-cell-menu>
+              <pa-button
+                icon="more-vertical"
+                aspect="basic"
+                size="small"
+                paTooltip="generic.actions"
+                [disabled]="bulkAction.inProgress"
+                [paPopup]="menu">
+                {{ 'generic.actions' | translate }}
+              </pa-button>
+              <pa-dropdown #menu>
+                <pa-option (selectOption)="triggerAction(row.resource, 'reprocess')">
+                  {{ 'generic.reindex' | translate }}
+                </pa-option>
+                <pa-separator></pa-separator>
+                <pa-option
+                  destructive
+                  (selectOption)="triggerAction(row.resource, 'delete')">
+                  {{ 'generic.delete' | translate }}
+                </pa-option>
+              </pa-dropdown>
+            </pa-table-cell-menu>
+          }
+        </pa-table-row>
+      }
     </pa-table>
   </pa-infinite-scroll>
 </div>

--- a/libs/common/src/lib/resources/resource-list/pending-resources-table/pending-resources-table.component.html
+++ b/libs/common/src/lib/resources/resource-list/pending-resources-table/pending-resources-table.component.html
@@ -67,34 +67,7 @@
           <pa-table-cell
             clickable
             (click)="onClickTitle(row.resource)">
-            <div class="title-with-icon">
-              @if (row.resource.icon | mimeIcon; as icon) {
-                <pa-icon [name]="icon"></pa-icon>
-              }
-              <div class="title-and-description">
-                <div
-                  class="body-s"
-                  data-cy="resource-title">
-                  {{ row.resource.title }}
-                </div>
-                @if (row.description) {
-                  <small
-                    class="body-xs"
-                    data-cy="resource-description">
-                    {{ row.description }}
-                  </small>
-                }
-              </div>
-              <div class="title-status">
-                @if (row.resource.metadata?.status === 'PENDING') {
-                  <pa-icon name="clock-dash"></pa-icon>
-                } @else if (row.resource.metadata?.status === 'ERROR') {
-                  <pa-icon
-                    class="error"
-                    name="warning"></pa-icon>
-                }
-              </div>
-            </div>
+            <stf-title-cell [row]="row"></stf-title-cell>
           </pa-table-cell>
 
           <pa-table-cell center>

--- a/libs/common/src/lib/resources/resource-list/processed-resource-table/processed-resource-table.component.html
+++ b/libs/common/src/lib/resources/resource-list/processed-resource-table/processed-resource-table.component.html
@@ -162,39 +162,12 @@
                   (change)="toggleSelection(row.resource.id)"></pa-checkbox>
               </pa-table-cell>
             }
-
             <pa-table-cell
               clickable
               (click)="onClickTitle(row.resource)">
-              <div class="title-with-icon">
-                @if (row.resource.icon | mimeIcon; as icon) {
-                  <pa-icon [name]="icon"></pa-icon>
-                }
-                <div class="title-and-description">
-                  <div
-                    class="body-s"
-                    data-cy="resource-title">
-                    {{ row.resource.title }}
-                  </div>
-                  @if (row.description) {
-                    <small
-                      class="body-xs"
-                      data-cy="resource-description">
-                      {{ row.description }}
-                    </small>
-                  }
-                </div>
-                <div class="title-status">
-                  @if (row.resource.metadata?.status === 'PENDING') {
-                    <pa-icon name="clock-dash"></pa-icon>
-                  } @else if (row.resource.metadata?.status === 'ERROR') {
-                    <pa-icon
-                      class="error"
-                      name="warning"></pa-icon>
-                  }
-                </div>
-              </div>
+              <stf-title-cell [row]="row"></stf-title-cell>
             </pa-table-cell>
+
             @if (visibleColumnsId | async; as visibleColumns) {
               @if (visibleColumns.includes('classification')) {
                 <pa-table-cell class="classification-cell">

--- a/libs/common/src/lib/resources/resource-list/processed-resource-table/processed-resource-table.component.html
+++ b/libs/common/src/lib/resources/resource-list/processed-resource-table/processed-resource-table.component.html
@@ -1,62 +1,65 @@
-<div
-  data-cy="spinner"
-  class="loading-shade"
-  *ngIf="isLoading">
-  <nsi-spinner></nsi-spinner>
-</div>
+@if (isLoading) {
+  <div
+    data-cy="spinner"
+    class="loading-shade">
+    <nsi-spinner></nsi-spinner>
+  </div>
+}
 
-<ng-container *ngIf="(isReady | async) === true && (emptyKb | async) === false">
+@if ((isReady | async) === true && (emptyKb | async) === false) {
   <div class="resource-table-header">
-    <div
-      class="resource-bulk-actions"
-      *ngIf="(isAdminOrContrib | async) && selection.length > 0">
-      {{ 'resource.selected_count' | translate: { num: selection.length } }}
+    @if ((isAdminOrContrib | async) && selection.length > 0) {
+      <div class="resource-bulk-actions">
+        {{ 'resource.selected_count' | translate: { num: selection.length } }}
 
-      <ng-container *ngIf="hasLabelSets | async">
-        <app-label-dropdown
-          [labelSets]="labelSets | async"
-          (selectionChange)="updateLabelList($event)"
-          (close)="addLabelsToSelection()"
-          aspect="basic"
-          size="small">
-          {{ 'resource.add_labels' | translate }}
-        </app-label-dropdown>
-      </ng-container>
+        @if (hasLabelSets | async) {
+          <app-label-dropdown
+            [labelSets]="labelSets | async"
+            (selectionChange)="updateLabelList($event)"
+            (close)="addLabelsToSelection()"
+            aspect="basic"
+            size="small">
+            {{ 'resource.add_labels' | translate }}
+          </app-label-dropdown>
+        }
 
-      <ng-container *ngIf="selection.length > 0">
-        <pa-button
-          data-cy="delete-selection"
-          kind="destructive"
-          aspect="basic"
-          size="small"
-          [disabled]="bulkAction.inProgress"
-          (click)="bulkDelete()">
-          {{ 'generic.delete' | translate }}
-        </pa-button>
-        <pa-button
-          aspect="basic"
-          size="small"
-          [disabled]="bulkAction.inProgress"
-          (click)="bulkReprocess()">
-          {{ (selection.length === 1 ? 'generic.reindex' : 'generic.reindex-plural') | translate }}
-        </pa-button>
-        <div
-          class="body-m"
-          *ngIf="bulkAction.inProgress">
-          {{ bulkAction.label | translate }}
-          {{ bulkAction.done }} / {{ bulkAction.total }}
-        </div>
-      </ng-container>
-    </div>
+        @if (selection.length > 0) {
+          <pa-button
+            data-cy="delete-selection"
+            kind="destructive"
+            aspect="basic"
+            size="small"
+            [disabled]="bulkAction.inProgress"
+            (click)="bulkDelete()">
+            {{ 'generic.delete' | translate }}
+          </pa-button>
+          <pa-button
+            aspect="basic"
+            size="small"
+            [disabled]="bulkAction.inProgress"
+            (click)="bulkReprocess()">
+            {{ (selection.length === 1 ? 'generic.reindex' : 'generic.reindex-plural') | translate }}
+          </pa-button>
+          @if (bulkAction.inProgress) {
+            <div class="body-m">
+              {{ bulkAction.label | translate }}
+              {{ bulkAction.done }} / {{ bulkAction.total }}
+            </div>
+          }
+        }
+      </div>
+    }
+
     <div class="table-options">
-      <ng-container *ngIf="hasFilters">
-        <pa-button
-          *ngIf="isFiltering"
-          aspect="basic"
-          kind="primary"
-          (click)="clearFilters()">
-          {{ 'resource.filter.clear' | translate }}
-        </pa-button>
+      @if (hasFilters) {
+        @if (isFiltering) {
+          <pa-button
+            aspect="basic"
+            kind="primary"
+            (click)="clearFilters()">
+            {{ 'resource.filter.clear' | translate }}
+          </pa-button>
+        }
 
         <div>
           <nsi-dropdown-button
@@ -67,39 +70,42 @@
             {{ 'resource.filtered-by' | translate }}
           </nsi-dropdown-button>
           <pa-dropdown #availableFilters>
-            <ng-container *ngIf="filterOptions.classification.length > 0">
+            @if (filterOptions.classification.length > 0) {
               <pa-option-header>{{ 'resource.classification-column' | translate }}</pa-option-header>
-              <pa-option
-                *ngFor="let option of filterOptions.classification"
-                (selectOption)="onSelectFilter(option, $event)"
-                dontCloseOnSelect>
-                <pa-checkbox
-                  [(value)]="option.selected"
-                  (valueChange)="onToggleFilter()">
-                  {{ option.label }}
-                </pa-checkbox>
-              </pa-option>
-            </ng-container>
-            <ng-container *ngIf="filterOptions.classification.length > 0 && filterOptions.mainTypes.length > 0">
+
+              @for (option of filterOptions.classification; track option.id) {
+                <pa-option
+                  (selectOption)="onSelectFilter(option, $event)"
+                  dontCloseOnSelect>
+                  <pa-checkbox
+                    [(value)]="option.selected"
+                    (valueChange)="onToggleFilter()">
+                    {{ option.label }}
+                  </pa-checkbox>
+                </pa-option>
+              }
+            }
+            @if (filterOptions.classification.length > 0 && filterOptions.mainTypes.length > 0) {
               <pa-separator></pa-separator>
-            </ng-container>
-            <ng-container *ngIf="filterOptions.mainTypes.length > 0">
+            }
+            @if (filterOptions.mainTypes.length > 0) {
               <pa-option-header>{{ 'resource.filter.main-type' | translate }}</pa-option-header>
-              <pa-option
-                *ngFor="let option of filterOptions.mainTypes"
-                (selectOption)="onSelectFilter(option, $event)"
-                [paTooltip]="option.help"
-                dontCloseOnSelect>
-                <pa-checkbox
-                  [(value)]="option.selected"
-                  (valueChange)="onToggleFilter()">
-                  {{ option.label }}
-                </pa-checkbox>
-              </pa-option>
-            </ng-container>
+              @for (option of filterOptions.mainTypes; track option.id) {
+                <pa-option
+                  (selectOption)="onSelectFilter(option, $event)"
+                  [paTooltip]="option.help"
+                  dontCloseOnSelect>
+                  <pa-checkbox
+                    [(value)]="option.selected"
+                    (valueChange)="onToggleFilter()">
+                    {{ option.label }}
+                  </pa-checkbox>
+                </pa-option>
+              }
+            }
           </pa-dropdown>
         </div>
-      </ng-container>
+      }
 
       <div>
         <nsi-dropdown-button
@@ -110,17 +116,18 @@
           {{ 'resource.visible_columns_dropdown' | translate }}
         </nsi-dropdown-button>
         <pa-dropdown #visibleColumns>
-          <pa-option
-            *ngFor="let column of optionalColumns"
-            [value]="column.id"
-            (selectOption)="selectColumn(column, $event)"
-            dontCloseOnSelect>
-            <pa-checkbox
-              [(value)]="column.visible"
-              (valueChange)="this.columnVisibilityUpdate.next($event)">
-              {{ column.label | translate }}
-            </pa-checkbox>
-          </pa-option>
+          @for (column of optionalColumns; track column.id) {
+            <pa-option
+              [value]="column.id"
+              (selectOption)="selectColumn(column, $event)"
+              dontCloseOnSelect>
+              <pa-checkbox
+                [(value)]="column.visible"
+                (valueChange)="this.columnVisibilityUpdate.next($event)">
+                {{ column.label | translate }}
+              </pa-checkbox>
+            </pa-option>
+          }
         </pa-dropdown>
       </div>
     </div>
@@ -132,126 +139,128 @@
         <pa-table-sortable-header
           [cells]="headerCells | async"
           (sort)="sortBy($event)">
-          <pa-table-cell
-            header
-            *ngIf="isAdminOrContrib | async">
-            <pa-checkbox
-              data-cy="select-all"
-              [value]="allSelected | async"
-              [paTooltip]="((allSelected | async) === true ? 'generic.deselect_all' : 'generic.select_all') | translate"
-              [disabled]="bulkAction.inProgress"
-              (change)="toggleAll()"></pa-checkbox>
-          </pa-table-cell>
+          @if (isAdminOrContrib | async) {
+            <pa-table-cell header>
+              <pa-checkbox
+                data-cy="select-all"
+                [value]="allSelected | async"
+                [paTooltip]="
+                  ((allSelected | async) === true ? 'generic.deselect_all' : 'generic.select_all') | translate
+                "
+                [disabled]="bulkAction.inProgress"
+                (change)="toggleAll()"></pa-checkbox>
+            </pa-table-cell>
+          }
         </pa-table-sortable-header>
 
-        <pa-table-row *ngFor="let row of data | async; trackBy: trackById">
-          <pa-table-cell *ngIf="isAdminOrContrib | async">
-            <pa-checkbox
-              [value]="selection.includes(row.resource.id)"
-              (change)="toggleSelection(row.resource.id)"></pa-checkbox>
-          </pa-table-cell>
-          <pa-table-cell
-            clickable
-            (click)="onClickTitle(row.resource)">
-            <div class="title-with-icon">
-              <pa-icon
-                *ngIf="row.resource.icon | mimeIcon as icon"
-                [name]="icon"></pa-icon>
-              <div class="title-and-description">
-                <div
-                  class="body-s"
-                  data-cy="resource-title">
-                  {{ row.resource.title }}
+        @for (row of data | async; track row.resource.id) {
+          <pa-table-row>
+            @if (isAdminOrContrib | async) {
+              <pa-table-cell>
+                <pa-checkbox
+                  [value]="selection.includes(row.resource.id)"
+                  (change)="toggleSelection(row.resource.id)"></pa-checkbox>
+              </pa-table-cell>
+            }
+
+            <pa-table-cell
+              clickable
+              (click)="onClickTitle(row.resource)">
+              <div class="title-with-icon">
+                @if (row.resource.icon | mimeIcon; as icon) {
+                  <pa-icon [name]="icon"></pa-icon>
+                }
+                <div class="title-and-description">
+                  <div
+                    class="body-s"
+                    data-cy="resource-title">
+                    {{ row.resource.title }}
+                  </div>
+                  @if (row.description) {
+                    <small
+                      class="body-xs"
+                      data-cy="resource-description">
+                      {{ row.description }}
+                    </small>
+                  }
                 </div>
-                <small
-                  *ngIf="row.description"
-                  class="body-xs"
-                  data-cy="resource-description">
-                  {{ row.description }}
-                </small>
+                <div class="title-status">
+                  @if (row.resource.metadata?.status === 'PENDING') {
+                    <pa-icon name="clock-dash"></pa-icon>
+                  } @else if (row.resource.metadata?.status === 'ERROR') {
+                    <pa-icon
+                      class="error"
+                      name="warning"></pa-icon>
+                  }
+                </div>
               </div>
-              <div class="title-status">
-                <pa-icon
-                  *ngIf="row.resource.metadata?.status === 'PENDING'"
-                  name="clock-dash"></pa-icon>
-                <pa-icon
-                  class="error"
-                  *ngIf="row.resource.metadata?.status === 'ERROR'"
-                  name="warning"></pa-icon>
-              </div>
-            </div>
-          </pa-table-cell>
-          <pa-table-cell
-            class="classification-cell"
-            *ngIf="(visibleColumnsId | async)?.includes('classification')">
-            <div class="label-container">
-              <nsi-label
-                *ngFor="let label of row.labels"
-                [color]="label.color"
-                [disabled]="deletingLabel"
-                (removeLabel)="onRemoveLabel(row.resource, label, $event)">
-                {{ label.label }}
-              </nsi-label>
-            </div>
-          </pa-table-cell>
-          <pa-table-cell
-            center
-            *ngIf="(visibleColumnsId | async)?.includes('created')">
-            <span class="body-s">{{ row.resource.created | formatDate: { default: true } }}</span>
-          </pa-table-cell>
-          <pa-table-cell
-            center
-            *ngIf="(visibleColumnsId | async)?.includes('language')">
-            <span class="body-s">{{ row.resource.metadata?.language || '–' }}</span>
-          </pa-table-cell>
-          <pa-table-cell-menu *ngIf="isAdminOrContrib | async">
-            <pa-button
-              icon="more-vertical"
-              data-cy="menu-button"
-              aspect="basic"
-              size="small"
-              paTooltip="generic.actions"
-              [disabled]="bulkAction.inProgress"
-              [paPopup]="menu">
-              {{ 'generic.actions' | translate }}
-            </pa-button>
-            <pa-dropdown #menu>
-              <pa-option
-                [disabled]="!(isAdminOrContrib | async)"
-                (selectOption)="triggerAction(row.resource, 'edit')">
-                {{ 'resource.menu.edit' | translate }}
-              </pa-option>
-              <pa-option
-                [disabled]="!(isAdminOrContrib | async)"
-                (selectOption)="triggerAction(row.resource, 'annotate')">
-                {{ 'resource.menu.annotate' | translate }}
-              </pa-option>
-              <pa-option
-                [disabled]="!(isAdminOrContrib | async)"
-                (selectOption)="triggerAction(row.resource, 'classify')">
-                {{ 'resource.menu.classify' | translate }}
-              </pa-option>
-              <pa-option
-                [disabled]="!(isAdminOrContrib | async)"
-                (selectOption)="triggerAction(row.resource, 'summarize')">
-                {{ 'resource.menu.summarize' | translate }}
-              </pa-option>
-              <pa-option
-                [disabled]="!(isAdminOrContrib | async)"
-                (selectOption)="triggerAction(row.resource, 'reprocess')">
-                {{ 'generic.reindex' | translate }}
-              </pa-option>
-              <pa-separator></pa-separator>
-              <pa-option
-                destructive
-                [disabled]="!(isAdminOrContrib | async)"
-                (selectOption)="triggerAction(row.resource, 'delete')">
-                {{ 'generic.delete' | translate }}
-              </pa-option>
-            </pa-dropdown>
-          </pa-table-cell-menu>
-        </pa-table-row>
+            </pa-table-cell>
+            @if (visibleColumnsId | async; as visibleColumns) {
+              @if (visibleColumns.includes('classification')) {
+                <pa-table-cell class="classification-cell">
+                  <div class="label-container">
+                    @for (label of row.labels; track label.labelset + label.label) {
+                      <nsi-label
+                        [color]="label.color"
+                        [disabled]="deletingLabel"
+                        (removeLabel)="onRemoveLabel(row.resource, label, $event)">
+                        {{ label.label }}
+                      </nsi-label>
+                    }
+                  </div>
+                </pa-table-cell>
+              }
+              @if (visibleColumns.includes('created')) {
+                <pa-table-cell center>
+                  <span class="body-s">{{ row.resource.created | formatDate: { default: true } }}</span>
+                </pa-table-cell>
+              }
+              @if (visibleColumns.includes('language')) {
+                <pa-table-cell center>
+                  <span class="body-s">{{ row.resource.metadata?.language || '–' }}</span>
+                </pa-table-cell>
+              }
+            }
+            @if (isAdminOrContrib | async) {
+              <pa-table-cell-menu>
+                <pa-button
+                  icon="more-vertical"
+                  data-cy="menu-button"
+                  aspect="basic"
+                  size="small"
+                  paTooltip="generic.actions"
+                  [disabled]="bulkAction.inProgress"
+                  [paPopup]="menu">
+                  {{ 'generic.actions' | translate }}
+                </pa-button>
+                <pa-dropdown #menu>
+                  <pa-option (selectOption)="triggerAction(row.resource, 'edit')">
+                    {{ 'resource.menu.edit' | translate }}
+                  </pa-option>
+                  <pa-option (selectOption)="triggerAction(row.resource, 'annotate')">
+                    {{ 'resource.menu.annotate' | translate }}
+                  </pa-option>
+                  <pa-option (selectOption)="triggerAction(row.resource, 'classify')">
+                    {{ 'resource.menu.classify' | translate }}
+                  </pa-option>
+                  <pa-option (selectOption)="triggerAction(row.resource, 'summarize')">
+                    {{ 'resource.menu.summarize' | translate }}
+                  </pa-option>
+                  <pa-option (selectOption)="triggerAction(row.resource, 'reprocess')">
+                    {{ 'generic.reindex' | translate }}
+                  </pa-option>
+                  <pa-separator></pa-separator>
+                  <pa-option
+                    destructive
+                    (selectOption)="triggerAction(row.resource, 'delete')">
+                    {{ 'generic.delete' | translate }}
+                  </pa-option>
+                </pa-dropdown>
+              </pa-table-cell-menu>
+            }
+          </pa-table-row>
+        }
       </pa-table>
     </pa-infinite-scroll>
   </div>
-</ng-container>
+}

--- a/libs/common/src/lib/resources/resource-list/resources-table.component.scss
+++ b/libs/common/src/lib/resources/resource-list/resources-table.component.scss
@@ -36,33 +36,6 @@ table {
   width: 100%;
 }
 
-.title-with-icon {
-  align-items: center;
-  display: flex;
-  gap: rhythm(1);
-  justify-content: space-between;
-  width: 100%;
-
-  pa-icon {
-    color: $color-neutral-regular;
-  }
-
-  .title-and-description small {
-    overflow: hidden;
-    display: -webkit-box;
-    -webkit-box-orient: vertical;
-    -webkit-line-clamp: 2;
-  }
-
-  .title-status {
-    margin-left: auto;
-    color: $color-dark-stronger;
-    .error {
-      color: $color-secondary-strong;
-    }
-  }
-}
-
 .label-container {
   display: flex;
   gap: rhythm(0.5);

--- a/libs/common/src/lib/resources/resource-list/resources-table.directive.ts
+++ b/libs/common/src/lib/resources/resource-list/resources-table.directive.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectorRef, Directive, inject, OnDestroy, OnInit } from '@angular/core';
-import { BulkAction, ColumnHeader, MenuAction, ResourceWithLabels } from './resource-list.model';
+import { BulkAction, ColumnHeader, MenuAction } from './resource-list.model';
 import { Resource, RESOURCE_STATUS, SortField, SortOption } from '@nuclia/core';
 import { delay, map, switchMap } from 'rxjs/operators';
 import { SDKService } from '@flaps/core';
@@ -141,10 +141,6 @@ export class ResourcesTableDirective implements OnInit, OnDestroy {
         this.resourceListService.sortBy(sorting);
         break;
     }
-  }
-
-  trackById(index: number, resource: ResourceWithLabels) {
-    return resource.resource.id;
   }
 
   onClickTitle(resource: Resource) {

--- a/libs/common/src/lib/resources/resource-list/title-cell/title-cell.component.html
+++ b/libs/common/src/lib/resources/resource-list/title-cell/title-cell.component.html
@@ -1,32 +1,34 @@
-<div class="title-with-icon">
-  @if (row.resource.icon | mimeIcon; as icon) {
-    <pa-icon [name]="icon"></pa-icon>
-  }
-  <div class="title-and-description">
-    <div
-      class="body-s"
-      data-cy="resource-title">
-      <a
-        [routerLink]="'../' + row.resource.id + '/edit/preview'"
-        (click)="onClickLink($event)">
-        {{ row.resource.title }}
-      </a>
+@if (row) {
+  <div class="title-with-icon">
+    @if (row.resource.icon | mimeIcon; as icon) {
+      <pa-icon [name]="icon"></pa-icon>
+    }
+    <div class="title-and-description">
+      <div
+        class="body-s"
+        data-cy="resource-title">
+        <a
+          [routerLink]="'../' + row.resource.id + '/edit/preview'"
+          (click)="onClickLink($event)">
+          {{ row.resource.title }}
+        </a>
+      </div>
+      @if (row.description) {
+        <small
+          class="body-xs"
+          data-cy="resource-description">
+          {{ row.description }}
+        </small>
+      }
     </div>
-    @if (row.description) {
-      <small
-        class="body-xs"
-        data-cy="resource-description">
-        {{ row.description }}
-      </small>
-    }
+    <div class="title-status">
+      @if (row.resource.metadata?.status === 'PENDING') {
+        <pa-icon name="clock-dash"></pa-icon>
+      } @else if (row.resource.metadata?.status === 'ERROR') {
+        <pa-icon
+          class="error"
+          name="warning"></pa-icon>
+      }
+    </div>
   </div>
-  <div class="title-status">
-    @if (row.resource.metadata?.status === 'PENDING') {
-      <pa-icon name="clock-dash"></pa-icon>
-    } @else if (row.resource.metadata?.status === 'ERROR') {
-      <pa-icon
-        class="error"
-        name="warning"></pa-icon>
-    }
-  </div>
-</div>
+}

--- a/libs/common/src/lib/resources/resource-list/title-cell/title-cell.component.html
+++ b/libs/common/src/lib/resources/resource-list/title-cell/title-cell.component.html
@@ -1,0 +1,32 @@
+<div class="title-with-icon">
+  @if (row.resource.icon | mimeIcon; as icon) {
+    <pa-icon [name]="icon"></pa-icon>
+  }
+  <div class="title-and-description">
+    <div
+      class="body-s"
+      data-cy="resource-title">
+      <a
+        [routerLink]="'../' + row.resource.id + '/edit/preview'"
+        (click)="onClickLink($event)">
+        {{ row.resource.title }}
+      </a>
+    </div>
+    @if (row.description) {
+      <small
+        class="body-xs"
+        data-cy="resource-description">
+        {{ row.description }}
+      </small>
+    }
+  </div>
+  <div class="title-status">
+    @if (row.resource.metadata?.status === 'PENDING') {
+      <pa-icon name="clock-dash"></pa-icon>
+    } @else if (row.resource.metadata?.status === 'ERROR') {
+      <pa-icon
+        class="error"
+        name="warning"></pa-icon>
+    }
+  </div>
+</div>

--- a/libs/common/src/lib/resources/resource-list/title-cell/title-cell.component.scss
+++ b/libs/common/src/lib/resources/resource-list/title-cell/title-cell.component.scss
@@ -1,0 +1,39 @@
+@import 'apps/dashboard/src/variables';
+
+:host {
+  width: 100%;
+
+  .title-with-icon {
+    align-items: center;
+    display: flex;
+    gap: rhythm(1);
+    justify-content: space-between;
+    width: 100%;
+
+    pa-icon {
+      color: $color-neutral-regular;
+    }
+
+    .title-and-description {
+      a {
+        color: inherit;
+        font-weight: inherit;
+      }
+
+      small {
+        overflow: hidden;
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+      }
+    }
+
+    .title-status {
+      margin-left: auto;
+      color: $color-dark-stronger;
+      .error {
+        color: $color-secondary-strong;
+      }
+    }
+  }
+}

--- a/libs/common/src/lib/resources/resource-list/title-cell/title-cell.component.ts
+++ b/libs/common/src/lib/resources/resource-list/title-cell/title-cell.component.ts
@@ -1,0 +1,22 @@
+import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ResourceWithLabels } from '@flaps/common';
+import { PaIconModule } from '@guillotinaweb/pastanaga-angular';
+import { SisIconsModule } from '@nuclia/sistema';
+import { RouterModule } from '@angular/router';
+
+@Component({
+  selector: 'stf-title-cell',
+  standalone: true,
+  imports: [CommonModule, RouterModule, PaIconModule, SisIconsModule],
+  templateUrl: './title-cell.component.html',
+  styleUrl: './title-cell.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class TitleCellComponent {
+  @Input() row?: ResourceWithLabels;
+
+  onClickLink($event: MouseEvent) {
+    $event.stopPropagation();
+  }
+}

--- a/libs/common/src/lib/resources/resources.module.ts
+++ b/libs/common/src/lib/resources/resources.module.ts
@@ -52,6 +52,7 @@ import {
   PaTogglesModule,
   PaTooltipModule,
 } from '@guillotinaweb/pastanaga-angular';
+import { TitleCellComponent } from './resource-list/title-cell/title-cell.component';
 
 const ROUTES: Routes = [
   {
@@ -186,6 +187,7 @@ const ROUTES: Routes = [
     FileUploadModule,
 
     EditResourceModule,
+    TitleCellComponent,
   ],
   declarations: [
     DatasetImportComponent,


### PR DESCRIPTION
In resource list, we created a new `title-cell` component because all the resource tables (processed, pending and error) are sharing the same code for the title cell.

Now the resource title is a real link (but we kept the same style, except it is underlined on hover), so we can easily open it on a new tab. Clicking anywhere else on the title cell is still navigating to the resource on the same tab as it used to.

We took the opportunity to use new Angular control flow in resource list components.