### PR TITLE
Add hash in commit version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -239,7 +239,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Calculate short sha
-        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=`echo hash${GITHUB_SHA} | cut -c1-12`" >> $GITHUB_ENV
 
       - name: Set helm package image
         id: version_step

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
           cache: 'yarn'
 
       - name: Calculate short sha
-        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=`echo hash${GITHUB_SHA} | cut -c1-12`" >> $GITHUB_ENV
 
       - name: Install project dependencies
         run: |-
@@ -182,7 +182,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Calculate short sha
-        run: echo "SHORT_SHA=`echo ${GITHUB_SHA} | cut -c1-8`" >> $GITHUB_ENV
+        run: echo "SHORT_SHA=`echo hash${GITHUB_SHA} | cut -c1-12`" >> $GITHUB_ENV
 
       - name: Set helm package image
         id: version_step

--- a/apps/dashboard/src/app/app.module.ts
+++ b/apps/dashboard/src/app/app.module.ts
@@ -11,12 +11,9 @@ import { PaToastModule, SPRITE_CACHE_VERSION } from '@guillotinaweb/pastanaga-an
 import { BackendConfigurationService, LabelSetsModule, STFConfigModule, STFPipesModule } from '@flaps/core';
 import { environment } from '../environments/environment';
 
-// App modules
 import { AppRoutingModule } from './app-routing.module';
 import { FarewellModule } from './farewell/farewell.module';
 import { AccountModule } from './account/account.module';
-
-// Components
 import { AppComponent } from './app.component';
 
 // Load locales


### PR DESCRIPTION
This is to prevent deployment to fail when the commit sha starts with a `0`.

> The problem here is versioning of the charts, where if metadata (the part after +) starts with 0 is not matched with the correct version of a chart in the registry (that being said, version metadata are not used for version comparison by design in semver v2).
> In your pipelines, a hack fix could be changing this to something like ```echo "SHORT_SHA=`echo hash${GITHUB_SHA} | cut -c1-12`" >> $GITHUB_ENV```. That would make metadata (the git hash currently) being prepended with "hash" and hence getting around this problem.