### PR TITLE
Update documentation link

### DIFF
--- a/libs/sdk-core/README.md
+++ b/libs/sdk-core/README.md
@@ -4,7 +4,7 @@ Nuclia SDK is an open-source library wrapping Nuclia API in order to integrate [
 
 It supports both JavaScript and TypeScript.
 
-The full documentation is available at [https://docs.stashify.cloud/docs/docs/sdk/js-sdk/](https://docs.stashify.cloud/docs/docs/sdk/js-sdk/).
+The full documentation is available at [https://docs.nuclia.dev/docs/docs/sdk/js-sdk/](https://docs.nuclia.dev/docs/docs/sdk/js-sdk/).
 
 ## Basic usage
 


### PR DESCRIPTION
A quick fix I came across while browsing the docs. If I'm not mistaken, this file is what ends up being rendered to: https://docs.nuclia.dev/docs/guides/sdk/js-sdk/