### PR TITLE
[sc-10931] REMi metrics open context in the viewer

### DIFF
--- a/libs/common/src/lib/metrics/metrics-page.component.html
+++ b/libs/common/src/lib/metrics/metrics-page.component.html
@@ -160,7 +160,8 @@
                     noScore
                     [item]="item"
                     [missingKnowledgeDetails]="missingKnowledgeDetails"
-                    [missingKnowledgeError]="missingKnowledgeError"></stf-missing-knowledge-details>
+                    [missingKnowledgeError]="missingKnowledgeError"
+                    (openViewer)="openViewer($event)"></stf-missing-knowledge-details>
                 </pa-accordion-item-body>
               </pa-accordion-item>
             }
@@ -263,7 +264,8 @@
                   <stf-missing-knowledge-details
                     [item]="item"
                     [missingKnowledgeDetails]="missingKnowledgeDetails"
-                    [missingKnowledgeError]="missingKnowledgeError"></stf-missing-knowledge-details>
+                    [missingKnowledgeError]="missingKnowledgeError"
+                    (openViewer)="openViewer($event)"></stf-missing-knowledge-details>
                 </pa-accordion-item-body>
               </pa-accordion-item>
             }
@@ -272,4 +274,8 @@
       }
     }
   </section>
+</div>
+
+<div class="viewer-container">
+  <div [innerHTML]="viewerWidget | async"></div>
 </div>

--- a/libs/common/src/lib/metrics/metrics-page.component.html
+++ b/libs/common/src/lib/metrics/metrics-page.component.html
@@ -97,8 +97,12 @@
       }
     </div>
   </section>
-  <section class="missing-knowledge">
-    <div class="sticky-section">
+  <section
+    class="missing-knowledge"
+    [style]="missingKnowledgeHeaderHeight">
+    <div
+      class="sticky-section"
+      #missingKnowledgeHeader>
       <div class="title-l">{{ 'kb.metrics.missing-knowledge.title' | translate }}</div>
       <div class="page-description">{{ 'kb.metrics.missing-knowledge.description' | translate }}</div>
     </div>
@@ -153,6 +157,7 @@
                 (expandedChange)="loadMissingKnowledgeDetails(item.id)">
                 <pa-accordion-item-body>
                   <stf-missing-knowledge-details
+                    noScore
                     [item]="item"
                     [missingKnowledgeDetails]="missingKnowledgeDetails"
                     [missingKnowledgeError]="missingKnowledgeError"></stf-missing-knowledge-details>
