### PR TITLE
Fix homeUrl: make sure clicking on nuclia logo always works

### DIFF
--- a/libs/core/src/lib/api/sdk.service.ts
+++ b/libs/core/src/lib/api/sdk.service.ts
@@ -88,6 +88,9 @@ export class SDKService {
   set arag(arag: RetrievalAgent | null) {
     this._arag.next(arag);
   }
+  get arag(): Observable<RetrievalAgent | null> {
+    return this._arag.asObservable();
+  }
 
   set account(account: Account | null) {
     this.nuclia.options.accountId = account?.id;

--- a/libs/core/src/lib/services/navigation.service.ts
+++ b/libs/core/src/lib/services/navigation.service.ts
@@ -18,7 +18,7 @@ export class NavigationService {
     @Inject('staticEnvironmentConfiguration') private environment: StaticEnvironmentConfiguration,
   ) {}
 
-  homeUrl: Observable<string> = combineLatest([this.sdk.currentAccount, this.sdk.currentKb, this.sdk.currentArag]).pipe(
+  homeUrl: Observable<string> = combineLatest([this.sdk.currentAccount, this.sdk.currentKb, this.sdk.arag]).pipe(
     map(([account, kb, arag]) => {
       if (account && this.inAccountManagement(location.pathname)) {
         return this.getAccountManageUrl(account.slug);


### PR DESCRIPTION
From [combineLatest documentation](https://www.learnrxjs.io/learn-rxjs/operators/combination/combinelatest):
> `combineLatest` will not emit an initial value until each observable emits at least one value

`currentArag` is from a ReplaySubject, so it's not emitting until the user select an agent, while `arag` is from a behavior subject.