### PR TITLE
Add missing parameter when triggering second build image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -178,6 +178,8 @@ jobs:
           skip-context-creation: true
           push: true
           tag-latest: main
+          ghapp-nuclia-service-bot-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
+          ghapp-nuclia-service-bot-pk:  ${{ secrets.PK_GHAPP_NUCLIABOT }}
 
       - name: Create 404 page for gh-pages
         if: steps.check-deploy.outputs.deploy-sistema == 'yes' && github.ref == 'refs/heads/main'


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/deploy.yml` file. The change adds two new secrets for the GitHub App configuration.

* `jobs:` section in `.github/workflows/deploy.yml`: Added `ghapp-nuclia-service-bot-id` and `ghapp-nuclia-service-bot-pk` secrets for the GitHub App configuration.