### PR TITLE
[sc-10511] allow advanced filters in preselected filters

### DIFF
--- a/libs/common/common.babel
+++ b/libs/common/common.babel
@@ -23501,6 +23501,29 @@
 														</translations>
 													</concept_node>
 													<concept_node>
+														<name>textarea-help</name>
+														<description/>
+														<comment/>
+														<translations>
+															<translation>
+																<language>ca-ES</language>
+																<approved>false</approved>
+															</translation>
+															<translation>
+																<language>en-US</language>
+																<approved>false</approved>
+															</translation>
+															<translation>
+																<language>es-ES</language>
+																<approved>false</approved>
+															</translation>
+															<translation>
+																<language>fr-FR</language>
+																<approved>false</approved>
+															</translation>
+														</translations>
+													</concept_node>
+													<concept_node>
 														<name>textarea-label</name>
 														<description/>
 														<comment/>

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -972,6 +972,7 @@
 	"search.configuration.search-box.placeholder.toggle-description": "Canvieu el text que voleu que aparegui a la barra de cerca quan no estigui actiu. El text predeterminat és \"Escriu la teva pregunta aquí\".",
 	"search.configuration.search-box.placeholder.toggle-label": "Personalitza el placeholder de la barra de cerca",
 	"search.configuration.search-box.preselected-filters.info-box": "Format de filtre <a href=\"https://docs.nuclia.dev/docs/guides/using/search/#filters\" target=\"_blank\">documentat aquí</a>. Aquests filtres s'aplicaran a qualsevol consulta de cerca sense ser visibles per als usuaris finals. ",
+	"search.configuration.search-box.preselected-filters.textarea-help": "Una expressió de filtre per línia",
 	"search.configuration.search-box.preselected-filters.textarea-label": "Filtres preseleccionats",
 	"search.configuration.search-box.preselected-filters.toggle-description": "Definiu filtres que s'aplicaran per defecte a qualsevol consulta.",
 	"search.configuration.search-box.preselected-filters.toggle-label": "Filtres preseleccionats",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -972,6 +972,7 @@
 	"search.configuration.search-box.placeholder.toggle-description": "Change the text that you want to appear in the search bar when not active. The default text is “Type your question here”.",
 	"search.configuration.search-box.placeholder.toggle-label": "Customize search bar placeholder",
 	"search.configuration.search-box.preselected-filters.info-box": "Filter format <a href=\"https://docs.nuclia.dev/docs/guides/using/search/#filters\" target=\"_blank\">documented here</a>. These filters will be applied to any search queries without being visible to the end users. ",
+	"search.configuration.search-box.preselected-filters.textarea-help": "One filter expression per line",
 	"search.configuration.search-box.preselected-filters.textarea-label": "Preselected filters",
 	"search.configuration.search-box.preselected-filters.toggle-description": "Define filters that will be applied by default to any query.",
 	"search.configuration.search-box.preselected-filters.toggle-label": "Preselected filters",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -972,6 +972,7 @@
 	"search.configuration.search-box.placeholder.toggle-description": "Cambia el texto que quieres que aparezca en la barra de búsqueda cuando no esté activa. El texto predeterminado es \"Escriba su pregunta aquí\".",
 	"search.configuration.search-box.placeholder.toggle-label": "Personalizar el placeholder de la barra de búsqueda",
 	"search.configuration.search-box.preselected-filters.info-box": "Formato de filtro <a href=\"https://docs.nuclia.dev/docs/guides/using/search/#filters\" target=\"_blank\">documentado aquí</a>. Estos filtros se aplicarán a cualquier consulta de búsqueda sin ser visibles para los usuarios finales. ",
+	"search.configuration.search-box.preselected-filters.textarea-help": "Una expresión de filtro por línea",
 	"search.configuration.search-box.preselected-filters.textarea-label": "Filtros preseleccionados",
 	"search.configuration.search-box.preselected-filters.toggle-description": "Defina filtros que se aplicarán de forma predeterminada a cualquier consulta.",
 	"search.configuration.search-box.preselected-filters.toggle-label": "Filtros preseleccionados",

