### PR TITLE
Helm: Add support for specifying container `env`

### DIFF
--- a/charts/app/templates/app.deploy.yaml
+++ b/charts/app/templates/app.deploy.yaml
@@ -50,7 +50,7 @@ spec:
         imagePullPolicy: Always
 {{ with .Values.env }}
         env:
-{{ toYaml . | trim | nindent 8 }}
+{{ toYaml . | indent 8 }}
 {{ end }}
         envFrom:
         - configMapRef:

--- a/charts/manager/templates/manager.deploy.yaml
+++ b/charts/manager/templates/manager.deploy.yaml
@@ -46,7 +46,7 @@ spec:
 {{ toYaml .Values.resources | indent 10 }}
 {{ with .Values.env }}
         env:
-{{ toYaml . | trim | nindent 8 }}
+{{ toYaml . | indent 8 }}
 {{ end }}
         envFrom:
         - configMapRef:


### PR DESCRIPTION
This PR adds support for specifying environmental variables (from `env` in values) which will then be used by application containers.