### PR TITLE
[sc-8764] Add listenToResourceOperationNotifications method

### DIFF
--- a/libs/common/src/lib/notifications/notification.service.ts
+++ b/libs/common/src/lib/notifications/notification.service.ts
@@ -20,6 +20,9 @@ export class NotificationService {
     private sdk: SDKService,
     private navigationService: NavigationService,
   ) {
+    // TODO: cleanup, this is for test purpose
+    this.sdk.currentKb.pipe(switchMap((kb) => kb.listenToResourceOperationNotifications())).subscribe(console.log);
+
     combineLatest([this.sdk.currentAccount, this.sdk.currentKb])
       .pipe(
         switchMap(([account, kb]) =>

--- a/libs/common/src/lib/notifications/notification.service.ts
+++ b/libs/common/src/lib/notifications/notification.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { BehaviorSubject, combineLatest, map, Observable, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, combineLatest, map, Observable, switchMap, take, tap } from 'rxjs';
 import { NotificationData, NotificationUI } from './notification.model';
 import { SDKService } from '@flaps/core';
 import { NavigationService } from '../services';
@@ -20,9 +20,6 @@ export class NotificationService {
     private sdk: SDKService,
     private navigationService: NavigationService,
   ) {
-    // TODO: cleanup, this is for test purpose
-    this.sdk.currentKb.pipe(switchMap((kb) => kb.listenToResourceOperationNotifications())).subscribe(console.log);
-
     combineLatest([this.sdk.currentAccount, this.sdk.currentKb])
       .pipe(
         switchMap(([account, kb]) =>
@@ -73,5 +70,9 @@ export class NotificationService {
 
   deleteAll() {
     this._notifications.next([]);
+  }
+
+  stopListening() {
+    this.sdk.currentKb.pipe(take(1)).subscribe((kb) => kb.stopListeningToNotifications());
   }
 }

--- a/libs/common/src/lib/notifications/notifications-panel/notifications-panel.component.ts
+++ b/libs/common/src/lib/notifications/notifications-panel/notifications-panel.component.ts
@@ -5,6 +5,7 @@ import {
   EventEmitter,
   inject,
   Input,
+  OnDestroy,
   Output,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -23,7 +24,7 @@ import { NotificationService } from '../notification.service';
   styleUrl: './notifications-panel.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class NotificationsPanelComponent {
+export class NotificationsPanelComponent implements OnDestroy {
   private notificationsService = inject(NotificationService);
 
   @Input({ transform: booleanAttribute }) isOpen = false;
@@ -39,5 +40,9 @@ export class NotificationsPanelComponent {
   onClose() {
     this.notificationsService.markAllAsRead();
     this.close.emit();
+  }
+
+  ngOnDestroy() {
+    this.notificationsService.stopListening();
   }
 }

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 1.11.5 (2024-02-05)
+
+### Improvements
+
+- Add `listenToResourceOperationNotifications` method which is sending notifications about resource creation, modification and deletion.
+- Update `listenToProcessingNotifications` documentation to clarify that notifications are sent anytime processing is done, which occurs for both resource creation and modification.
+
 # 1.11.4 (2024-02-05)
 
 ### Improvements

--- a/libs/sdk-core/package.json
+++ b/libs/sdk-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuclia/core",
-  "version": "1.11.4",
+  "version": "1.11.5",
   "description": "SDK allowing to integrate Nuclia services in your frontend application",
   "license": "MIT",
   "keywords": [

--- a/libs/sdk-core/src/lib/db/kb/kb.models.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.models.ts
@@ -4,7 +4,7 @@ import type { FileMetadata, FileWithMetadata, UploadResponse, UploadStatus } fro
 import type { Chat, ChatOptions, Search, SearchOptions } from '../search';
 import type { IErrorResponse } from '../../models';
 import type { ResourceProperties } from '../db.models';
-import { NotificationMessage } from '../notifications';
+import { NotificationMessage, NotificationOperation } from '../notifications';
 
 export type KBStates = 'PUBLISHED' | 'PRIVATE';
 export type KBRoles = 'SOWNER' | 'SCONTRIBUTOR' | 'SMEMBER';
@@ -152,6 +152,7 @@ export interface IKnowledgeBox extends IKnowledgeBoxCreation {
 
   listenToAllNotifications(): Observable<NotificationMessage[]>;
   listenToProcessingNotifications(): Observable<ResourceProcessingNotification[]>;
+  listenToResourceOperationNotifications(): Observable<ResourceOperationNotification[]>;
   stopListeningToNotifications(): void;
 
   processingStatus(
@@ -384,9 +385,13 @@ export interface ProcessingStatus {
   title: string;
 }
 
-export interface ResourceProcessingNotification {
+export interface ResourceBaseNotification {
   resourceId: string;
   resourceTitle: string;
   timestamp: string;
   success: boolean;
 }
+export interface ResourceOperationNotification extends ResourceBaseNotification {
+  operation: NotificationOperation;
+}
+export type ResourceProcessingNotification = ResourceBaseNotification;

--- a/libs/sdk-core/src/lib/db/kb/kb.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.ts
@@ -631,7 +631,7 @@ export class KnowledgeBox implements IKnowledgeBox {
       map((notifications) => {
         notifications.forEach((message) => {
           const data = message.data;
-          if (!this.resourceOperationStatus[data.resource_uuid] || message.type === 'resource_written') {
+          if (!this.resourceOperationStatus[data.resource_uuid] && message.type === 'resource_written') {
             this.resourceOperationStatus[data.resource_uuid] = {
               seqid: data.seqid,
               resource_title: data.resource_title,
@@ -639,14 +639,16 @@ export class KnowledgeBox implements IKnowledgeBox {
               sequence: [],
             };
           }
-          if (message.type === 'resource_indexed') {
-            this.resourceOperationStatus[data.resource_uuid].indexedNotificationCount++;
-          } else {
-            this.resourceOperationStatus[data.resource_uuid] = {
-              ...this.resourceOperationStatus[data.resource_uuid],
-              ...data,
-              sequence: [...this.resourceOperationStatus[data.resource_uuid].sequence, message.type],
-            };
+          if (this.resourceOperationStatus[data.resource_uuid]) {
+            if (message.type === 'resource_indexed') {
+              this.resourceOperationStatus[data.resource_uuid].indexedNotificationCount++;
+            } else {
+              this.resourceOperationStatus[data.resource_uuid] = {
+                ...this.resourceOperationStatus[data.resource_uuid],
+                ...data,
+                sequence: [...this.resourceOperationStatus[data.resource_uuid].sequence, message.type],
+              };
+            }
           }
         });
         return Object.entries(this.resourceOperationStatus).reduce((notificationList, [resourceId, data]) => {

--- a/libs/sdk-core/src/lib/db/kb/kb.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.ts
@@ -668,6 +668,10 @@ export class KnowledgeBox implements IKnowledgeBox {
           return notificationList;
         }, [] as ResourceOperationNotification[]);
       }),
+      tap((notificationList) => {
+        // clean up resource status when notification is sent
+        notificationList.forEach((item) => delete this.resourceOperationStatus[item.resourceId]);
+      }),
     );
   }
 


### PR DESCRIPTION
- Add `listenToResourceOperationNotifications` method which is sending notifications about resource creation, modification and deletion.
- Update `listenToProcessingNotifications` documentation to clarify that notifications are sent anytime processing is done, which occurs for both resource creation and modification.