### PR TITLE
[sc-8270] Display relations in a modal

### DIFF
--- a/apps/search-widget-demo/src/App.svelte
+++ b/apps/search-widget-demo/src/App.svelte
@@ -21,10 +21,10 @@
 
   // let kb = 'eed07421-dc96-4067-a73b-32c89eac0229'; // philo
   // let kb = 'd10ea56b-7af9-495d-860f-23b616a44f9a'; // eudald
-  // let kb = '5fad8445-ff08-4428-85a4-3c6eeb9d2ece'; // chat
+  let kb = '5fad8445-ff08-4428-85a4-3c6eeb9d2ece'; // chat
   // let kb = '0b8017a4-083a-4c11-b400-5234fb0530cf'; // carmen
   // let kb = '6b9f8f55-a57f-4ed4-b60e-759da54281fd'; // Robin Hobb
-  let kb = '5c2bc432-a579-48cd-b408-4271e5e7a43c'; // medias
+  // let kb = '5c2bc432-a579-48cd-b408-4271e5e7a43c'; // medias
   // let kb = 'f5d0ec7f-9ac3-46a3-b284-a38d5333d9e6'; // le petit prince
   // let kb = '1154f6a1-af3c-4a19-9039-35466f024448'; // Knowledge graph (daria wiki + an article)
   // let kb = '096d9070-f7be-40c8-a24c-19c89072e3ff'; // e2e permanent
@@ -140,7 +140,7 @@
         no_tracking
         {placeholder}
         preselected_filters={preselectedFilters}
-        features="filter,suggestions,permalink,relations,knowledgeGraph,navigateToLink,znavigateToFile,answers,citations,zhideSources,displayMetadata,hideThumbnails,znoBM25forChat" />
+        features="filter,suggestions,permalink,relations,knowledgeGraph,znavigateToLink,znavigateToFile,zanswers,citations,zhideSources,displayMetadata,hideThumbnails,znoBM25forChat" />
       <NucliaSearchResults bind:this={resultsWidget} no_tracking />
     </div>
   {/if}

--- a/libs/search-widget/src/common/modal/Modal.scss
+++ b/libs/search-widget/src/common/modal/Modal.scss
@@ -16,8 +16,8 @@
   }
 
   &:not(.popup) .modal-content {
-    width: var(--modal-width, fit-content);
-    height: var(--modal-height, fit-content);
+    width: fit-content;
+    height: fit-content;
   }
 }
 @media (min-width: 599px) {
@@ -29,10 +29,6 @@
     }
     &.popup.align-right .modal {
       left: max(calc(var(--popup-left) - var(--modal-width)), 0px);
-    }
-    &:not(.popup) .modal-content {
-      width: var(--resource-modal-width-md, fit-content);
-      height: 100vh;
     }
   }
 }

--- a/libs/search-widget/src/widgets/search-widget/SearchBar.scss
+++ b/libs/search-widget/src/widgets/search-widget/SearchBar.scss
@@ -1,0 +1,24 @@
+@import '../../common/common-style';
+
+.nuclia-widget {
+  .search-box {
+    align-items: center;
+    display: flex;
+    gap: var(--rhythm-1);
+  }
+  .dialog-content {
+    max-height: 80vh;
+    overflow: auto;
+    padding: var(--rhythm-3) var(--rhythm-2);
+    position: relative;
+  }
+
+  .close-button {
+    background: var(--container-background-color);
+    border-radius: 50%;
+    position: absolute;
+    right: var(--rhythm-1_5);
+    top: var(--rhythm-1_5);
+    z-index: 1;
+  }
+}

--- a/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
@@ -21,9 +21,11 @@
     resetStatesAndEffects,
     setupTriggerGraphNerSearch
   } from '../../core/stores/effects';
-  import { preselectedFilters, searchQuery, triggerSearch } from '../../core/stores/search.store';
+  import { entityRelations, preselectedFilters, searchQuery, triggerSearch } from '../../core/stores/search.store';
   import { typeAhead } from '../../core/stores/suggestions.store';
   import type { WidgetFilters } from '../../core';
+  import { InfoCard } from '../../components';
+  import { IconButton, Modal } from '../../common';
 
   export let backend = 'https://nuclia.cloud/api';
   export let zone = 'europe-1';
@@ -87,6 +89,8 @@
   let svgSprite: string;
   let ready = false;
   let container: HTMLElement;
+
+  let showRelations = false;
 
   onMount(() => {
     if (cdn) {
@@ -172,6 +176,13 @@
       resetStatesAndEffects();
     };
   });
+
+  function displayRelations(){
+    showRelations = true;
+  }
+  function hideRelations(){
+    showRelations = false;
+  }
 </script>
 
 <svelte:element this="style">{@html globalCss}</svelte:element>
@@ -182,8 +193,24 @@
   class:dark-mode={darkMode}
   data-version="__NUCLIA_DEV_VERSION__">
   {#if ready && !!svgSprite}
-    <SearchInput />
+    <div class="search-box">
+      <SearchInput />
+
+      {#if $entityRelations.length > 0}
+        <IconButton icon="info" aspect="basic" on:click={displayRelations} />
+      {/if}
+    </div>
   {/if}
+
+  <Modal show={showRelations} on:close={hideRelations}>
+    <div class="close-button">
+      <IconButton icon="cross" aspect="basic" on:click={hideRelations} />
+    </div>
+    <div class="dialog-content">
+      <InfoCard entityRelations={$entityRelations} />
+    </div>
+  </Modal>
+
   <div
     id="nuclia-glyphs-sprite"
     hidden>
@@ -193,4 +220,4 @@
 
 <style
   lang="scss"
-  src="../../common/common-style.scss"></style>
+  src="./SearchBar.scss"></style>

--- a/libs/search-widget/src/widgets/search-widget/SearchResults.scss
+++ b/libs/search-widget/src/widgets/search-widget/SearchResults.scss
@@ -32,7 +32,4 @@
   .results-container {
     flex-direction: row;
   }
-  .results.with-relations {
-    width: calc(100% - var(--rhythm-40) - var(--rhythm-2));
-  }
 }

--- a/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchResults.svelte
@@ -8,7 +8,6 @@
   import globalCss from '../../common/_global.scss?inline';
   import {
     _,
-    entityRelations,
     getResultUniqueKey,
     getTrackingDataAfterResultsReceived,
     hasMore,
@@ -28,7 +27,7 @@
     trackingReset
   } from '../../core';
   import InfiniteScroll from '../../common/infinite-scroll/InfiniteScroll.svelte';
-  import { InfoCard, InitialAnswer, onClosePreview, ResultRow, Viewer } from '../../components';
+  import { InitialAnswer, onClosePreview, ResultRow, Viewer } from '../../components';
   import { injectCustomCss } from '../../core/utils';
 
   export let cssPath = '';
@@ -103,8 +102,7 @@
       {/if}
       <div class="results-container">
         <div
-          class="results"
-          class:with-relations={$entityRelations.length > 0}>
+          class="results">
           {#if $isAnswerEnabled}
             <InitialAnswer />
           {/if}
@@ -125,9 +123,6 @@
             {/if}
           </div>
         </div>
-        {#if $entityRelations.length > 0}
-          <InfoCard entityRelations={$entityRelations} />
-        {/if}
       </div>
       {#if $showLoading}
         <LoadingDots />


### PR DESCRIPTION
Move relations out of the search results layout and display them in a modal instead, which is displayed when clicking on an info button next to the search bar.