@@ -223,7 +228,7 @@
         @if (missingKnowledge.length === 0) {
           <nsi-info-card>{{ 'kb.metrics.error.no-data-for-criteria' | translate }}</nsi-info-card>
         } @else {
-          <pa-accordion #missingKnowledgeAccordion>
+          <pa-accordion>
             @for (item of missingKnowledge; track item.id) {
               <pa-accordion-item
                 [id]="'' + item.id"

--- a/libs/common/src/lib/metrics/metrics-page.component.html
+++ b/libs/common/src/lib/metrics/metrics-page.component.html
@@ -231,43 +231,45 @@
         } @else {
           <pa-accordion>
             @for (item of missingKnowledge; track item.id) {
-              <pa-accordion-item
-                [id]="'' + item.id"
-                [itemTitle]="item.question"
-                [description]="
-                  '<strong>' +
-                  ('kb.metrics.missing-knowledge.summary.answer' | translate) +
-                  '</strong>' +
-                  item.answer +
-                  '<br><strong>' +
-                  ('kb.metrics.missing-knowledge.summary.relevance' | translate) +
-                  item.remi.answer_relevance.score * 20 +
-                  '%</strong> – ' +
-                  item.remi.answer_relevance.reason +
-                  '<br>' +
-                  ('kb.metrics.missing-knowledge.summary.context-count'
-                    | translate: { count: item.remi.context_relevance.length })
-                "
-                (expandedChange)="loadMissingKnowledgeDetails(item.id)">
-                <pa-accordion-item-extra-description>
-                  @if (missingKnowledgeBarPlotData | async; as data) {
-                    <div class="chart-container">
-                      <stf-grouped-bar-chart
-                        [data]="data[item.id]"
-                        height="144"></stf-grouped-bar-chart>
-                      <h6>Text blocks scores distribution</h6>
-                    </div>
-                  }
-                </pa-accordion-item-extra-description>
+              @if (item.remi) {
+                <pa-accordion-item
+                  [id]="'' + item.id"
+                  [itemTitle]="item.question"
+                  [description]="
+                    '<strong>' +
+                    ('kb.metrics.missing-knowledge.summary.answer' | translate) +
+                    '</strong>' +
+                    item.answer +
+                    '<br><strong>' +
+                    ('kb.metrics.missing-knowledge.summary.relevance' | translate) +
+                    item.remi.answer_relevance.score * 20 +
+                    '%</strong> – ' +
+                    item.remi.answer_relevance.reason +
+                    '<br>' +
+                    ('kb.metrics.missing-knowledge.summary.context-count'
+                      | translate: { count: item.remi.context_relevance.length })
+                  "
+                  (expandedChange)="loadMissingKnowledgeDetails(item.id)">
+                  <pa-accordion-item-extra-description>
+                    @if (missingKnowledgeBarPlotData | async; as data) {
+                      <div class="chart-container">
+                        <stf-grouped-bar-chart
+                          [data]="data[item.id]"
+                          height="144"></stf-grouped-bar-chart>
+                        <h6>Text blocks scores distribution</h6>
+                      </div>
+                    }
+                  </pa-accordion-item-extra-description>
 
-                <pa-accordion-item-body>
-                  <stf-missing-knowledge-details
-                    [item]="item"
-                    [missingKnowledgeDetails]="missingKnowledgeDetails"
-                    [missingKnowledgeError]="missingKnowledgeError"
-                    (openViewer)="openViewer($event)"></stf-missing-knowledge-details>
-                </pa-accordion-item-body>
-              </pa-accordion-item>
+                  <pa-accordion-item-body>
+                    <stf-missing-knowledge-details
+                      [item]="item"
+                      [missingKnowledgeDetails]="missingKnowledgeDetails"
+                      [missingKnowledgeError]="missingKnowledgeError"
+                      (openViewer)="openViewer($event)"></stf-missing-knowledge-details>
+                  </pa-accordion-item-body>
+                </pa-accordion-item>
+              }
             }
           </pa-accordion>
         }

--- a/libs/common/src/lib/metrics/metrics-page.component.scss
+++ b/libs/common/src/lib/metrics/metrics-page.component.scss
@@ -100,7 +100,7 @@
     &.sub-section {
       padding-top: rhythm(2);
       margin-bottom: rhythm(2);
-      top: rhythm(8);
+      top: var(--header-height);
     }
   }
 

--- a/libs/common/src/lib/metrics/metrics-page.component.ts
+++ b/libs/common/src/lib/metrics/metrics-page.component.ts
@@ -1,10 +1,13 @@
 import {
+  AfterViewInit,
   ChangeDetectionStrategy,
   ChangeDetectorRef,
   Component,
+  ElementRef,
   inject,
   OnDestroy,
   OnInit,
+  ViewChild,
   ViewChildren,
 } from '@angular/core';
 import { CommonModule } from '@angular/common';
@@ -18,7 +21,8 @@ import {
   PaTableModule,
   PaTextFieldModule,
 } from '@guillotinaweb/pastanaga-angular';
