### PR TITLE
[sc-12121] arag fallback with one link constraint

### DIFF
--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/basic-elements/connectable-entry/connectable-entry.component.html
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/basic-elements/connectable-entry/connectable-entry.component.html
@@ -4,6 +4,7 @@
     #output
     class="output"
     [class.active]="activeState()"
+    [class.disabled]="disabledState()"
     (click)="onOutputClick()">
     <svg
       width="6"

--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/basic-elements/connectable-entry/connectable-entry.component.scss
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/basic-elements/connectable-entry/connectable-entry.component.scss
@@ -19,7 +19,6 @@
     background: $color-light-stronger;
     border-radius: 50%;
     border: 1.5px solid $color-neutral-regular;
-    cursor: pointer;
     display: flex;
     flex-shrink: 0;
     height: rhythm(2);
@@ -35,13 +34,21 @@
       transition: opacity $transition-hint;
     }
 
-    &:hover,
-    &.active {
-      border-color: $color-primary-regular;
+    &:not(.disabled) {
+      cursor: pointer;
 
-      svg {
-        opacity: 1;
+      &:hover,
+      &.active {
+        border-color: $color-primary-regular;
+
+        svg {
+          opacity: 1;
+        }
       }
+    }
+    &.disabled {
+      border-color: $color-neutral-light;
+      cursor: default;
     }
   }
 }

--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/basic-elements/connectable-entry/connectable-entry.component.ts
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/basic-elements/connectable-entry/connectable-entry.component.ts
@@ -32,11 +32,14 @@ export class ConnectableEntryComponent {
 
   clickOutput = output();
   activeState = signal(false);
+  disabledState = signal(false);
 
   @ViewChild('output') outputElement!: ElementRef;
 
   onOutputClick() {
-    this.clickOutput.emit();
-    this.activeState.set(true);
+    if (!this.disabledState()) {
+      this.clickOutput.emit();
+      this.activeState.set(true);
+    }
   }
 }

--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/basic-elements/node.directive.ts
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/basic-elements/node.directive.ts
@@ -18,6 +18,7 @@ export class NodeDirective {
   addNode = output<{ entry: ConnectableEntryComponent; targetColumn: number }>();
   removeNode = output();
   selectNode = output();
+  configUpdated = output();
 
   @ViewChild(NodeBoxComponent) boxComponent!: NodeBoxComponent;
 

--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/nodes/ask/ask-node.component.ts
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/nodes/ask/ask-node.component.ts
@@ -50,6 +50,9 @@ export class AskNodeComponent extends NodeDirective implements OnInit {
         take(1),
         switchMap((account) => this.sdk.nuclia.db.getKnowledgeBoxes(account.slug, account.id)),
       )
-      .subscribe((kbList) => this.kbList.set(kbList));
+      .subscribe((kbList) => {
+        this.kbList.set(kbList);
+        this.configUpdated.emit();
+      });
   }
 }

--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/nodes/internet/internet-form.component.ts
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/nodes/internet/internet-form.component.ts
@@ -9,7 +9,7 @@ import { InternetProviderType } from '@nuclia/core';
 import { InfoCardComponent } from '@nuclia/sistema';
 import { forkJoin, map, switchMap, take } from 'rxjs';
 import { ConfigurationFormComponent, FormDirective, RulesFieldComponent } from '../../basic-elements';
-import { InternetAgentUI } from '../../workflow.models';
+import { InternetAgentUI, isInternetProvider } from '../../workflow.models';
 
 @Component({
   selector: 'app-internet-form',
@@ -73,12 +73,14 @@ export class InternetFormComponent extends FormDirective implements OnInit {
           this.aragUrl.set(this.navigationService.getRetrievalAgentUrl(account.slug, arag.slug));
           return arag;
         }),
-        switchMap((arag) => arag.getDrivers('sql')),
+        switchMap((arag) => arag.getDrivers()),
         map((drivers) =>
-          drivers.map(
-            (driver) =>
-              new OptionModel({ id: driver.id, label: driver.name, value: driver.provider, help: driver.provider }),
-          ),
+          drivers
+            .filter((driver) => isInternetProvider(driver.provider))
+            .map(
+              (driver) =>
+                new OptionModel({ id: driver.id, label: driver.name, value: driver.provider, help: driver.provider }),
+            ),
         ),
       )
       .subscribe((options) => this.providerOptions.set(options));

--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/workflow.effects.ts
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/workflow.effects.ts
@@ -80,6 +80,14 @@ export class WorkflowEffectService {
         node.nodeRef.setInput('state', 'unsaved');
       }
     }
+
+    // Disable fallback entry when a node is already linked to it, enable it otherwise (for the case a child node has been removed)
+    const fallbackEntry = node.nodeRef.instance.boxComponent.connectableEntries?.find(
+      (entry) => entry.id() === 'fallback',
+    );
+    if (fallbackEntry) {
+      fallbackEntry.disabledState.set(!!node.fallback);
+    }
   }
 
   private checkForUpdates(node: ParentNode, backendState: BackendState, category: NodeCategory) {

--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/workflow.models.ts
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/workflow.models.ts
@@ -156,6 +156,7 @@ export interface CypherAgentUI extends CommonAgentConfig {
 
 export interface AskAgentUI extends CommonAgentConfig {
   sources: string;
+  fallback?: ContextAgent | null;
   pre_queries?: string[];
   filters?: string[];
   security_groups?: string[];

--- a/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/workflow.service.ts
+++ b/apps/dashboard/src/app/retrieval-agent/agent-dashboard/workflow/workflow.service.ts
@@ -481,6 +481,7 @@ export class WorkflowService {
     nodeRef.instance.addNode.subscribe((data) => this.triggerNodeCreation(data.entry, data.targetColumn));
     nodeRef.instance.removeNode.subscribe(() => this.removeNodeAndLink(nodeRef, column));
     nodeRef.instance.selectNode.subscribe(() => this.selectNode(nodeRef.instance.id, nodeCategory));
+    nodeRef.instance.configUpdated.subscribe(() => setTimeout(() => this.updateLinksOnColumn(columnIndex)));
 
     setTimeout(() => this.updateLinksOnColumn(columnIndex));
     addNode(nodeRef, nodeType, nodeCategory, origin, nodeConfig, agent);

--- a/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.models.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.models.ts
@@ -197,7 +197,7 @@ export interface CypherAgentCreation {
 export interface AskAgentCreation {
   module: 'ask';
   sources: string[];
-  fallback?: ContextAgent;
+  fallback?: ContextAgent | null;
   pre_queries?: string[];
   filters?: string[];
   security_groups?: string[];


### PR DESCRIPTION
- Ask agent can have only one fallback node, disable fallback output when it already has a child link
- Update fallback link position when ask conffig is fully loaded (as it may change the box height)
- Properly save on backend when we delete fallback node from the UI