### PR TITLE
[sc-8274] consistent language model on KB creation

### DIFF
--- a/libs/common/src/lib/kb-add/kb-add.component.html
+++ b/libs/common/src/lib/kb-add/kb-add.component.html
@@ -3,106 +3,111 @@
     {{ 'stash.create.title' | translate }}
   </pa-modal-title>
   <pa-modal-content>
-    <form
-      *ngIf="kbForm"
-      class="form-container"
-      [formGroup]="kbForm"
-      (ngSubmit)="save()">
-      <ng-container *ngIf="step === 0">
-        <pa-input
-          id="kb-title"
-          formControlName="title"
-          [errorMessages]="validationMessages['title']">
-          {{ 'stash.name' | translate }}
-        </pa-input>
+    @if (kbForm) {
+      <form
+        class="form-container"
+        [formGroup]="kbForm"
+        (ngSubmit)="save()">
+        @if (step === 0) {
+          <pa-input
+            id="kb-title"
+            formControlName="title"
+            [errorMessages]="validationMessages['title']">
+            {{ 'stash.name' | translate }}
+          </pa-input>
 
-        <pa-textarea
-          id="kb-description"
-          formControlName="description"
-          [rows]="4">
-          {{ 'generic.description' | translate }}
-        </pa-textarea>
+          <pa-textarea
+            id="kb-description"
+            formControlName="description"
+            [rows]="4">
+            {{ 'generic.description' | translate }}
+          </pa-textarea>
 
-        <div class="kb-add-separator"></div>
-        <div
-          class="kb-add-zone"
-          *ngIf="zones.length > 0">
-          <h4>{{ 'generic.zone' | translate }}</h4>
-          <div class="mb-24">{{ 'stash.create.zone_description' | translate }}</div>
-          <pa-select
-            formControlName="zone"
-            externalLabel
-            [readonly]="zones.length === 1"
-            class="kb-add-zone-select">
-            <pa-option
-              *ngFor="let zone of zones"
-              [value]="zone.slug">
-              {{ zone.title }}
-            </pa-option>
-          </pa-select>
-        </div>
-      </ng-container>
-
-      <ng-container *ngIf="step === 1">
-        <div
-          formGroupName="config"
-          class="learning-config">
-          <div *ngFor="let conf of displayedLearningConfigurations">
-            <h3>{{ 'stash.create.' + conf.id + '.label' | translate }}</h3>
-            <p>{{ 'stash.create.' + conf.id + '.help' | translate }}</p>
-            <pa-radio-group
-              [formControlName]="conf.id"
-              [name]="conf.id">
-              <pa-radio
-                *ngFor="let option of conf.data.options"
-                [value]="option.value">
-                {{ option | learningOption: conf.id }}
-              </pa-radio>
-            </pa-radio-group>
+          <div class="kb-add-separator"></div>
+          @if (zones.length > 0) {
+            <div class="kb-add-zone">
+              <h4>{{ 'generic.zone' | translate }}</h4>
+              <div class="mb-24">{{ 'stash.create.zone_description' | translate }}</div>
+              <pa-select
+                formControlName="zone"
+                externalLabel
+                [readonly]="zones.length === 1"
+                class="kb-add-zone-select">
+                @for (zone of zones; track zone.id) {
+                  <pa-option [value]="zone.slug">
+                    {{ zone.title }}
+                  </pa-option>
+                }
+              </pa-select>
+            </div>
+          }
+        } @else if (step === 1) {
+          <div
+            formGroupName="config"
+            class="learning-config">
+            <nus-language-field (languageSelected)="updateLanguages($event)"></nus-language-field>
+            @for (conf of displayedLearningConfigurations; track conf.id) {
+              <div>
+                <h3>{{ 'stash.create.' + conf.id + '.label' | translate }}</h3>
+                <p>{{ 'stash.create.' + conf.id + '.help' | translate }}</p>
+                <pa-radio-group
+                  [formControlName]="conf.id"
+                  [name]="conf.id">
+                  <pa-radio
+                    *ngFor="let option of conf.data.options"
+                    [value]="option.value">
+                    {{ option | learningOption: conf.id }}
+                  </pa-radio>
+                </pa-radio-group>
+              </div>
+            }
           </div>
-        </div>
-
-        <div
-          *ngIf="creationInProgress"
-          class="saving-spinner">
-          <nsi-spinner size="large"></nsi-spinner>
-          <p>{{ 'stash.create.in_progress' | translate }}</p>
-        </div>
-      </ng-container>
-    </form>
+          @if (creationInProgress) {
+            <div class="saving-spinner">
+              <nsi-spinner size="large"></nsi-spinner>
+              <p>{{ 'stash.create.in_progress' | translate }}</p>
+            </div>
+          }
+        }
+      </form>
+    }
   </pa-modal-content>
 
   <pa-modal-footer>
     <div class="kb-creation-footer">
