### PR TITLE
manage: Quote boolean in chart

### DIFF
--- a/apps/manager-v2/src/app/app.component.ts
+++ b/apps/manager-v2/src/app/app.component.ts
@@ -1,9 +1,9 @@
 import { Component, OnDestroy, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
-import { Subject } from 'rxjs';
 import { BackendConfigurationService, STFUtils } from '@flaps/core';
-import { TranslateService } from '@ngx-translate/core';
-import { takeUntil } from 'rxjs/operators';
 import { TranslateService as PaTranslateService } from '@guillotinaweb/pastanaga-angular';
+import { TranslateService } from '@ngx-translate/core';
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
 
 const userLocaleKey = 'NUCLIA_USER_LOCALE';
 
@@ -15,10 +15,9 @@ const userLocaleKey = 'NUCLIA_USER_LOCALE';
 })
 export class AppComponent implements OnInit, OnDestroy {
   @ViewChild('toastsContainer', { read: ViewContainerRef, static: true }) toastsContainer?: ViewContainerRef;
+  version?: string;
 
   private unsubscribeAll: Subject<void> = new Subject<void>();
-
-  version?: string;
 
   constructor(
     private paTranslate: PaTranslateService,

--- a/charts/manager/templates/manager.cm.yaml
+++ b/charts/manager/templates/manager.cm.yaml
@@ -15,7 +15,7 @@ data:
   BRAND_DOMAIN: "{{ .Values.brand_domain }}"
   ASSETS_PATH: "{{ .Values.assets_path }}"
   APP_NAME: {{ .Values.app_name }}
-  NO_STRIPE: {{ .Values.no_stripe }}
+  NO_STRIPE: "{{ .Values.no_stripe }}"
   SENTRY_ENV: {{ .Values.sentry_environment }}
   SENTRY_URL: "{{ .Values.sentry_url }}"
   STF_VERSION: "{{ .Chart.Version }}"


### PR DESCRIPTION
This pull request includes a small change to the `charts/manager/templates/manager.cm.yaml` file. The change ensures that the `NO_STRIPE` value is properly quoted.

* [`charts/manager/templates/manager.cm.yaml`](diffhunk://#diff-dbe807a14a4343ece07a9735f4cfbb9b80aa904c6cb81d4e39dcee2dab650f2dL18-R18): Quoted the `NO_STRIPE` value to ensure it is interpreted correctly.