### PR TITLE
[sc-8176] simplify updateStateOnRouteChange in dashboard and NucliaDB admin

### DIFF
--- a/apps/dashboard/src/app/app-routing.module.ts
+++ b/apps/dashboard/src/app/app-routing.module.ts
@@ -16,6 +16,8 @@ import {
   selectAccountGuard,
   SelectKbComponent,
   selectKbGuard,
+  setAccountGuard,
+  setKbGuard,
   UploadDataComponent,
 } from '@flaps/common';
 import { authGuard } from '@flaps/core';
@@ -56,6 +58,7 @@ const routes: Routes = [
       {
         path: `at/:account`,
         component: DashboardLayoutComponent,
+        canActivate: [setAccountGuard],
         children: [
           {
             path: '',
@@ -120,6 +123,7 @@ const routes: Routes = [
           {
             path: `:zone/:kb`,
             component: KnowledgeBoxComponent,
+            canActivate: [setKbGuard],
             children: [
               {
                 path: '',
@@ -227,6 +231,7 @@ const routes: Routes = [
 
 const routerOptions: ExtraOptions = {
   scrollPositionRestoration: 'enabled',
+  paramsInheritanceStrategy: 'always',
 };
 
 @NgModule({

--- a/apps/dashboard/src/app/app-title.strategy.ts
+++ b/apps/dashboard/src/app/app-title.strategy.ts
@@ -1,0 +1,37 @@
+import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { SDKService } from '@flaps/core';
+import { forkJoin, map, of, switchMap, take } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AppTitleStrategy extends TitleStrategy {
+  constructor(
+    private readonly title: Title,
+    private sdk: SDKService,
+  ) {
+    super();
+  }
+
+  override updateTitle(routerState: RouterStateSnapshot): void {
+    const specificRouteTitle = this.buildTitle(routerState);
+
+    if (specificRouteTitle) {
+      this.title.setTitle(`Nuclia – ${specificRouteTitle}`);
+    } else if (routerState.url.includes(`/at`) || routerState.url.includes(`/select/`)) {
+      forkJoin([this.sdk.currentAccount.pipe(take(1)), this.sdk.hasKb.pipe(take(1))])
+        .pipe(
+          switchMap(([account, hasKb]) => {
+            const baseTitle = `Nuclia – ${account.title}`;
+            return hasKb
+              ? this.sdk.currentKb.pipe(
+                  take(1),
+                  map((kb) => `${baseTitle} – ${kb.title}`),
+                )
+              : of(baseTitle);
+          }),
+        )
+        .subscribe((title) => this.title.setTitle(title));
+    }
+  }
+}

--- a/apps/dashboard/src/app/app.component.ts
+++ b/apps/dashboard/src/app/app.component.ts
@@ -10,13 +10,11 @@ import {
   UserService,
 } from '@flaps/core';
 import { NavigationEnd, Router } from '@angular/router';
-import { catchError, combineLatest, filter, map, of, Subject, switchMap, take, tap, throwError } from 'rxjs';
-import { Title } from '@angular/platform-browser';
+import { filter, Subject, take } from 'rxjs';
 import { ModalConfig, TranslateService as PaTranslateService } from '@guillotinaweb/pastanaga-angular';
 import { takeUntil } from 'rxjs/operators';
 import { SisModalService } from '@nuclia/sistema';
-import { FeaturesModalComponent, MessageModalComponent, NavigationService } from '@flaps/common';
-import { Account, IKnowledgeBoxItem } from '@nuclia/core';
+import { FeaturesModalComponent, MessageModalComponent } from '@flaps/common';
 
 @Component({
   selector: 'app-root',
@@ -37,16 +35,16 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     private ngxTranslate: TranslateService,
     private tracking: STFTrackingService,
     private config: BackendConfigurationService,
-    private navigation: NavigationService,
     private sdk: SDKService,
     private modalService: SisModalService,
     private paTranslate: PaTranslateService,
-    private titleService: Title,
     @Inject(DOCUMENT) private document: any,
   ) {
     this.unsubscribeAll = new Subject();
 
-    this.updateStateOnRouteChange();
+    this.router.events
+      .pipe(filter((event) => event instanceof NavigationEnd))
+      .subscribe((event) => this.tracking.navigation(event as NavigationEnd));
 
     this.initTranslate(undefined);
     this.user.userPrefs.subscribe((prefs) => {
@@ -98,64 +96,6 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     this.ngxTranslate.onLangChange
       .pipe(takeUntil(this.unsubscribeAll))
       .subscribe((event) => this.paTranslate.initTranslationsAndUse(event.lang, event.translations));
-  }
-
-  private updateStateOnRouteChange() {
-    this.router.events
-      .pipe(
-        filter((event) => event instanceof NavigationEnd),
-        tap((event) => this.tracking.navigation(event as NavigationEnd)),
-        filter(
-          (event) =>
-            ((event as NavigationEnd).url.startsWith('/at/') || (event as NavigationEnd).url.startsWith('/select/')) &&
-            !!this.router.routerState.root.firstChild?.firstChild,
-        ),
-        switchMap(() =>
-          combineLatest([
-            this.router.routerState.root.firstChild!.firstChild!.paramMap,
-            this.router.routerState.root.firstChild?.firstChild?.firstChild?.paramMap || of(),
-          ]),
-        ),
-        filter(([accountParams]) => !!accountParams.get('account')),
-        switchMap(([accountParams, kbParams]) => {
-          const account = accountParams.get('account') as string;
-          const kbSlug = kbParams && kbParams.get('kb');
-          const zone: string | null = kbParams && kbParams.get('zone');
-
-          const getAccountAndKb = this.sdk.setCurrentAccount(account).pipe(
-            switchMap((account) => {
-              const accountId = account.id;
-              this.sdk.nuclia.options.accountId = accountId;
-              return zone
-                ? this.sdk.nuclia.db.getKnowledgeBoxesForZone(accountId, zone).pipe(
-                    switchMap((kbs) => {
-                      const kb = kbs.find((item) => item.slug === kbSlug);
-                      if (!kb) {
-                        return throwError(() => ({
-                          status: 403,
-                          message: `No KB found for ${kbSlug} in account ${account} on ${zone}.`,
-                        }));
-                      }
-                      this.sdk.nuclia.options.knowledgeBox = kb.id;
-                      return this.sdk
-                        .setCurrentKnowledgeBox(account.slug, kb.id, zone)
-                        .pipe(map((kb) => [account, kb] as [Account, IKnowledgeBoxItem | null]));
-                    }),
-                  )
-                : of([]);
-            }),
-          );
-          return getAccountAndKb.pipe(
-            catchError((error) => {
-              if (error.status === 403) {
-                this.navigation.resetState();
-              }
-              return of([{ title: '' }, { title: '' }]);
-            }),
-          );
-        }),
-      )
-      .subscribe();
   }
 
   private displayAlert() {

--- a/apps/dashboard/src/app/app.component.ts
+++ b/apps/dashboard/src/app/app.component.ts
@@ -155,11 +155,7 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
           );
         }),
       )
-      .subscribe(([account, kb]) =>
-        this.titleService.setTitle(
-          `Nuclia${account?.title ? ' – ' + account.title : ''}${kb?.title ? ' – ' + kb.title : ''}`,
-        ),
-      );
+      .subscribe();
   }
 
   private displayAlert() {

--- a/apps/dashboard/src/app/app.module.ts
+++ b/apps/dashboard/src/app/app.module.ts
@@ -40,6 +40,8 @@ import { InviteModule } from './invite/invite.module';
 import { MultiTranslateHttpLoader } from 'ngx-translate-multi-http-loader';
 import { SyncService } from '@nuclia/sync';
 import { NewSyncService } from '../../../../libs/sync/src/lib/sync/new-sync.service';
+import { TitleStrategy } from '@angular/router';
+import { AppTitleStrategy } from './app-title.strategy';
 
 registerLocaleData(localeEn);
 registerLocaleData(localeEs);
@@ -101,6 +103,7 @@ const appModules = [
     },
     { provide: HTTP_INTERCEPTORS, useClass: AuthInterceptor, multi: true },
     TranslatePipe,
+    { provide: TitleStrategy, useClass: AppTitleStrategy },
     // TO BE REMOVED WHEN DESKTOP APP IS GONE
     // override SyncService with NewSyncService to use the new agent API
     { provide: SyncService, useClass: NewSyncService },

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-metrics/kb-metrics.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-metrics/kb-metrics.component.scss
@@ -11,12 +11,12 @@
     flex-wrap: wrap;
 
     dt {
-      flex: 1 0 75%;
+      flex: 1 0 60%;
       font-weight: $font-weight-thin;
     }
 
     dd {
-      flex: 1 0 25%;
+      flex: 1 0 40%;
       font-weight: $font-weight-bold;
       margin-bottom: 0;
       text-align: right;

--- a/apps/nucliadb-admin/src/app/app-routing.ts
+++ b/apps/nucliadb-admin/src/app/app-routing.ts
@@ -13,12 +13,15 @@ import {
   SelectAccountComponent,
   SelectKbComponent,
   selectKbGuard,
+  setAccountGuard,
   UploadDataComponent,
 } from '@flaps/common';
+import { setLocalKbGuard } from '../../../../libs/common/src/lib/guards/set-local-kb.guard';
 
 export const routerOptions: ExtraOptions = {
   onSameUrlNavigation: 'reload',
   scrollPositionRestoration: 'enabled',
+  paramsInheritanceStrategy: 'always',
   useHash: true,
 };
 
@@ -35,10 +38,12 @@ export const routes: Routes = [
       {
         path: `at/:account`,
         component: DashboardLayoutComponent,
+        canActivate: [setAccountGuard],
         children: [
           {
             path: `:kb`,
             component: MainContainerComponent,
+            canActivate: [setLocalKbGuard],
             children: [
               {
                 path: '',

--- a/apps/nucliadb-admin/src/app/app-routing.ts
+++ b/apps/nucliadb-admin/src/app/app-routing.ts
@@ -14,9 +14,9 @@ import {
   SelectKbComponent,
   selectKbGuard,
   setAccountGuard,
+  setLocalKbGuard,
   UploadDataComponent,
 } from '@flaps/common';
-import { setLocalKbGuard } from '../../../../libs/common/src/lib/guards/set-local-kb.guard';
 
 export const routerOptions: ExtraOptions = {
   onSameUrlNavigation: 'reload',

--- a/apps/nucliadb-admin/src/app/app-title.strategy.ts
+++ b/apps/nucliadb-admin/src/app/app-title.strategy.ts
@@ -1,0 +1,30 @@
+import { RouterStateSnapshot, TitleStrategy } from '@angular/router';
+import { Injectable } from '@angular/core';
+import { Title } from '@angular/platform-browser';
+import { SDKService } from '@flaps/core';
+import { map, take } from 'rxjs';
+
+@Injectable({ providedIn: 'root' })
+export class AppTitleStrategy extends TitleStrategy {
+  constructor(
+    private readonly title: Title,
+    private sdk: SDKService,
+  ) {
+    super();
+  }
+
+  override updateTitle(routerState: RouterStateSnapshot): void {
+    const specificRouteTitle = this.buildTitle(routerState);
+
+    if (specificRouteTitle) {
+      this.title.setTitle(`NucliaDB – ${specificRouteTitle}`);
+    } else if (routerState.url.includes(`/at`) || routerState.url.includes(`/select/`)) {
+      this.sdk.currentKb
+        .pipe(
+          take(1),
+          map((kb) => `NucliaDB – ${kb.title}`),
+        )
+        .subscribe((title) => this.title.setTitle(title));
+    }
+  }
+}

--- a/apps/nucliadb-admin/src/app/app.module.ts
+++ b/apps/nucliadb-admin/src/app/app.module.ts
@@ -9,7 +9,7 @@ import { APP_BASE_HREF, registerLocaleData } from '@angular/common';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { AngularSvgIconModule } from 'angular-svg-icon';
 import { environment } from '../environments/environment';
-import { RouterModule } from '@angular/router';
+import { RouterModule, TitleStrategy } from '@angular/router';
 import { routerOptions, routes } from './app-routing';
 import { HomePageComponent } from './home/home-page.component';
 import { MainContainerComponent } from './home/main-container/main-container.component';
@@ -22,6 +22,7 @@ import localeEs from '@angular/common/locales/es';
 import localeCa from '@angular/common/locales/ca';
 import { MultiTranslateHttpLoader } from 'ngx-translate-multi-http-loader';
 import { HomeContainerComponent } from '@nuclia/sistema';
+import { AppTitleStrategy } from './app-title.strategy';
 
 registerLocaleData(localeEn);
 registerLocaleData(localeEs);
@@ -56,7 +57,11 @@ export function createTranslateLoader(http: HttpBackend, config: BackendConfigur
     PaIconModule,
     HomeContainerComponent,
   ],
-  providers: [TranslatePipe, { provide: APP_BASE_HREF, useValue: '/admin' }],
+  providers: [
+    TranslatePipe,
+    { provide: APP_BASE_HREF, useValue: '/admin' },
+    { provide: TitleStrategy, useClass: AppTitleStrategy },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/libs/common/src/lib/guards/index.ts
+++ b/libs/common/src/lib/guards/index.ts
@@ -3,3 +3,5 @@ export * from './permission.guard';
 export * from './root.guard';
 export * from './select-account.guard';
 export * from './select-kb.guard';
+export * from './set-account.guard';
+export * from './set-kb.guard';

--- a/libs/common/src/lib/guards/index.ts
+++ b/libs/common/src/lib/guards/index.ts
@@ -5,3 +5,4 @@ export * from './select-account.guard';
 export * from './select-kb.guard';
 export * from './set-account.guard';
 export * from './set-kb.guard';
+export * from './set-local-kb.guard';

--- a/libs/common/src/lib/guards/set-account.guard.ts
+++ b/libs/common/src/lib/guards/set-account.guard.ts
@@ -1,0 +1,23 @@
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { SDKService } from '@flaps/core';
+import { inject } from '@angular/core';
+import { NavigationService } from '../services';
+import { of, switchMap } from 'rxjs';
+
+export const setAccountGuard = (route: ActivatedRouteSnapshot) => {
+  const sdk: SDKService = inject(SDKService);
+  const router: Router = inject(Router);
+  const navigation: NavigationService = inject(NavigationService);
+
+  const accountSlug = route.paramMap.get('account');
+  if (!accountSlug) {
+    return of(router.createUrlTree(['/select']));
+  }
+
+  return sdk.setCurrentAccount(accountSlug).pipe(
+    switchMap((account) => {
+      sdk.nuclia.options.accountId = account.id;
+      return navigation.getAccountUrl(accountSlug);
+    }),
+  );
+};

--- a/libs/common/src/lib/guards/set-kb.guard.ts
+++ b/libs/common/src/lib/guards/set-kb.guard.ts
@@ -1,0 +1,33 @@
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { SDKService } from '@flaps/core';
+import { inject } from '@angular/core';
+import { map, of, switchMap } from 'rxjs';
+
+export const setKbGuard = (route: ActivatedRouteSnapshot) => {
+  const sdk: SDKService = inject(SDKService);
+  const router: Router = inject(Router);
+
+  const kbSlug = route.paramMap.get('kb');
+  const zone = route.paramMap.get('zone');
+
+  if (!kbSlug || !zone) {
+    return of(router.createUrlTree(['/select']));
+  }
+
+  return sdk.currentAccount.pipe(
+    switchMap((account) => {
+      return sdk.nuclia.db.getKnowledgeBoxesForZone(account.id, zone).pipe(
+        switchMap((kbs) => {
+          const kb = kbs.find((item) => item.slug === kbSlug);
+          if (!kb) {
+            sdk.cleanAccount();
+            return of(router.createUrlTree(['/select']));
+          }
+          sdk.nuclia.options.knowledgeBox = kb.id;
+          return sdk.setCurrentKnowledgeBox(account.slug, kb.id, zone);
+        }),
+      );
+    }),
+    map(() => true),
+  );
+};

--- a/libs/common/src/lib/guards/set-local-kb.guard.ts
+++ b/libs/common/src/lib/guards/set-local-kb.guard.ts
@@ -1,0 +1,20 @@
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { SDKService } from '@flaps/core';
+import { inject } from '@angular/core';
+import { map, of } from 'rxjs';
+import { NavigationService } from '@flaps/common';
+
+export const setLocalKbGuard = (route: ActivatedRouteSnapshot) => {
+  const sdk: SDKService = inject(SDKService);
+  const router: Router = inject(Router);
+  const navigation: NavigationService = inject(NavigationService);
+
+  const accountSlug = route.paramMap.get('account');
+  const kbId = route.paramMap.get('kb');
+
+  if (!accountSlug || !kbId) {
+    return of(router.createUrlTree(['/select']));
+  }
+
+  return sdk.setCurrentKnowledgeBox(accountSlug, kbId).pipe(map(() => true));
+};

--- a/libs/common/src/lib/resources/resource-list/resource-list.component.spec.ts
+++ b/libs/common/src/lib/resources/resource-list/resource-list.component.spec.ts
@@ -63,7 +63,6 @@ describe('ResourceListComponent', () => {
               type: 'test-type',
             }),
             counters: of({ resources: 0 }),
-            refreshing: of(true),
             nuclia: {
               options: {
                 zone: 'europe',

--- a/libs/common/src/lib/select-account-kb/select-account/select-account.component.ts
+++ b/libs/common/src/lib/select-account-kb/select-account/select-account.component.ts
@@ -5,6 +5,7 @@ import { standaloneSimpleAccount, StaticEnvironmentConfiguration } from '@flaps/
 import { SelectAccountKbService } from '../select-account-kb.service';
 import { selectAnimations } from '../utils';
 import { Account } from '@nuclia/core';
+import { takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-select-account',
@@ -29,7 +30,10 @@ export class SelectAccountComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.router.events
-      .pipe(filter((event) => event instanceof NavigationStart || event instanceof Scroll))
+      .pipe(
+        filter((event) => event instanceof NavigationStart || event instanceof Scroll),
+        takeUntil(this.unsubscribeAll),
+      )
       .subscribe((event) => {
         // Good animation is done using NavigationStart,
         // but we also listen to Scroll event because NavigationStart isn't triggered when loading a page directly

--- a/libs/common/src/lib/select-account-kb/select-kb/select-kb.component.scss
+++ b/libs/common/src/lib/select-account-kb/select-kb/select-kb.component.scss
@@ -55,7 +55,7 @@
     display: flex;
     gap: rhythm(2);
     justify-content: center;
-    padding: rhythm(3) 0 rhythm(6);
+    padding: rhythm(6) 0;
   }
 
   .kb {

--- a/libs/core/src/lib/api/sdk.service.ts
+++ b/libs/core/src/lib/api/sdk.service.ts
@@ -47,6 +47,7 @@ export class SDKService {
   private _repetitiveRefreshCounter = new Subject<void>();
   private _isKbLoaded = false;
 
+  hasKb = this._kb.pipe(map((kb) => kb !== null));
   currentKb = this._currentKB.asObservable();
   kbList: Observable<IKnowledgeBoxItem[]> = this._kbList.asObservable();
   refreshingKbList: Observable<boolean> = this._refreshingKbList.asObservable();
@@ -56,7 +57,6 @@ export class SDKService {
   );
   counters = new ReplaySubject<Counters>(1);
   pendingRefresh = new BehaviorSubject(false);
-  refreshing = this._refreshCounter.asObservable();
   isAdminOrContrib = this.currentKb.pipe(map((kb) => this.nuclia.options.standalone || !!kb.admin || !!kb.contrib));
 
   get isKbLoaded() {


### PR DESCRIPTION
- Use proper title strategy on Dashboard and NucliaDB admin apps
- Move `updateStateOnRouteChange` logic in new guards
  - Keep only tracking navigation logic in `app.component`, and remove `updateStateOnRouteChange` method
  - Create two new guards for dashboard: `setAccountGuard` and `setKbGuard` allowing to set the current account and KB while navigating through the app
  - Create a new guard `setLocalKbGuard` for NucliaDB admin
- Some style improvements