-import { Observable, Subject } from 'rxjs';
+import { fromEvent, Observable, Subject } from 'rxjs';
+import { auditTime, takeUntil } from 'rxjs/operators';
 import {
   DatedRangeChartData,
   GroupedBarChartComponent,
@@ -31,10 +35,17 @@ import { RemiMetricsService, RemiPeriods } from './remi-metrics.service';
 import { InfoCardComponent, SisProgressModule } from '@nuclia/sistema';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { format } from 'date-fns';
-import { takeUntil } from 'rxjs/operators';
-import { RemiQueryCriteria, RemiQueryResponseContextDetails, RemiQueryResponseItem } from '@nuclia/core';
+import {
+  RemiQueryCriteria,
+  RemiQueryResponseContextDetails,
+  RemiQueryResponseItem,
+  SHORT_FIELD_TYPE,
+  shortToLongFieldType,
+} from '@nuclia/core';
 import { DateAfter } from '../validators';
 import { MissingKnowledgeDetailsComponent } from './missing-knowledge-details/missing-knowledge-details.component';
+import { PreviewService } from '../resources';
+import { SafeHtml } from '@angular/platform-browser';
 
 @Component({
   standalone: true,
@@ -60,12 +71,13 @@ import { MissingKnowledgeDetailsComponent } from './missing-knowledge-details/mi
   styleUrl: './metrics-page.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MetricsPageComponent implements OnInit, OnDestroy {
+export class MetricsPageComponent implements AfterViewInit, OnInit, OnDestroy {
   private remiMetrics = inject(RemiMetricsService);
   private cdr = inject(ChangeDetectorRef);
 
   private unsubscribeAll: Subject<void> = new Subject();
 
+  @ViewChild('missingKnowledgeHeader', { read: ElementRef }) missingKnowledgeHeader?: ElementRef;
   @ViewChildren(AccordionItemComponent) accordionItems?: AccordionItemComponent[];
 
   period: Observable<RemiPeriods> = this.remiMetrics.period;
@@ -117,6 +129,22 @@ export class MetricsPageComponent implements OnInit, OnDestroy {
   }
   get noAnswerMonthValue() {
     return this.noAnswerMonthControl.value;
+  }
+
+  missingKnowledgeHeaderHeight = '';
+
+  ngAfterViewInit() {
+    if (this.missingKnowledgeHeader) {
+      this.missingKnowledgeHeaderHeight = `--header-height:${this.missingKnowledgeHeader.nativeElement.offsetHeight}px`;
+      fromEvent(window, 'resize')
+        .pipe(auditTime(200), takeUntil(this.unsubscribeAll))
+        .subscribe(() => {
+          if (this.missingKnowledgeHeader) {
+            this.missingKnowledgeHeaderHeight = `--header-height:${this.missingKnowledgeHeader.nativeElement.offsetHeight}px`;
+            this.cdr.detectChanges();
+          }
+        });
+    }
   }
 
   ngOnInit() {

--- a/libs/common/src/lib/metrics/missing-knowledge-details/missing-knowledge-details.component.html
+++ b/libs/common/src/lib/metrics/missing-knowledge-details/missing-knowledge-details.component.html
@@ -1,23 +1,36 @@
 @if (missingKnowledgeDetails[item.id]; as details) {
   <pa-table
     border
-    columns="repeat(2, 112px) 1fr">
+    [columns]="noScore ? '1fr 80px' : 'repeat(2, 112px) 1fr 80px'">
     <pa-table-header>
-      <pa-table-cell header>
-        {{ 'metrics.remi.category-short.context_relevance' | translate }}
-      </pa-table-cell>
-      <pa-table-cell header>
-        {{ 'metrics.remi.category-short.groundedness' | translate }}
-      </pa-table-cell>
+      @if (!noScore) {
+        <pa-table-cell header>
+          {{ 'metrics.remi.category-short.context_relevance' | translate }}
+        </pa-table-cell>
+        <pa-table-cell header>
+          {{ 'metrics.remi.category-short.groundedness' | translate }}
+        </pa-table-cell>
+      }
       <pa-table-cell header>
         {{ 'kb.metrics.missing-knowledge.table.context-header' | translate }}
       </pa-table-cell>
+      <pa-table-cell header></pa-table-cell>
     </pa-table-header>
     @for (context of details.context; track context) {
       <pa-table-row>
-        <pa-table-cell center>{{ item.remi.context_relevance[$index] * 20 }}%</pa-table-cell>
-        <pa-table-cell center>{{ item.remi.groundedness[$index] * 20 }}%</pa-table-cell>
+        @if (!noScore) {
+          <pa-table-cell center>{{ item.remi ? item.remi.context_relevance[$index] * 20 + '%' : '–' }}</pa-table-cell>
+          <pa-table-cell center>{{ item.remi ? item.remi.groundedness[$index] * 20 + '%' : '–' }}</pa-table-cell>
+        }
         <pa-table-cell><span [innerHTML]="context.text"></span></pa-table-cell>
+        <pa-table-cell-menu>
+          @if (context.text_block_id) {
+            <pa-button
+              aspect="basic"
+              icon="eye"
+              (click)="openViewer.emit(context.text_block_id)"></pa-button>
+          }
+        </pa-table-cell-menu>
       </pa-table-row>
     }
   </pa-table>

--- a/libs/common/src/lib/metrics/missing-knowledge-details/missing-knowledge-details.component.ts
+++ b/libs/common/src/lib/metrics/missing-knowledge-details/missing-knowledge-details.component.ts
@@ -1,6 +1,6 @@
-import { ChangeDetectionStrategy, Component, Input } from '@angular/core';
+import { booleanAttribute, ChangeDetectionStrategy, Component, EventEmitter, Input, Output } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { PaTableModule } from '@guillotinaweb/pastanaga-angular';
+import { PaButtonModule, PaTableModule } from '@guillotinaweb/pastanaga-angular';
 import { InfoCardComponent, SisProgressModule } from '@nuclia/sistema';
 import { RemiQueryResponseContextDetails, RemiQueryResponseItem } from '@nuclia/core';
 import { TranslateModule } from '@ngx-translate/core';
@@ -8,7 +8,7 @@ import { TranslateModule } from '@ngx-translate/core';
 @Component({
   selector: 'stf-missing-knowledge-details',
   standalone: true,
-  imports: [CommonModule, PaTableModule, InfoCardComponent, SisProgressModule, TranslateModule],
+  imports: [CommonModule, PaTableModule, InfoCardComponent, SisProgressModule, TranslateModule, PaButtonModule],
   templateUrl: './missing-knowledge-details.component.html',
   styleUrl: './missing-knowledge-details.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -17,4 +17,7 @@ export class MissingKnowledgeDetailsComponent {
   @Input({ required: true }) item!: RemiQueryResponseItem;
   @Input({ required: true }) missingKnowledgeDetails: { [id: number]: RemiQueryResponseContextDetails } = {};
   @Input({ required: true }) missingKnowledgeError: { [id: number]: boolean } = {};
+  @Input({ transform: booleanAttribute }) noScore = false;
+
+  @Output() openViewer = new EventEmitter<string>();
 }

--- a/libs/common/src/lib/metrics/remi-metrics.service.ts
+++ b/libs/common/src/lib/metrics/remi-metrics.service.ts
@@ -188,8 +188,12 @@ export class RemiMetricsService {
       map((items) =>
         items.reduce(
           (plotData, item) => {
-            const contextDistribution: { [score: string]: number } = this.getDistribution(item.remi.context_relevance);
-            const groundednessDistribution: { [score: string]: number } = this.getDistribution(item.remi.groundedness);
+            const contextDistribution: { [score: string]: number } = this.getDistribution(
+              item.remi?.context_relevance || [],
+            );
+            const groundednessDistribution: { [score: string]: number } = this.getDistribution(
+              item.remi?.groundedness || [],
+            );
             const groups: string[] = Object.keys(contextDistribution)
               .concat(Object.keys(groundednessDistribution))
               .reduce((deduplicatedGroups, key) => {

--- a/libs/common/src/lib/resources/edit-resource/edit-resource.module.ts
+++ b/libs/common/src/lib/resources/edit-resource/edit-resource.module.ts
@@ -38,11 +38,11 @@ import {
 } from '@guillotinaweb/pastanaga-angular';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { TranslateModule } from '@ngx-translate/core';
-import { FileUploadModule, STFPipesModule, LabelModule } from '@flaps/core';
+import { FileUploadModule, LabelModule, STFPipesModule } from '@flaps/core';
 import { RouterModule } from '@angular/router';
 import { HintModule } from '../../hint/hint.module';
 import { ThumbnailComponent } from './profile/thumbnail/thumbnail.component';
-import { PipesModule } from '@flaps/common';
+import { PipesModule } from '../../pipes';
 
 @NgModule({
   imports: [

--- a/libs/common/src/lib/resources/edit-resource/index.ts
+++ b/libs/common/src/lib/resources/edit-resource/index.ts
@@ -2,7 +2,7 @@ export * from './add-field/add-field.component';
 export * from './annotation/paragraph-annotation/paragraph-annotation.component';
 export * from './classification';
 export * from './dropzone/dropzone.component';
-export * from './preview/preview.component';
+export * from './preview';
 export * from './profile';
 export * from './select-first-field/select-first-field.directive';
 export * from './edit-resource.component';

--- a/libs/common/src/lib/resources/edit-resource/preview/index.ts
+++ b/libs/common/src/lib/resources/edit-resource/preview/index.ts
@@ -1,0 +1,2 @@
+export * from './preview.component';
+export * from './preview.service';

--- a/libs/common/src/lib/resources/edit-resource/preview/preview.service.ts
+++ b/libs/common/src/lib/resources/edit-resource/preview/preview.service.ts
@@ -1,0 +1,40 @@
+import { inject, Injectable } from '@angular/core';
+import { combineLatest, distinctUntilKeyChanged, map, Observable, tap } from 'rxjs';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { TranslateService } from '@ngx-translate/core';
+import { BackendConfigurationService, SDKService } from '@flaps/core';
+
+const viewerId = 'viewer-widget';
+
+@Injectable({ providedIn: 'root' })
+export class PreviewService {
+  private sdk = inject(SDKService);
+  private sanitizer = inject(DomSanitizer);
+  private backendConfig = inject(BackendConfigurationService);
+  private translate = inject(TranslateService);
+
+  viewerWidget: Observable<SafeHtml> = combineLatest([
+    this.sdk.currentKb.pipe(distinctUntilKeyChanged('id')),
+    this.sdk.currentAccount.pipe(distinctUntilKeyChanged('id')),
+  ]).pipe(
+    tap(() => document.getElementById(viewerId)?.remove()),
+    map(([kb, account]) => {
+      return this.sanitizer.bypassSecurityTrustHtml(`<nuclia-viewer id="viewer-widget"
+        knowledgebox="${kb.id}"
+        zone="${this.sdk.nuclia.options.zone}"
+        client="dashboard"
+        cdn="${this.backendConfig.getCDN() ? this.backendConfig.getCDN() + '/' : ''}"
+        backend="${this.backendConfig.getAPIURL()}"
+        state="${kb.state || ''}"
+        kbslug="${kb.slug || ''}"
+        account="${account.id}"
+        lang="${this.translate.currentLang}"
+        ${this.sdk.nuclia.options.standalone ? 'standalone="true"' : ''}
+        ></nuclia-viewer>`);
+    }),
+  );
+
+  openViewer(fullFieldId: { resourceId: string; field_id: string; field_type: string }): Observable<boolean> {
+    return (document.getElementById(viewerId) as unknown as any)?.openPreview(fullFieldId);
+  }
+}

--- a/libs/sdk-core/CHANGELOG.md
+++ b/libs/sdk-core/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ### Improvement
 
-- Update `RemiQueryCriteria` model allowing now to query either on `context_relevance` or on answer `status`. 
+- Update `RemiQueryCriteria` model allowing now to query either on `context_relevance` or on answer `status`.
+- Update `RemiQueryResponseItem` as REMi score is actually optional
+- Remove Algolia mappers
 
 ### Bug fix
 

--- a/libs/sdk-core/src/lib/db/kb/activity/remi.models.ts
+++ b/libs/sdk-core/src/lib/db/kb/activity/remi.models.ts
@@ -20,7 +20,7 @@ export interface RemiQueryResponseItem {
   id: number;
   question: string;
   answer: string;
-  remi: RemiScore;
+  remi?: RemiScore;
 }
 
 export interface RemiQueryResponseContextDetails extends RemiQueryResponseItem {

--- a/libs/sdk-core/src/lib/db/resource/resource.mapper.ts
+++ b/libs/sdk-core/src/lib/db/resource/resource.mapper.ts
@@ -1,36 +1,5 @@
-import type { Resource } from './resource';
-import { Classification, FIELD_TYPE, ResourceData } from './resource.models';
+import { FIELD_TYPE, ResourceData } from './resource.models';
 import { SHORT_FIELD_TYPE } from '../search';
-
-interface AlgoliaRecord {
-  title?: string;
-  fullText?: string[];
-  images?: string[];
-}
-
-export const resourceToAlgoliaFormat = (resource: Resource, backend: string): AlgoliaRecord => {
-  const record: AlgoliaRecord = {
-    title: resource.title,
-    fullText: resource
-      .getExtractedTexts()
-      .filter((extracted) => extracted)
-      .map((extracted) => extracted.text as string),
-  };
-
-  resource.getClassifications().forEach((classification: Classification) => {
-    if (classification.labelset && classification.label) {
-      // Adding labels as properties of the final json
-      (record as any)[classification.labelset] = classification.label;
-    }
-  });
-
-  const images = resource
-    .getThumbnails()
-    .filter((link) => !!link.uri)
-    .map((link) => `${backend}/v1${link.uri}`);
-
-  return { ...record, images, ...resource.getNamedEntities() };
-};
 
 /**
  * Currently in our models, there are more FIELD_TYPEs than ResourceData keys, so we need the switch for typing reason


### PR DESCRIPTION
- Fix gap between missing knowledge section and the criteria expanders appearing on scroll
- Don't display scores columns on missing answers details table
- Open viewer from missing knowledge context (opens only the corresponding resource/field for now)