### PR TITLE
[sc-10860] Fix time format on getting started dialog

### DIFF
--- a/apps/dashboard/src/app/onboarding/getting-started/getting-started.component.ts
+++ b/apps/dashboard/src/app/onboarding/getting-started/getting-started.component.ts
@@ -199,7 +199,7 @@ export class GettingStartedComponent implements OnDestroy {
                       item.processed = resource.metadata?.status === RESOURCE_STATUS.PROCESSED;
                       if (!item.processed && status) {
                         item.processing = status.schedule_order === -1;
-                        item.estimation = status.schedule_eta === -1 ? 1 : status.schedule_eta;
+                        item.estimation = status.schedule_eta === -1 ? 60 : status.schedule_eta;
                         item.rank = status.schedule_order;
                       }
                     }

--- a/apps/dashboard/src/app/onboarding/getting-started/upload-list/upload-list.component.html
+++ b/apps/dashboard/src/app/onboarding/getting-started/upload-list/upload-list.component.html
@@ -43,7 +43,7 @@
                   <span class="body-s">
                     {{
                       'getting-started.processing.status.estimated-time'
-                        | translate: { estimation: formatETA.transform(item.estimation || 1) }
+                        | translate: { estimation: formatETA.transform(item.estimation || 60) }
                     }}
                   </span>
                 }

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -470,7 +470,7 @@
 	"getting-started.intro.title": "Comença amb només 3 passos senzills",
 	"getting-started.processing.description": "Depenent del contingut, pot trigar uns minuts a processar les vostres dades a la base de dades vectorial NucliaDB.",
 	"getting-started.processing.estimated-time": "Temps de processament estimat: {{estimation}}",
-	"getting-started.processing.status.estimated-time": "Queden {{estimation}} min",
+	"getting-started.processing.status.estimated-time": "Queden {{estimation}}",
 	"getting-started.processing.status.failed": "Ha fallat",
 	"getting-started.processing.status.processed": "Processament completat",
 	"getting-started.processing.status.processing": "Processament",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -470,7 +470,7 @@
 	"getting-started.intro.title": "Get started in just 3 simple steps",
 	"getting-started.processing.description": "Depending on the contents, it can take a few minutes to process your data into the NucliaDB vector database.",
 	"getting-started.processing.estimated-time": "Estimated processing time: {{estimation}}",
-	"getting-started.processing.status.estimated-time": "{{estimation}} min left",
+	"getting-started.processing.status.estimated-time": "{{estimation}} left",
 	"getting-started.processing.status.failed": "Failed",
 	"getting-started.processing.status.processed": "Processing completed",
 	"getting-started.processing.status.processing": "Processing",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -470,7 +470,7 @@
 	"getting-started.intro.title": "Comience en solo 3 simples pasos",
 	"getting-started.processing.description": "Dependiendo del contenido, puede llevar algunos minutos procesar sus datos en la base de datos vectorial NucliaDB.",
 	"getting-started.processing.estimated-time": "Tiempo de procesamiento estimado: {{estimation}}",
-	"getting-started.processing.status.estimated-time": "Quedan {{estimation}} min",
+	"getting-started.processing.status.estimated-time": "Quedan {{estimation}}",
 	"getting-started.processing.status.failed": "Ha fallado",
 	"getting-started.processing.status.processed": "Procesamiento completado",
 	"getting-started.processing.status.processing": "Tratamiento",

--- a/libs/common/src/assets/i18n/fr.json
+++ b/libs/common/src/assets/i18n/fr.json
@@ -470,7 +470,7 @@
 	"getting-started.intro.title": "Commencez en seulement 3 étapes simples",
 	"getting-started.processing.description": "Selon le contenu, le traitement de vos données dans la base de données vectorielles NucliaDB peut prendre quelques minutes.",
 	"getting-started.processing.estimated-time": "Temps de traitement estimé :  {{estimation}}",
-	"getting-started.processing.status.estimated-time": "Il reste {{estimation}}  min",
+	"getting-started.processing.status.estimated-time": "Il reste {{estimation}} ",
 	"getting-started.processing.status.failed": "En échec",
 	"getting-started.processing.status.processed": "Traitement terminé",
 	"getting-started.processing.status.processing": "Traitement",


### PR DESCRIPTION
- Fix remaining time format
- When the backend doesn't return the remaining processing time, `1min` is displayed instead of `1s`