### PR TITLE
[sc-9223] display only aws zones on aws accounts

### DIFF
--- a/apps/dashboard/src/app/account/billing/subscriptions/aws-subscription/aws-subscription.component.ts
+++ b/apps/dashboard/src/app/account/billing/subscriptions/aws-subscription/aws-subscription.component.ts
@@ -10,13 +10,11 @@ import { map } from 'rxjs';
 })
 export class AwsSubscriptionComponent {
   awsUrl = this.billing
-    .getSubscription()
+    .getAwsSubscription()
     .pipe(
       map(
         (subscription) =>
-          `https://console.aws.amazon.com/marketplace/home#/subscriptions/${
-            subscription?.subscription?.aws_product_code || ''
-          }`,
+          `https://console.aws.amazon.com/marketplace/home#/subscriptions/${subscription?.aws_product_code || ''}`,
       ),
     );
 

--- a/apps/dashboard/src/app/account/billing/usage/budget.component.html
+++ b/apps/dashboard/src/app/account/billing/usage/budget.component.html
@@ -1,7 +1,6 @@
 <div class="budget">
   <pa-input
     type="number"
-    externalLabel
     [formControl]="budget">
     @if (usage) {
       {{ usage.currency === 'USD' ? '$' : '€' }}

--- a/apps/dashboard/src/app/account/billing/usage/budget.component.ts
+++ b/apps/dashboard/src/app/account/billing/usage/budget.component.ts
@@ -26,14 +26,17 @@ export class BudgetComponent {
   }
 
   saveBudget() {
-    this.billing
-      .modifySubscription({ on_demand_budget: parseInt(this.budget.value) })
+    this.isSubscribedToAws
       .pipe(
-        switchMap(() => this.getBudget()),
-        catchError((error) => {
-          this.toaster.error('generic.error.oops');
-          throw error;
-        }),
+        switchMap((isAws) =>
+          this.billing.modifySubscription({ on_demand_budget: parseInt(this.budget.value) }, isAws).pipe(
+            switchMap(() => this.getBudget()),
+            catchError((error) => {
+              this.toaster.error('generic.error.oops');
+              throw error;
+            }),
+          ),
+        ),
       )
       .subscribe((budget) => {
         this.budget.setValue(budget.toString());

--- a/apps/dashboard/src/app/onboarding/aws-onboarding/aws-onboarding.component.ts
+++ b/apps/dashboard/src/app/onboarding/aws-onboarding/aws-onboarding.component.ts
@@ -34,7 +34,7 @@ export class AwsOnboardingComponent {
 
   setupBudget(data: { budget: number | null }) {
     const request: Observable<void | boolean> =
-      data.budget !== null ? this.billing.modifySubscription({ on_demand_budget: data.budget }) : of(true);
+      data.budget !== null ? this.billing.modifySubscription({ on_demand_budget: data.budget }, true) : of(true);
     request.subscribe({
       next: () => {
         this.step = 2;

--- a/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.component.html
+++ b/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.component.html
@@ -28,7 +28,7 @@
           <pa-input
             formControlName="title"
             [errorMessages]="validationMessages['title']">
-            {{ 'kb.name' | translate }}
+            {{ 'kb.form.name' | translate }}
           </pa-input>
 
           <pa-textarea

--- a/libs/core/src/lib/api/billing.service.ts
+++ b/libs/core/src/lib/api/billing.service.ts
@@ -5,6 +5,7 @@ import { AccountTypes } from '@nuclia/core';
 import {
   AccountSubscription,
   AccountUsage,
+  AwsAccountSubscription,
   BillingDetails,
   Currency,
   InvoicesList,
@@ -95,6 +96,7 @@ export class BillingService {
       ),
       map((data) => {
         if (!data.hasOwnProperty('provider')) {
+          // Backward compatibility: when there is no provider, it's an old STRIPE subscription
           return {
             provider: 'STRIPE',
             subscription: data,
@@ -113,10 +115,22 @@ export class BillingService {
         if (!data || data.provider !== 'STRIPE') {
           return null;
         } else {
-          return data.subscription;
+          return data.subscription as StripeAccountSubscription;
         }
       }),
       catchError(() => of(null)),
+    );
+  }
+
+  getAwsSubscription(): Observable<AwsAccountSubscription | null> {
+    return this.getSubscription().pipe(
+      map((data) => {
+        if (!data || data.provider !== 'AWS_MARKETPLACE') {
+          return null;
+        } else {
+          return data.subscription as AwsAccountSubscription;
+        }
+      }),
     );
   }
 

--- a/libs/core/src/lib/api/billing.service.ts
+++ b/libs/core/src/lib/api/billing.service.ts
@@ -129,10 +129,12 @@ export class BillingService {
     );
   }
 
-  modifySubscription(data: { on_demand_budget: number }) {
+  modifySubscription(data: { on_demand_budget: number }, isAws = false) {
     return this.sdk.currentAccount.pipe(
       take(1),
-      switchMap((account) => this.sdk.nuclia.rest.patch<void>(`/billing/account/${account.id}/subscription`, data)),
+      switchMap((account) =>
+        this.sdk.nuclia.rest.patch<void>(`/billing/account/${account.id}${isAws ? '/aws' : ''}/subscription`, data),
+      ),
     );
   }
 

--- a/libs/core/src/lib/api/sdk.service.ts
+++ b/libs/core/src/lib/api/sdk.service.ts
@@ -47,6 +47,7 @@ export class SDKService {
   private _repetitiveRefreshCounter = new Subject<void>();
   private _isKbLoaded = false;
 
+  hasAccount = this._account.pipe(map((account) => account !== null));
   hasKb = this._kb.pipe(map((kb) => kb !== null));
   currentKb = this._currentKB.asObservable();
   kbList: Observable<IKnowledgeBoxItem[]> = this._kbList.asObservable();

--- a/libs/core/src/lib/models/billing.model.ts
+++ b/libs/core/src/lib/models/billing.model.ts
@@ -83,16 +83,22 @@ export enum CancellationFeedback {
 
 export interface AccountSubscription {
   provider: 'STRIPE' | 'AWS_MARKETPLACE';
-  subscription: StripeAccountSubscription;
+  subscription: StripeAccountSubscription | AwsAccountSubscription;
 }
 
-export interface StripeAccountSubscription {
+interface BaseAccountSubscription {
   status: SubscriptionStatus;
   on_demand_budget: number;
+}
+
+export interface StripeAccountSubscription extends BaseAccountSubscription {
   billing_interval: RecurrentPriceInterval;
   start_billing_period: string;
   end_billing_period: string;
-  aws_product_code?: string;
+}
+
+export interface AwsAccountSubscription extends BaseAccountSubscription {
+  aws_product_code: string;
 }
 
 export interface StripeSubscriptionCreation {

--- a/libs/user/src/lib/onboarding/onboarding.component.ts
+++ b/libs/user/src/lib/onboarding/onboarding.component.ts
@@ -11,7 +11,7 @@ import { OnboardingPayload, OnboardingStep } from './onboarding.models';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class OnboardingComponent {
-  zones: Observable<Zone[]> = this.zoneService.getZones(true);
+  zones: Observable<Zone[]> = this.zoneService.getZones();
   onboardingStep: Observable<OnboardingStep> = this.onboardingService.onboardingStep;
 
   private step1Data?: OnboardingPayload;


### PR DESCRIPTION
- Fix `getZones` method
  - return all zones when there is no account (regular onboarding)
  - return all zones when there is an error while get the account subscription
  - return all zones when the subscription is not AWS
  - return only AWS zones when subscription is AWS and the environment is not dev or stage.
- Fix subscription update for AWS
- [sc-9199]: Separate AWS model properties from StripeAccountSubscription
