### PR TITLE
[sc-10922] Properly update current kb when switching to another user

### DIFF
--- a/libs/core/src/lib/api/sdk.service.ts
+++ b/libs/core/src/lib/api/sdk.service.ts
@@ -79,9 +79,9 @@ export class SDKService {
 
     combineLatest([this._kb, this._account])
       .pipe(
+        distinctUntilChanged(([previous], [current]) => previous?.id === current?.id && previous?.slug === current?.slug),
         filter(([kb, account]) => !!kb && !!kb.slug && !!account),
         map(([kb, account]) => [kb, account] as [KnowledgeBox, Account]),
-        distinctUntilChanged(([previous], [current]) => previous.id === current.id && previous.slug === current.slug),
         switchMap(([kb, account]) =>
           this.nuclia.db
             .getKnowledgeBox(account.id, kb.id, kb.zone)


### PR DESCRIPTION
- When switching to another user in the Dashboard, the `currentKb` observable is not always updated as expected, keeping the kb from the previous user. It's fixed by moving the `distinctUntilChanged` operator.