### PR TITLE
[sc-9515]: Replace slug by region in KB details

### DIFF
--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.html
@@ -87,19 +87,11 @@
               <pre><code>{{ uid | async }}</code></pre>
             </div>
           </div>
+
           <div>
-            <div class="title-xxs">{{ 'dashboard-home.kb-details.slug' | translate }}</div>
-            <div class="details-block">
-              @if (clipboardSupported) {
-                <pa-button
-                  aspect="basic"
-                  size="small"
-                  [icon]="copyIcon.slug"
-                  (click)="copySlug()">
-                  {{ 'generic.copy' | translate }}
-                </pa-button>
-              }
-              <pre><code>{{ slug | async }}</code></pre>
+            <div class="title-xxs">{{ 'dashboard-home.kb-details.region' | translate }}</div>
+            <div class="body-s">
+              {{ zone | async }}
             </div>
           </div>
           @if (configuration | async; as config) {

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.spec.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.spec.ts
@@ -4,10 +4,9 @@ import { KnowledgeBoxHomeComponent } from './knowledge-box-home.component';
 import { of } from 'rxjs';
 import { TranslateLoader, TranslateModule } from '@ngx-translate/core';
 import * as EN from '../../../../../../libs/common/src/assets/i18n/en.json';
-import { RouterTestingModule } from '@angular/router/testing';
 import { MockComponent, MockModule, MockProvider } from 'ng-mocks';
 import { AppService, UploadModule, UploadService } from '@flaps/common';
-import { FeaturesService, NavigationService, SDKService, STFTrackingService } from '@flaps/core';
+import { FeaturesService, NavigationService, SDKService, STFTrackingService, ZoneService } from '@flaps/core';
 import { MetricsService } from '../../account/metrics.service';
 import { DropdownButtonComponent, HomeContainerComponent, SisModalService } from '@nuclia/sistema';
 import { Account, WritableKnowledgeBox } from '@nuclia/core';
@@ -15,6 +14,7 @@ import { KbMetricsComponent } from './kb-metrics/kb-metrics.component';
 import { PaButtonModule, PaDropdownModule, PaTableModule } from '@guillotinaweb/pastanaga-angular';
 import { UsageChartsComponent } from './kb-usage/usage-charts.component';
 import { AccountStatusComponent } from '../../account/account-status/account-status.component';
+import { RouterModule } from '@angular/router';
 
 function createTranslateLoader() {
   return {
@@ -30,7 +30,6 @@ describe('KnowledgeBoxHomeComponent', () => {
     TestBed.configureTestingModule({
       declarations: [KnowledgeBoxHomeComponent],
       imports: [
-        RouterTestingModule,
         TranslateModule.forRoot({
           loader: {
             provide: TranslateLoader,
@@ -42,6 +41,7 @@ describe('KnowledgeBoxHomeComponent', () => {
         MockModule(PaButtonModule),
         MockModule(PaDropdownModule),
         MockModule(PaTableModule),
+        MockModule(RouterModule),
         MockModule(UploadModule),
         MockComponent(DropdownButtonComponent),
         MockComponent(AccountStatusComponent),
@@ -80,6 +80,7 @@ describe('KnowledgeBoxHomeComponent', () => {
         }),
         MockProvider(MetricsService),
         MockProvider(SisModalService),
+        MockProvider(ZoneService),
       ],
     }).compileComponents();
   }));

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, OnDestroy } from '@angular/core';
-import { FeaturesService, NavigationService, SDKService, STFTrackingService } from '@flaps/core';
+import { FeaturesService, NavigationService, SDKService, STFTrackingService, ZoneService } from '@flaps/core';
 import { AppService, searchResources, STATUS_FACET, UploadService } from '@flaps/common';
 import { MetricsService } from '../../account/metrics.service';
 import { SisModalService } from '@nuclia/sistema';
@@ -35,6 +35,12 @@ export class KnowledgeBoxHomeComponent implements OnDestroy {
   endpoint = this.currentKb.pipe(map((kb) => kb.fullpath));
   uid = this.currentKb.pipe(map((kb) => kb.id));
   slug = this.currentKb.pipe(map((kb) => kb.slug));
+  zone = combineLatest([this.currentKb, this.zoneService.getZones()]).pipe(
+    map(([kb, zones]) => {
+      const zone = zones.find((zone) => zone.slug === kb.zone);
+      return zone?.title || kb.zone;
+    }),
+  );
   stateLabel: Observable<string> = this.currentKb.pipe(
     map((kb) => kb.state),
     map((state) => (state ? `dashboard-home.state.${state.toLowerCase()}` : '')),
@@ -140,6 +146,7 @@ export class KnowledgeBoxHomeComponent implements OnDestroy {
     private uploadService: UploadService,
     private metrics: MetricsService,
     private modal: SisModalService,
+    private zoneService: ZoneService,
   ) {}
 
   ngOnDestroy() {
@@ -155,11 +162,6 @@ export class KnowledgeBoxHomeComponent implements OnDestroy {
   copyUid() {
     this.tracking.logEvent('home_page_copy', { data: 'uid' });
     this.uid.pipe(take(1)).subscribe((uid) => this.copyToClipboard('uid', uid));
-  }
-
-  copySlug() {
-    this.tracking.logEvent('home_page_copy', { data: 'slug' });
-    this.slug.pipe(take(1)).subscribe((slug) => this.copyToClipboard('slug', slug || ''));
   }
 
   private copyToClipboard(type: 'endpoint' | 'uid' | 'slug', text: string) {

--- a/libs/common/common.babel
+++ b/libs/common/common.babel
@@ -6963,7 +6963,7 @@
 										</translations>
 									</concept_node>
 									<concept_node>
-										<name>slug</name>
+										<name>region</name>
 										<description/>
 										<comment/>
 										<translations>

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -292,7 +292,7 @@
 	"dashboard-home.kb-content.processing-queue.title": "Cua de processament",
 	"dashboard-home.kb-details.endpoint": "NucliaDB API endpoint",
 	"dashboard-home.kb-details.generative-model": "Model generatiu",
-	"dashboard-home.kb-details.slug": "Knowledge Box slug",
+	"dashboard-home.kb-details.region": "Regió de la Knowledge Box",
 	"dashboard-home.kb-details.title": "Detalls de la Knowledge Box ",
 	"dashboard-home.kb-details.uid": "Knowledge Box UID",
 	"dashboard-home.kb-metrics.title": "Contingut de la Knowledge Box",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -293,7 +293,7 @@
 	"dashboard-home.kb-content.processing-queue.title": "Processing queue",
 	"dashboard-home.kb-details.endpoint": "NucliaDB API endpoint",
 	"dashboard-home.kb-details.generative-model": "Generative model",
-	"dashboard-home.kb-details.slug": "Knowledge Box slug",
+	"dashboard-home.kb-details.region": "Knowledge Box region",
 	"dashboard-home.kb-details.title": "Knowledge Box details",
 	"dashboard-home.kb-details.uid": "Knowledge Box UID",
 	"dashboard-home.kb-metrics.title": "Knowledge Box content",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -292,7 +292,7 @@
 	"dashboard-home.kb-content.processing-queue.title": "Cola de procesamiento",
 	"dashboard-home.kb-details.endpoint": "NucliaDB API endpoint",
 	"dashboard-home.kb-details.generative-model": "Modelo generativo",
-	"dashboard-home.kb-details.slug": "Knowledge Box slug",
+	"dashboard-home.kb-details.region": "Región de la Knowledge Box ",
 	"dashboard-home.kb-details.title": "Detalles del Knowledge Box ",
 	"dashboard-home.kb-details.uid": "Knowledge Box UID",
 	"dashboard-home.kb-metrics.title": "Contenido del Knowledge Box",

--- a/libs/common/src/assets/i18n/fr.json
+++ b/libs/common/src/assets/i18n/fr.json
@@ -293,7 +293,7 @@
 	"dashboard-home.kb-content.processing-queue.title": "File d'attente de traitement",
 	"dashboard-home.kb-details.endpoint": "NucliaDB API endpoint",
 	"dashboard-home.kb-details.generative-model": "Modèle génératif",
-	"dashboard-home.kb-details.slug": "Knowledge Box slug",
+	"dashboard-home.kb-details.region": "Région de la Knowledge Box",
 	"dashboard-home.kb-details.title": "Détails de la Knowledge Box ",
 	"dashboard-home.kb-details.uid": "Knowledge Box UID",
 	"dashboard-home.kb-metrics.title": "Contenu de la Knowledge Box",


### PR DESCRIPTION
In the dashboard home page, we removed the KB slug, and we added the KB region in the KB details block.