-      <div
-        *ngIf="error"
-        class="error body-m">
-        {{ error | translate }}
-      </div>
+      @if (error) {
+        <div class="error body-m">
+          {{ error | translate }}
+        </div>
+      }
+
       <div class="footer-buttons">
-        <pa-button
-          *ngIf="step > 0"
-          aspect="basic"
-          [disabled]="saving"
-          (click)="back()">
-          {{ 'generic.back' | translate }}
-        </pa-button>
+        @if (step > 0) {
+          <pa-button
+            aspect="basic"
+            [disabled]="saving"
+            (click)="back()">
+            {{ 'generic.back' | translate }}
+          </pa-button>
+        }
 
-        <pa-button
-          *ngIf="step === lastStep"
-          type="submit"
-          kind="primary"
-          [disabled]="saving"
-          (click)="save()">
-          {{ 'generic.save' | translate }}
-        </pa-button>
+        @if (step === lastStep) {
+          <pa-button
+            type="submit"
+            kind="primary"
+            [disabled]="saving"
+            (click)="save()">
+            {{ 'generic.save' | translate }}
+          </pa-button>
+        }
 
-        <pa-button
-          *ngIf="step < lastStep"
-          [disabled]="step === 0 && kbForm?.invalid"
-          (click)="next()">
-          {{ 'generic.next' | translate }}
-        </pa-button>
+        @if (step < lastStep) {
+          <pa-button
+            [disabled]="step === 0 && kbForm?.invalid"
+            (click)="next()">
+            {{ 'generic.next' | translate }}
+          </pa-button>
+        }
       </div>
       <div class="steps">
         <small>{{ step + 1 }} / {{ totalSteps }}</small>

