### PR TITLE
[sc-9421] new sync page fixes

### DIFF
--- a/libs/common/src/lib/tasks-automation/task-forms/labeling-configuration/labeling-configuration.component.ts
+++ b/libs/common/src/lib/tasks-automation/task-forms/labeling-configuration/labeling-configuration.component.ts
@@ -20,7 +20,7 @@ import {
 } from '@nuclia/sistema';
 import { LabelModule, LabelSetFormModalComponent, LabelsService, SDKService } from '@flaps/core';
 import { TranslateModule } from '@ngx-translate/core';
-import { PaButtonModule, PaTextFieldModule, PaTogglesModule } from '@guillotinaweb/pastanaga-angular';
+import { ModalConfig, PaButtonModule, PaTextFieldModule, PaTogglesModule } from '@guillotinaweb/pastanaga-angular';
 import { LabelSet, LabelSetKind, LabelSets, Search } from '@nuclia/core';
 import { filter, map, Observable, Subject, switchMap, take } from 'rxjs';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
@@ -118,7 +118,12 @@ export class LabelingConfigurationComponent implements OnInit, OnDestroy {
 
   createLabelSet() {
     this.modalService
-      .openModal(LabelSetFormModalComponent)
+      .openModal(
+        LabelSetFormModalComponent,
+        new ModalConfig({
+          data: { kind: this.type === 'resources' ? LabelSetKind.RESOURCES : LabelSetKind.PARAGRAPHS },
+        }),
+      )
       .onClose.pipe(
         filter((labelset) => !!labelset),
         map((data) => data as { id: string; labelSet: LabelSet }),

--- a/libs/core/src/lib/label/label-sets/label-set/label-set-form/label-set-form-modal.component.html
+++ b/libs/core/src/lib/label/label-sets/label-set/label-set-form/label-set-form-modal.component.html
@@ -4,6 +4,7 @@
     <stf-label-set-form
       addNew
       inModal
+      [kind]="modal.config.data?.['kind']"
       (cancel)="modal.close(null)"
       (done)="modal.close($event)"></stf-label-set-form>
   </pa-modal-content>

--- a/libs/core/src/lib/label/label-sets/label-set/label-set-form/label-set-form-modal.component.ts
+++ b/libs/core/src/lib/label/label-sets/label-set/label-set-form/label-set-form-modal.component.ts
@@ -3,6 +3,7 @@ import { CommonModule } from '@angular/common';
 import { ModalRef, PaModalModule } from '@guillotinaweb/pastanaga-angular';
 import { LabelSetFormComponent } from './label-set-form.component';
 import { TranslateModule } from '@ngx-translate/core';
+import { LabelSetKind } from '@nuclia/core';
 
 @Component({
   selector: 'stf-label-set-form-modal',
@@ -13,5 +14,5 @@ import { TranslateModule } from '@ngx-translate/core';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class LabelSetFormModalComponent {
-  constructor(public modal: ModalRef) {}
+  constructor(public modal: ModalRef<{ kind?: LabelSetKind }>) {}
 }

--- a/libs/core/src/lib/label/label-sets/label-set/label-set-form/label-set-form.component.html
+++ b/libs/core/src/lib/label/label-sets/label-set/label-set-form/label-set-form.component.html
@@ -14,7 +14,7 @@
             {{ 'label-set.form.name' | translate }}
           </pa-input>
 
-          @if (addNew) {
+          @if (addNew && !kind) {
             <div>
               <label class="title-xxs">
                 {{ 'label-set.form.kind' | translate }}

--- a/libs/core/src/lib/label/label-sets/label-set/label-set-form/label-set-form.component.ts
+++ b/libs/core/src/lib/label/label-sets/label-set/label-set-form/label-set-form.component.ts
@@ -60,6 +60,7 @@ export class LabelSetFormComponent implements OnInit, OnChanges {
 
   @Input({ transform: booleanAttribute }) addNew = false;
   @Input({ transform: booleanAttribute }) inModal = false;
+  @Input() kind?: LabelSetKind;
   @Input() labelSetId?: string;
 
   @Output() cancel = new EventEmitter<void>();
@@ -121,6 +122,9 @@ export class LabelSetFormComponent implements OnInit, OnChanges {
   }
 
   ngOnInit() {
+    if (this.kind) {
+      this.labelSetForm.patchValue({ kind: this.kind });
+    }
     this.labelSetForm.valueChanges.pipe(takeUntil(this.unsubscribeAll)).subscribe(() => {
       if (this.labelSet) {
         const data = this.labelSetForm.getRawValue();

--- a/libs/sync/src/lib/configuration-form/configuration-form.component.ts
+++ b/libs/sync/src/lib/configuration-form/configuration-form.component.ts
@@ -14,7 +14,7 @@ import { CommonModule } from '@angular/common';
 import { Filters, IConnector, ISyncEntity } from '../logic';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { filter, map, Observable, Subject, take, takeUntil } from 'rxjs';
-import { Classification, LabelSets } from '@nuclia/core';
+import { Classification, LabelSetKind, LabelSets } from '@nuclia/core';
 import { LabelModule, LabelSetFormModalComponent, LabelsService, ParametersTableComponent } from '@flaps/core';
 import {
   InfoCardComponent,
@@ -23,6 +23,7 @@ import {
   TwoColumnsConfigurationItemComponent,
 } from '@nuclia/sistema';
 import {
+  ModalConfig,
   PaButtonModule,
   PaDatePickerModule,
   PaTextFieldModule,
@@ -174,7 +175,10 @@ export class ConfigurationFormComponent implements OnInit, OnDestroy {
   }
 
   createLabelSet() {
-    this.modalService.openModal(LabelSetFormModalComponent);
+    this.modalService.openModal(
+      LabelSetFormModalComponent,
+      new ModalConfig({ data: { kind: LabelSetKind.RESOURCES } }),
+    );
   }
 
   updateLabelSelection(labels: Classification[]) {

--- a/libs/sync/src/lib/sync-details-page/sync-settings/sync-settings.component.html
+++ b/libs/sync/src/lib/sync-details-page/sync-settings/sync-settings.component.html
@@ -9,16 +9,19 @@
     </div>
     <div class="separator-line"></div>
 
-    <div class="body-s settings-item">
-      <label>{{ 'sync.details.settings.synchronize-security-groups' | translate }}</label>
-      <div style="text-transform: capitalize">
-        {{
-          (sync.syncSecurityGroups ? 'sync.details.settings.boolean.true' : 'sync.details.settings.boolean.false')
-            | translate
-        }}
+    @if (connector?.canSyncSecurityGroups) {
+      <div class="body-s settings-item">
+        <label>{{ 'sync.details.settings.synchronize-security-groups' | translate }}</label>
+        <div style="text-transform: capitalize">
+          {{
+            (sync.syncSecurityGroups ? 'sync.details.settings.boolean.true' : 'sync.details.settings.boolean.false')
+              | translate
+          }}
+        </div>
       </div>
-    </div>
-    <div class="separator-line"></div>
+      <div class="separator-line"></div>
+    }
+
     <div class="body-s settings-item">
       <label>{{ 'sync.details.settings.labels' | translate }}</label>
       <div class="row-container">


### PR DESCRIPTION
- Don't display label set kind radio group in label set creation modal on sync and task creation forms (as there is only one possible kind to be chosen for those cases)
- Don't display security groups toggle in sync details when the corresponding connector doesn't have `canSyncSecurityGroups: true`