### PR TITLE
Prevent sanitizing chevrons from prompts

### DIFF
--- a/libs/common/src/lib/ai-models/ai-models.component.html
+++ b/libs/common/src/lib/ai-models/ai-models.component.html
@@ -102,6 +102,7 @@
                           <pa-textarea
                             formControlName="prompt"
                             resizable
+                            acceptHtmlTags
                             [rows]="3"
                             [help]="prompt.info || ''">
                             {{ prompt.title }}
@@ -132,6 +133,7 @@
                           <pa-textarea
                             formControlName="system"
                             resizable
+                            acceptHtmlTags
                             [rows]="3"
                             [help]="system.info || ''">
                             {{ 'kb.ai-models.generative_model.system_prompt_label' | translate }}

--- a/libs/common/src/lib/ai-models/ai-models.component.scss
+++ b/libs/common/src/lib/ai-models/ai-models.component.scss
@@ -42,7 +42,7 @@
     }
 
     pa-radio-group {
-      max-height: rhythm(10);
+      max-height: rhythm(20);
       flex-wrap: wrap;
       pa-radio {
         break-inside: avoid;

--- a/libs/common/src/lib/prompt-lab/prompt-lab.component.html
+++ b/libs/common/src/lib/prompt-lab/prompt-lab.component.html
@@ -66,6 +66,7 @@
           <div class="field-and-button">
             <pa-textarea
               resizable
+              acceptHtmlTags
               rows="3"
               [(value)]="currentPrompt"
               [help]="'prompt-lab.configuration.prompts.placeholder' | translate"


### PR DESCRIPTION
Also increase radio-group max-height for models to stay displayed on two columns (we added quite a lot of models lately)