### PR TITLE
charts: Parametrize envFrom

### DIFF
--- a/charts/app/templates/app.cm.yaml
+++ b/charts/app/templates/app.cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-config"
+  name: app-config
   labels:
     app: app
     version: "{{ .Values.hash }}"

--- a/charts/app/templates/app.deploy.yaml
+++ b/charts/app/templates/app.deploy.yaml
@@ -52,9 +52,10 @@ spec:
         env:
 {{ toYaml . | indent 8 }}
 {{ end }}
+{{- with .Values.envFrom }}
         envFrom:
-        - configMapRef:
-            name: "{{ .Release.Name }}-config"
+{{- toYaml . | nindent 10 }}
+{{- end }}
         readinessProbe:
           httpGet:
             path: /

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -68,3 +68,6 @@ podDisruptionBudget:
 # annotations:
 #   what: "add annotations"
 #   where: "in the pods"
+envFrom:
+  - configMapRef:
+      name: app-config

--- a/charts/manager/templates/manager.cm.yaml
+++ b/charts/manager/templates/manager.cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: "{{ .Release.Name }}-config"
+  name: manager-config
   labels:
     app: {{ .Release.Name }}
     version: "{{ .Values.hash }}"

--- a/charts/manager/templates/manager.deploy.yaml
+++ b/charts/manager/templates/manager.deploy.yaml
@@ -48,9 +48,10 @@ spec:
         env:
 {{ toYaml . | indent 8 }}
 {{ end }}
+{{- with .Values.envFrom }}
         envFrom:
-        - configMapRef:
-            name: "{{ .Release.Name }}-config"
+{{- toYaml . | nindent 10 }}
+{{- end }}
         imagePullPolicy: Always
         readinessProbe:
           httpGet:

--- a/charts/manager/values.yaml
+++ b/charts/manager/values.yaml
@@ -39,3 +39,6 @@ podDisruptionBudget:
 # annotations:
 #   what: "add annotations"
 #   where: "in the pods"
+envFrom:
+  - configMapRef:
+      name: manager-config


### PR DESCRIPTION
This pull request updates the configuration management for `app` and `manager` Helm charts by standardizing the naming conventions for `ConfigMap` resources and introducing support for `envFrom` values. The changes improve clarity and flexibility in environment variable management.

### Updates to `app` Helm chart:

* **Standardized ConfigMap naming**: Changed the `ConfigMap` name from `{{ .Release.Name }}-config` to `app-config` in `charts/app/templates/app.cm.yaml`.
* **Added `envFrom` support**: Introduced the ability to configure environment variables using `envFrom` in `charts/app/templates/app.deploy.yaml` and `charts/app/values.yaml`. [[1]](diffhunk://#diff-0720014cb417d58c8cbb5717d9aa6402e157855002fdb20373eea9f2677fd2f0R55-R58) [[2]](diffhunk://#diff-dfbca39ca13a7dd62bff1bd65a1ea1aa719d16eb5ccda48ef12a2eead0bf865fR71-R73)

### Updates to `manager` Helm chart:

* **Standardized ConfigMap naming**: Changed the `ConfigMap` name from `{{ .Release.Name }}-config` to `manager-config` in `charts/manager/templates/manager.cm.yaml`.
* **Added `envFrom` support**: Introduced the ability to configure environment variables using `envFrom` in `charts/manager/templates/manager.deploy.yaml` and `charts/manager/values.yaml`. [[1]](diffhunk://#diff-73f8aec5fbe895129bf5e4593879747ac78ca8e7d7ce7a070636bff1f8ee123bR51-R54) [[2]](diffhunk://#diff-a30244a1c6b29393df50213d0af45e3d3d6bc1f729f291602a990a78d41af452R42-R44)