### PR TITLE
Don't push to chart museum

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -229,7 +229,6 @@ jobs:
         run: |-
           helm lint charts/app
           helm package charts/app
-          curl --data-binary "@app-${{ steps.version_step.outputs.version_number }}.tgz" ${{ secrets.HELM_CHART_URL }}/api/charts
           helm push app-${{ steps.version_step.outputs.version_number }}.tgz ${{ env.ARTIFACT_REGISTRY_URL }}
 
   deploy-manager:
@@ -292,7 +291,6 @@ jobs:
         run: |-
           helm lint charts/manager
           helm package charts/manager
-          curl --data-binary "@manager-${{ steps.version_step.outputs.version_number }}.tgz" ${{ secrets.HELM_CHART_URL }}/api/charts
           helm push manager-${{ steps.version_step.outputs.version_number }}.tgz ${{ env.ARTIFACT_REGISTRY_URL }}
 
   send-to-promotion:


### PR DESCRIPTION
This pull request includes changes to the deployment workflow in the `.github/workflows/deploy.yml` file, specifically replacing the `curl` command with `helm push` for uploading Helm charts. 

Deployment workflow updates:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L232): Removed the `curl` command and replaced it with `helm push` for uploading the `app` Helm chart.
* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L295): Removed the `curl` command and replaced it with `helm push` for uploading the `manager` Helm chart.