### PR TITLE
[sc-9361] Add management of allowed CORS domains in KB settings page

### DIFF
--- a/libs/common/common.babel
+++ b/libs/common/common.babel
@@ -12186,6 +12186,57 @@
 							<folder_node>
 								<name>form</name>
 								<children>
+									<folder_node>
+										<name>allowed_origins</name>
+										<children>
+											<concept_node>
+												<name>help</name>
+												<description/>
+												<comment/>
+												<translations>
+													<translation>
+														<language>ca-ES</language>
+														<approved>false</approved>
+													</translation>
+													<translation>
+														<language>en-US</language>
+														<approved>false</approved>
+													</translation>
+													<translation>
+														<language>es-ES</language>
+														<approved>false</approved>
+													</translation>
+													<translation>
+														<language>fr-FR</language>
+														<approved>false</approved>
+													</translation>
+												</translations>
+											</concept_node>
+											<concept_node>
+												<name>label</name>
+												<description/>
+												<comment/>
+												<translations>
+													<translation>
+														<language>ca-ES</language>
+														<approved>false</approved>
+													</translation>
+													<translation>
+														<language>en-US</language>
+														<approved>false</approved>
+													</translation>
+													<translation>
+														<language>es-ES</language>
+														<approved>false</approved>
+													</translation>
+													<translation>
+														<language>fr-FR</language>
+														<approved>false</approved>
+													</translation>
+												</translations>
+											</concept_node>
+										</children>
+									</folder_node>
 									<concept_node>
 										<name>existing-name</name>
 										<description/>

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -510,6 +510,8 @@
 	"kb.create.in_progress": "Creació de la Knowledge Box en curs...",
 	"kb.create.invalid_name": "El nom de la Knowledge Box no és vàlid",
 	"kb.create.title": "Crea una Knowledge Box",
+	"kb.form.allowed_origins.help": "Un domini per línia",
+	"kb.form.allowed_origins.label": "Orígens permesos (CORS)",
 	"kb.form.existing-name": "Aquest nom de Knowledge Box ja existeix al compte.",
 	"kb.form.invalid-slug": "El Knowledge Box slug no és vàlid",
 	"kb.form.name": "Nom de la Knowledge Box",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -511,6 +511,8 @@
 	"kb.create.in_progress": "Knowledge Box creation in progress…",
 	"kb.create.invalid_name": "Invalid Knowledge Box name",
 	"kb.create.title": "Create a Knowledge Box",
+	"kb.form.allowed_origins.help": "One domain per line",
+	"kb.form.allowed_origins.label": "Allowed origins (CORS)",
 	"kb.form.existing-name": "This Knowledge Box name already exists in the account.",
 	"kb.form.invalid-slug": "Invalid Knowledge Box slug",
 	"kb.form.name": "Knowledge Box name",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -510,6 +510,8 @@
 	"kb.create.in_progress": "Creación de la Knowledge Box en curso...",
 	"kb.create.invalid_name": "El nombre de la Knowledge Box no es válido",
 	"kb.create.title": "Crea una Knowledge Box",
+	"kb.form.allowed_origins.help": "Un dominio por línea",
+	"kb.form.allowed_origins.label": "Orígenes permitidos (CORS)",
 	"kb.form.existing-name": "Este nombre de Knowledge Box ya existe en la cuenta.",
 	"kb.form.invalid-slug": "El Knowledge Box slug no es válido",
 	"kb.form.name": "Nombre de la Knowledge Box",

--- a/libs/common/src/assets/i18n/fr.json
+++ b/libs/common/src/assets/i18n/fr.json
@@ -511,6 +511,8 @@
 	"kb.create.in_progress": "Création de la Knowledge Box en cours…",
 	"kb.create.invalid_name": "Nom de la Knowledge Box invalide",
 	"kb.create.title": "Créer une Knowledge Box",
+	"kb.form.allowed_origins.help": "Un domaine par ligne",
+	"kb.form.allowed_origins.label": "Origines autorisées (CORS)",
 	"kb.form.existing-name": "Ce nom de Knowledge Box existe déjà dans le compte.",
 	"kb.form.invalid-slug": "Knowledge Box slug invalide",
 	"kb.form.name": "Nom de la Knowledge Box",

--- a/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.component.html
+++ b/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.component.html
@@ -33,8 +33,17 @@
 
           <pa-textarea
             formControlName="description"
+            resizable
             [rows]="4">
             {{ 'generic.description' | translate }}
+          </pa-textarea>
+
+          <pa-textarea
+            formControlName="allowed_origins"
+            help="kb.form.allowed_origins.help"
+            rows="3"
+            resizable>
+            {{ 'kb.form.allowed_origins.label' | translate }}
           </pa-textarea>
 
           @if (kb?.state?.toLowerCase(); as state) {

--- a/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.component.ts
+++ b/libs/common/src/lib/knowledge-box-settings/knowledge-box-settings.component.ts
@@ -25,6 +25,7 @@ export class KnowledgeBoxSettingsComponent implements OnInit, OnDestroy {
     slug: new FormControl<string>('', { nonNullable: true, validators: [Sluggable(true)] }),
     title: new FormControl<string>('', { nonNullable: true, validators: [Validators.required] }),
     description: new FormControl<string>('', { nonNullable: true }),
+    allowed_origins: new FormControl<string | null>(null),
   });
 
   validationMessages: { [key: string]: IErrorMessages } = {
@@ -69,6 +70,7 @@ export class KnowledgeBoxSettingsComponent implements OnInit, OnDestroy {
         slug: this.kb.slug,
         title: this.kb.title,
         description: this.kb.description || '',
+        allowed_origins: (this.kb.allowed_origins || []).join('\n'),
       });
       this.kbForm.markAsPristine();
       this.cdr.markForCheck();
@@ -87,12 +89,17 @@ export class KnowledgeBoxSettingsComponent implements OnInit, OnDestroy {
     const newSlug = STFUtils.generateSlug(kbDetails.slug);
     const oldSlug = kbBackup.slug || '';
     const isSlugUpdated = newSlug !== oldSlug;
+    const origins = kbDetails.allowed_origins
+      ?.split('\n')
+      .map((origin) => origin.trim())
+      .filter((origin) => !!origin);
 
     kbBackup
       .modify({
         title: kbDetails.title,
         description: kbDetails.description,
         slug: newSlug,
+        allowed_origins: !!origins && origins.length > 0 ? origins : null,
       })
       .pipe(
         tap(() => this.toast.success(this.translate.instant('kb.settings.toasts.success'))),

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -1,8 +1,9 @@
-# 1.14.3 (2024-03-18)
+# 1.14.3 (unreleased)
 
 ### Improvements
 
 - Knowledge Box `title` and `slug` are required fields in `IKnowledgeBoxCreation` model
+- Adding optional `allowed_origins` field in `IKnowledgeBoxCreation` model
 
 # 1.14.2 (2024-03-15)
 

--- a/libs/sdk-core/src/lib/db/kb/kb.models.ts
+++ b/libs/sdk-core/src/lib/db/kb/kb.models.ts
@@ -35,6 +35,7 @@ export interface IKnowledgeBoxCreation {
   description?: string;
   zone: string;
   uuid?: string;
+  allowed_origins?: string[] | null;
 }
 
 export interface IKnowledgeBoxItem extends IKnowledgeBoxCreation {


### PR DESCRIPTION
The frontend is fully ready, but resetting the field doesn't work yet (Core services team is aware and working on a fix)