### PR TITLE
charts: Remove secrets from ConfigMap

### DIFF
--- a/apps/dashboard/src/app/app.component.ts
+++ b/apps/dashboard/src/app/app.component.ts
@@ -37,8 +37,8 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     private config: BackendConfigurationService,
     private sdk: SDKService,
     private modalService: SisModalService,
-    private paTranslate: PaTranslateService,
     private labelService: LabelsService,
+    private paTranslate: PaTranslateService,
     @Inject(DOCUMENT) private document: any,
   ) {
     this.unsubscribeAll = new Subject();

--- a/apps/manager-v2/src/app/app.component.ts
+++ b/apps/manager-v2/src/app/app.component.ts
@@ -21,8 +21,8 @@ export class AppComponent implements OnInit, OnDestroy {
 
   constructor(
     private paTranslate: PaTranslateService,
-    private ngxTranslate: TranslateService,
     private config: BackendConfigurationService,
+    private ngxTranslate: TranslateService,
   ) {
     const userLocale = localStorage.getItem(userLocaleKey);
     this.initTranslate(userLocale);

--- a/charts/app/templates/app.cm.yaml
+++ b/charts/app/templates/app.cm.yaml
@@ -9,7 +9,6 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
 data:
-  SITE_KEY: "{{ .Values.site_key }}"
   APP_NAME: {{ .Values.app_name }}
   CDN: "{{ .Values.cdn }}"
   BRAND_NAME: "{{ .Values.brand_name }}"
@@ -17,7 +16,6 @@ data:
   ASSETS_PATH: "{{ .Values.assets_path }}"
   NO_STRIPE: "{{ .Values.no_stripe }}"
   SENTRY_ENV: {{ .Values.sentry_environment }}
-  SENTRY_URL: "{{ .Values.sentry_url }}"
   EDITOR_URL: "{{ .Values.editor_url }}"
   STF_VERSION: "{{ .Chart.Version }}"
   EMAIL_DOMAIN: "{{ .Values.email_domain }}"

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -18,7 +18,6 @@ service:
   internalPort: 80
   externalPort: 80
 
-site_key: XXX
 app_name: app
 no_stripe: false
 cdn: XXX
@@ -26,7 +25,6 @@ brand_name: XXX
 brand_domain: XXX
 assets_path: XXX
 sentry_environment: stage
-sentry_url: XXX
 editor_url: XXX
 email_domain: XXX
 saml_enabled: XXX
@@ -71,3 +69,8 @@ podDisruptionBudget:
 envFrom:
   - configMapRef:
       name: app-config
+
+## Intended to be used with secret
+# env:
+#   SITE_KEY: XXX
+#   SENTRY_URL: XXX

--- a/charts/manager/templates/manager.cm.yaml
+++ b/charts/manager/templates/manager.cm.yaml
@@ -10,13 +10,11 @@ metadata:
     heritage: "{{ .Release.Service }}"
 data:
   API_PATH: {{ .Values.api_path }}
-  SITE_KEY: "{{ .Values.site_key }}"
   BRAND_NAME: "{{ .Values.brand_name }}"
   BRAND_DOMAIN: "{{ .Values.brand_domain }}"
   ASSETS_PATH: "{{ .Values.assets_path }}"
   APP_NAME: {{ .Values.app_name }}
   NO_STRIPE: "{{ .Values.no_stripe }}"
   SENTRY_ENV: {{ .Values.sentry_environment }}
-  SENTRY_URL: "{{ .Values.sentry_url }}"
   STF_VERSION: "{{ .Chart.Version }}"
   EMAIL_DOMAIN: "{{ .Values.email_domain }}"

--- a/charts/manager/values.yaml
+++ b/charts/manager/values.yaml
@@ -19,14 +19,12 @@ service:
   externalPort: 80
 
 api_path: XXX
-site_key: XXX
 app_name: app
 no_stripe: false
 brand_name: XXX
 brand_domain: XXX
 assets_path: XXX
 sentry_environment: stage
-sentry_url: XXX
 
 virtualService:
   enabled: false
@@ -42,3 +40,8 @@ podDisruptionBudget:
 envFrom:
   - configMapRef:
       name: manager-config
+
+## Intended to be used with secret
+# env:
+#   SITE_KEY: XXX
+#   SENTRY_URL: XXX


### PR DESCRIPTION
This pull request refactors configuration management for sensitive data by removing `SITE_KEY` and `SENTRY_URL` from the Helm charts' `ConfigMap` and `values.yaml` files. These values are now intended to be managed as secrets, improving security practices. The changes affect both the `app` and `manager` charts.

### Changes to configuration management:

* [`charts/app/templates/app.cm.yaml`](diffhunk://#diff-26ed6a864e2f47f08cb34f34fc86184c2b6d90c777f9200bc1202d57b906d5fbL12-L20): Removed `SITE_KEY` and `SENTRY_URL` from the `ConfigMap` definition.
* [`charts/app/values.yaml`](diffhunk://#diff-dfbca39ca13a7dd62bff1bd65a1ea1aa719d16eb5ccda48ef12a2eead0bf865fL21-L29): Removed `site_key` and `sentry_url` from the `values.yaml` file. Added comments indicating these values should be managed as secrets. [[1]](diffhunk://#diff-dfbca39ca13a7dd62bff1bd65a1ea1aa719d16eb5ccda48ef12a2eead0bf865fL21-L29) [[2]](diffhunk://#diff-dfbca39ca13a7dd62bff1bd65a1ea1aa719d16eb5ccda48ef12a2eead0bf865fR72-R76)
* [`charts/manager/templates/manager.cm.yaml`](diffhunk://#diff-dbe807a14a4343ece07a9735f4cfbb9b80aa904c6cb81d4e39dcee2dab650f2dL13-L20): Removed `SITE_KEY` and `SENTRY_URL` from the `ConfigMap` definition.
* [`charts/manager/values.yaml`](diffhunk://#diff-a30244a1c6b29393df50213d0af45e3d3d6bc1f729f291602a990a78d41af452L22-L29): Removed `site_key` and `sentry_url` from the `values.yaml` file. Added comments indicating these values should be managed as secrets. [[1]](diffhunk://#diff-a30244a1c6b29393df50213d0af45e3d3d6bc1f729f291602a990a78d41af452L22-L29) [[2]](diffhunk://#diff-a30244a1c6b29393df50213d0af45e3d3d6bc1f729f291602a990a78d41af452R43-R47)