--- a/libs/common/src/lib/kb-add/kb-add.component.ts
+++ b/libs/common/src/lib/kb-add/kb-add.component.ts
@@ -156,7 +156,6 @@ export class KbAddComponent implements OnInit {
   }
 
   updateLanguages(data: { multilingualSelected: boolean; languages: string[] }) {
-    console.log(`updateLanguages`, data);
     this.multilingualSelected = data.multilingualSelected;
     this.languages = data.languages;
     this.cdr.markForCheck();

--- a/libs/common/src/lib/kb-add/kb-add.component.ts
+++ b/libs/common/src/lib/kb-add/kb-add.component.ts
@@ -1,9 +1,9 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { UntypedFormBuilder, UntypedFormGroup } from '@angular/forms';
-import { SDKService, STFUtils, Zone } from '@flaps/core';
+import { getSemanticModel, SDKService, STFUtils, Zone } from '@flaps/core';
 import { Sluggable } from '../validators';
 import { KnowledgeBoxSettingsService } from '../knowledge-box-settings';
-import { Account, KnowledgeBoxCreation, LearningConfiguration } from '@nuclia/core';
+import { Account, KnowledgeBoxCreation, LearningConfiguration, LearningConfigurations } from '@nuclia/core';
 import * as Sentry from '@sentry/angular';
 import { IErrorMessages, ModalRef } from '@guillotinaweb/pastanaga-angular';
 import { TranslateService } from '@ngx-translate/core';
@@ -37,6 +37,9 @@ export class KbAddComponent implements OnInit {
   error = '';
   zones: Zone[] = [];
   account?: Account;
+
+  multilingualSelected = true;
+  languages: string[] = [];
 
   private _lastStep = 1;
 
@@ -95,6 +98,18 @@ export class KbAddComponent implements OnInit {
       return acc;
     }, default_learning_configuration);
 
+    const learningConf = (this.learningConfigurations || []).reduce((acc, entry) => {
+      acc[entry.id] = entry.data;
+      return acc;
+    }, {} as LearningConfigurations);
+    learning_configuration['semantic_model'] = getSemanticModel(
+      {
+        languages: this.languages,
+        multilingual: this.multilingualSelected,
+      },
+      learningConf,
+    );
+
     const payload: KnowledgeBoxCreation = {
       slug: STFUtils.generateSlug(formValue.title),
       title: formValue.title,
@@ -140,8 +155,10 @@ export class KbAddComponent implements OnInit {
     this.cdr?.markForCheck();
   }
 
-  hasTranslation(key: string) {
-    const translation = this.translate.instant(key);
-    return translation !== key && translation !== '';
+  updateLanguages(data: { multilingualSelected: boolean; languages: string[] }) {
+    console.log(`updateLanguages`, data);
+    this.multilingualSelected = data.multilingualSelected;
+    this.languages = data.languages;
+    this.cdr.markForCheck();
   }
 }

--- a/libs/common/src/lib/kb-add/kb-add.module.ts
+++ b/libs/common/src/lib/kb-add/kb-add.module.ts
@@ -15,6 +15,7 @@ import { SisProgressModule } from '@nuclia/sistema';
 import { KnowledgeBoxSettingsModule } from '../knowledge-box-settings';
 
 import { KbAddComponent } from './kb-add.component';
+import { LanguageFieldComponent } from '@nuclia/user';
 
 @NgModule({
   imports: [
@@ -30,6 +31,7 @@ import { KbAddComponent } from './kb-add.component';
     PaTogglesModule,
     ReactiveFormsModule,
     SisProgressModule,
+    LanguageFieldComponent,
   ],
   declarations: [KbAddComponent],
   exports: [KbAddComponent],

--- a/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.service.ts
+++ b/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.service.ts
@@ -59,6 +59,7 @@ export class KnowledgeBoxSettingsService {
               (hasSummarization &&
                 (entry.id === SUMMARY_PROMPT || entry.id === 'summary' || entry.id === 'summary_model')) ||
               (entry.data.options &&
+                entry.id !== 'semantic_model' &&
                 entry.data.options.length > 1 &&
                 (entry.id !== 'anonymization_model' || hasAnonymization) &&
                 (entry.id !== 'visual_labeling' || hasPdfAnnotation)),

--- a/libs/common/src/lib/select-account-kb/select-kb/select-kb.component.scss
+++ b/libs/common/src/lib/select-account-kb/select-kb/select-kb.component.scss
@@ -47,7 +47,7 @@
     // Move scrollbar to the edge
     padding: 0 rhythm(2);
     margin: 0 -#{rhythm(2)};
-    max-height: calc(#{$height-page-container} - #{$vertical-padding} * 4 - #{rhythm(7)});
+    max-height: calc(#{$height-page-container} - #{$vertical-padding} * 4 - #{rhythm(9)});
     @include scrollbar-black();
   }
 

--- a/libs/core/src/lib/models/index.ts
+++ b/libs/core/src/lib/models/index.ts
@@ -1,5 +1,6 @@
 export * from './account.model';
 export * from './billing.model';
+export * from './kb.models';
 export * from './local.model';
 export * from './magic.model';
 export * from './permissions.model';

--- a/libs/core/src/lib/models/kb.models.ts
+++ b/libs/core/src/lib/models/kb.models.ts
@@ -1,0 +1,14 @@
+export type KbLanguageConf = {
+  multilingual: boolean;
+  languages: string[];
+};
+
+export type KbConfiguration = {
+  zoneSlug: string;
+  ownData: boolean;
+  dataset?: string;
+} & KbLanguageConf;
+
+export type AccountAndKbConfiguration = {
+  company: string;
+} & KbConfiguration;

--- a/libs/core/src/lib/utils/utils.ts
+++ b/libs/core/src/lib/utils/utils.ts
@@ -1,5 +1,7 @@
 import latinize from 'latinize';
 import { of, Subject } from 'rxjs';
+import { LearningConfigurations } from '@nuclia/core';
+import { KbLanguageConf } from '../models';
 
 export const MIN_PASSWORD_LENGTH = 8;
 
@@ -34,6 +36,23 @@ export function injectScript(url: string) {
     return isInit.asObservable();
   }
 }
+
+export function getSemanticModel(languageConf: KbLanguageConf, learningConfiguration: LearningConfigurations) {
+  const semanticModelName = !languageConf.multilingual
+    ? 'EN'
+    : languageConf.languages.includes('catalan') || languageConf.languages.includes('other')
+      ? 'MULTILINGUAL_ALPHA'
+      : 'MULTILINGUAL';
+  const semanticModel = learningConfiguration['semantic_model'].options?.find(
+    (model) => model.name === semanticModelName,
+  );
+  const defaultSemanticModel = learningConfiguration['semantic_model'].default;
+  if (!semanticModel) {
+    console.warn(`Semantic model ${semanticModelName} not found, using default model ${defaultSemanticModel}.`);
+  }
+  return semanticModel?.value || defaultSemanticModel;
+}
+
 export class STFUtils {
   // Generate a slug from arbitrary text.
   // Slugs only have alphanumeric lowercase characters (a-z, 0-9) and separators (-_)

--- a/libs/user/src/lib/index.ts
+++ b/libs/user/src/lib/index.ts
@@ -5,6 +5,7 @@ export * from './login/login.component';
 export * from './logout/logout.component';
 export * from './magic/magic.component';
 export * from './magic/magic.service';
+export * from './onboarding/language-field/language-field.component';
 export * from './onboarding/onboarding.component';
 export * from './onboarding/onboarding.models';
 export * from './onboarding/onboarding.service';

--- a/libs/user/src/lib/onboarding/language-field/language-field.component.html
+++ b/libs/user/src/lib/onboarding/language-field/language-field.component.html
@@ -1,0 +1,18 @@
+<div class="field">
+  <label class="title-s">{{ 'onboarding.step2.languages.label' | translate }}</label>
+  <pa-radio-group [formControl]="multilingual">
+    <pa-radio value="english">{{ 'onboarding.step2.languages.english' | translate }}</pa-radio>
+    <pa-radio value="multilingual">{{ 'onboarding.step2.languages.multilingual' | translate }}</pa-radio>
+  </pa-radio-group>
+  @if (multilingualSelected) {
+    <div class="second-choice languages-container">
+      @for (language of languages; track language.label) {
+        <pa-checkbox
+          [(value)]="language.selected"
+          (valueChange)="sendSelection()">
+          {{ language.label }}
+        </pa-checkbox>
+      }
+    </div>
+  }
+</div>

--- a/libs/user/src/lib/onboarding/language-field/language-field.component.scss
+++ b/libs/user/src/lib/onboarding/language-field/language-field.component.scss
@@ -1,0 +1,13 @@
+@import 'apps/dashboard/src/variables';
+
+.languages-container {
+  display: flex;
+  flex-wrap: wrap;
+  flex-direction: column;
+  max-height: rhythm(13);
+}
+
+.second-choice {
+  margin-top: rhythm(1);
+  padding-left: rhythm(3) + rhythm(0.5);
+}

--- a/libs/user/src/lib/onboarding/language-field/language-field.component.ts
+++ b/libs/user/src/lib/onboarding/language-field/language-field.component.ts
@@ -1,0 +1,87 @@
+import {
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  EventEmitter,
+  OnDestroy,
+  OnInit,
+  Output,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, ReactiveFormsModule } from '@angular/forms';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { Subject, takeUntil } from 'rxjs';
+import { PaTogglesModule } from '@guillotinaweb/pastanaga-angular';
+
+const LANGUAGES = [
+  'arabic',
+  'catalan',
+  'chinese',
+  'danish',
+  'english',
+  'finnish',
+  'french',
+  'german',
+  'italian',
+  'japanese',
+  'norwegian',
+  'portuguese',
+  'spanish',
+  'swedish',
+];
+
+@Component({
+  selector: 'nus-language-field',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, TranslateModule, PaTogglesModule],
+  templateUrl: './language-field.component.html',
+  styleUrl: './language-field.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LanguageFieldComponent implements OnInit, OnDestroy {
+  @Output() languageSelected = new EventEmitter<{ multilingualSelected: boolean; languages: string[] }>();
+
+  private unsubscribeAll = new Subject<void>();
+
+  multilingual = new FormControl<'multilingual' | 'english'>('multilingual', { nonNullable: true });
+  languages: { id: string; label: string; selected: boolean }[];
+
+  get multilingualSelected() {
+    return this.multilingual.value === 'multilingual';
+  }
+
+  constructor(
+    private translate: TranslateService,
+    private cdr: ChangeDetectorRef,
+  ) {
+    const languages: { id: string; label: string }[] = LANGUAGES.map((language) => ({
+      id: language,
+      label: this.translate.instant(`onboarding.step2.languages.${language}`),
+    })).sort((a, b) => a.label.localeCompare(b.label));
+    languages.push({ id: 'other', label: this.translate.instant(`onboarding.step2.languages.other`) });
+    this.languages = languages.map((language) => ({ ...language, selected: false }));
+  }
+
+  ngOnInit() {
+    this.multilingual.valueChanges.pipe(takeUntil(this.unsubscribeAll)).subscribe((language) => {
+      if (language === 'english') {
+        this.languages.forEach((language) => (language.selected = false));
+        this.cdr.markForCheck();
+      }
+
+      this.sendSelection();
+    });
+  }
+
+  ngOnDestroy() {
+    this.unsubscribeAll.next();
+    this.unsubscribeAll.complete();
+  }
+
+  sendSelection() {
+    this.languageSelected.emit({
+      multilingualSelected: this.multilingualSelected,
+      languages: this.languages.filter((language) => language.selected).map((language) => language.id),
+    });
+  }
+}

--- a/libs/user/src/lib/onboarding/onboarding.component.ts
+++ b/libs/user/src/lib/onboarding/onboarding.component.ts
@@ -1,8 +1,8 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { OnboardingService } from './onboarding.service';
-import { Zone, ZoneService } from '@flaps/core';
+import { KbConfiguration, Zone, ZoneService } from '@flaps/core';
 import { Observable } from 'rxjs';
-import { KbConfiguration, OnboardingPayload, OnboardingStep } from './onboarding.models';
+import { OnboardingPayload, OnboardingStep } from './onboarding.models';
 
 @Component({
   selector: 'nus-onboarding',

--- a/libs/user/src/lib/onboarding/onboarding.models.ts
+++ b/libs/user/src/lib/onboarding/onboarding.models.ts
@@ -8,18 +8,6 @@ export interface OnboardingPayload {
 }
 export type DatasetType = { id: string; title: string; description: string };
 
-export type KbConfiguration = {
-  zoneSlug: string;
-  multilingual: boolean;
-  languages: string[];
-  ownData: boolean;
-  dataset?: string;
-};
-
-export type AccountAndKbConfiguration = {
-  company: string;
-} & KbConfiguration;
-
 export interface OnboardingStatus {
   creating: boolean;
   accountCreated: boolean;

--- a/libs/user/src/lib/onboarding/step2/step2.component.html
+++ b/libs/user/src/lib/onboarding/step2/step2.component.html
@@ -23,20 +23,8 @@
       }
     </pa-radio-group>
   </div>
-  <div class="field">
-    <label class="title-s">{{ 'onboarding.step2.languages.label' | translate }}</label>
-    <pa-radio-group formControlName="multilingual">
-      <pa-radio value="english">{{ 'onboarding.step2.languages.english' | translate }}</pa-radio>
-      <pa-radio value="multilingual">{{ 'onboarding.step2.languages.multilingual' | translate }}</pa-radio>
-    </pa-radio-group>
-    @if (multilingualSelected) {
-      <div class="second-choice languages-container">
-        @for (language of languages; track language.label) {
-          <pa-checkbox [(value)]="language.selected">{{ language.label }}</pa-checkbox>
-        }
-      </div>
-    }
-  </div>
+  <nus-language-field (languageSelected)="updateLanguages($event)"></nus-language-field>
+
   @if (datasets.length > 0) {
     <div class="field">
       <label class="title-s">{{ 'onboarding.step2.starting-data.label' | translate }}</label>

--- a/libs/user/src/lib/onboarding/step2/step2.component.scss
+++ b/libs/user/src/lib/onboarding/step2/step2.component.scss
@@ -1,17 +1,5 @@
 @import 'apps/dashboard/src/variables';
 
-.languages-container {
-  display: flex;
-  flex-wrap: wrap;
-  flex-direction: column;
-  max-height: rhythm(13);
-}
-
-.second-choice {
-  margin-top: rhythm(1);
-  padding-left: rhythm(3) + rhythm(0.5);
-}
-
 .consent {
   align-items: center;
   display: flex;

--- a/libs/user/src/lib/user-container/user-container.component.scss
+++ b/libs/user/src/lib/user-container/user-container.component.scss
@@ -32,6 +32,6 @@
 @media (max-height: $height-viewport-medium-max) {
   .user-background .user-container.top-aligned-small {
     align-items: start;
-    padding-top: rhythm(10);
+    padding-top: rhythm(12);
   }
 }


### PR DESCRIPTION
- Create a standalone component for language field in KB creation
- Move function allowing to get KB configuration from backend configuration and user’s choices to the core lib.
- Update KB création dialog to use the new language-field component
- Fix KB creation from onboarding by passing account id instead of account slug (have been broken during SDK clean up)