--- a/libs/common/src/assets/i18n/fr.json
+++ b/libs/common/src/assets/i18n/fr.json
@@ -972,6 +972,7 @@
 	"search.configuration.search-box.placeholder.toggle-description": "Modifiez le texte que vous souhaitez afficher dans la barre de recherche lorsqu'elle n'est pas active. Le texte par défaut est « Tapez votre question ici ».",
 	"search.configuration.search-box.placeholder.toggle-label": "Personnaliser le placeholder de la barre de recherche",
 	"search.configuration.search-box.preselected-filters.info-box": "Format de filtre <a href=\"https://docs.nuclia.dev/docs/guides/using/search/#filters\" target=\"_blank\">documenté ici</a>. Ces filtres seront appliqués à toutes les requêtes de recherche sans être visibles pour les utilisateurs finaux. ",
+	"search.configuration.search-box.preselected-filters.textarea-help": "Une expression de filtre par ligne",
 	"search.configuration.search-box.preselected-filters.textarea-label": "Filtres présélectionnés",
 	"search.configuration.search-box.preselected-filters.toggle-description": "Définissez des filtres qui seront appliqués par défaut à toutes les requêtes.",
 	"search.configuration.search-box.preselected-filters.toggle-label": "Filtres présélectionnés",

--- a/libs/common/src/lib/search-widget/search-configuration/search-box-form/search-box-form.component.html
+++ b/libs/common/src/lib/search-widget/search-configuration/search-box-form/search-box-form.component.html
@@ -92,6 +92,7 @@
         formControlName="preselectedFilters"
         resizable
         rows="4"
+        help="search.configuration.search-box.preselected-filters.textarea-help"
         (resizing)="heightChanged.emit()">
         {{ 'search.configuration.search-box.preselected-filters.textarea-label' | translate }}
       </pa-textarea>

--- a/libs/common/src/lib/search-widget/search-widget.models.ts
+++ b/libs/common/src/lib/search-widget/search-widget.models.ts
@@ -229,9 +229,18 @@ export function getFilters(config: SearchBoxConfig): string {
 export function getPreselectedFilters(config: SearchBoxConfig): string {
   const value = config.preselectedFilters
     .split('\n')
-    .map((filter) => filter.trim())
+    .map((filter) => {
+      let formattedFilter = filter.trim();
+      try {
+        formattedFilter = JSON.stringify(JSON.parse(formattedFilter));
+      } catch (e) {
+        // do nothing more if the filter wasn't in JSON format
+      }
+      return formattedFilter;
+    })
     .join(',');
-  return config.setPreselectedFilters && value ? `\n  preselected_filters="${value}"` : '';
+  const quote = value.includes('"') ? `'` : `"`;
+  return config.setPreselectedFilters && value ? `\n  preselected_filters=${quote}${value}${quote}` : '';
 }
 export function getRagStrategies(ragStrategiesConfig: RagStrategiesConfig) {
   const ragStrategies: string[] = [];

--- a/libs/search-widget/src/widgets/chat-widget/ChatWidget.svelte
+++ b/libs/search-widget/src/widgets/chat-widget/ChatWidget.svelte
@@ -79,7 +79,7 @@
     );
 
     if (preselected_filters) {
-      preselectedFilters.set(preselected_filters.split(','));
+      preselectedFilters.set(preselected_filters);
     }
 
     _ragStrategies = getRAGStrategies(rag_strategies, rag_field_ids);

--- a/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
@@ -219,7 +219,7 @@
       }
     }
     if (preselected_filters) {
-      preselectedFilters.set(preselected_filters.split(','));
+      preselectedFilters.set(preselected_filters);
     }
     if (_features.answers) {
       initAnswer();


### PR DESCRIPTION
Fix the widget to support the advanced filters as well as simple filters. 

`preselected_filters` can take either advanced filters or simple filters, but mixing both will not work (only advanced one will be used when mixing both)

several advanced filters is working:

```
preselected_filters='{"any":["/icon/application/pdf","/icon/image/jpeg"]},{"any":["/icon/video/mp4"]}'
```

but mixing advanced and simple filters is taking only advanced ones:
```
preselected_filters='{"any":["/icon/application/pdf","/icon/image/jpeg"]},/icon/video/mp4'
```

