### PR TITLE
[sc-12307] retrieval agent test and interactions 4

### DIFF
--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/ask/ask-form.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/ask/ask-form.component.ts
@@ -2,7 +2,7 @@ import { CommonModule } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, OnInit, signal } from '@angular/core';
 import { FormArray, FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { RouterLink } from '@angular/router';
-import { NavigationService, SDKService } from '@flaps/core';
+import { SDKService } from '@flaps/core';
 import { OptionModel, PaButtonModule, PaTextFieldModule, PaTogglesModule } from '@guillotinaweb/pastanaga-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { NucliaDBDriver } from '@nuclia/core';
@@ -32,7 +32,6 @@ import { aragUrl } from '../../workflow.state';
 })
 export class AskFormComponent extends FormDirective implements OnInit {
   private sdk = inject(SDKService);
-  private navigationService = inject(NavigationService);
 
   override form = new FormGroup({
     ask: new FormGroup({
@@ -69,7 +68,9 @@ export class AskFormComponent extends FormDirective implements OnInit {
         take(1),
         switchMap((arag) => arag.getDrivers('nucliadb') as Observable<NucliaDBDriver[]>),
         map((drivers) =>
-          drivers.map((driver) => new OptionModel({ id: driver.id, label: driver.name, value: driver.config.kbid })),
+          drivers.map(
+            (driver) => new OptionModel({ id: driver.identifier, label: driver.name, value: driver.identifier }),
+          ),
         ),
       )
       .subscribe((options) => this.sourceOptions.set(options));

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/cypher/cypher-form.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/cypher/cypher-form.component.ts
@@ -59,7 +59,9 @@ export class CypherFormComponent extends FormDirective implements OnInit {
         take(1),
         switchMap((arag) => arag.getDrivers('cypher')),
         map((drivers) =>
-          drivers.map((driver) => new OptionModel({ id: driver.id, label: driver.name, value: driver.id })),
+          drivers.map(
+            (driver) => new OptionModel({ id: driver.identifier, label: driver.name, value: driver.identifier }),
+          ),
         ),
       )
       .subscribe((options) => this.sourceOptions.set(options));

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/cypher/cypher-node.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/cypher/cypher-node.component.ts
@@ -21,7 +21,7 @@ export class CypherNodeComponent extends NodeDirective implements OnInit {
   cypherConfig = computed<ConfigBlockItem[]>(() => {
     if (this.config()) {
       const config = this.config() as CypherAgentUI;
-      const source = this.cypherDrivers().find((driver) => driver.id === config.source);
+      const source = this.cypherDrivers().find((driver) => driver.identifier === config.source);
       return [
         {
           title: this.translate.instant('retrieval-agents.workflow.node-types.cypher.form.source'),

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/guardrails/guardrails-form.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/guardrails/guardrails-form.component.ts
@@ -78,7 +78,12 @@ export class GuardrailsFormComponent extends FormDirective implements OnInit {
         map((drivers) =>
           drivers.map(
             (driver) =>
-              new OptionModel({ id: driver.id, label: driver.name, value: driver.provider, help: driver.provider }),
+              new OptionModel({
+                id: driver.identifier,
+                label: driver.name,
+                value: driver.identifier,
+                help: driver.provider,
+              }),
           ),
         ),
       )

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/internet/internet-form.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/internet/internet-form.component.ts
@@ -75,7 +75,12 @@ export class InternetFormComponent extends FormDirective implements OnInit {
             .filter((driver) => isInternetProvider(driver.provider))
             .map(
               (driver) =>
-                new OptionModel({ id: driver.id, label: driver.name, value: driver.provider, help: driver.provider }),
+                new OptionModel({
+                  id: driver.identifier,
+                  label: driver.name,
+                  value: driver.identifier,
+                  help: driver.provider,
+                }),
             ),
         ),
       )

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/mcp/mcp-form.component.html
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/mcp/mcp-form.component.html
@@ -48,8 +48,8 @@
       <pa-select
         id="source"
         formControlName="source">
-        @for (source of mcpList(); track source.id) {
-          <pa-option [value]="source.id">{{ source.name }}</pa-option>
+        @for (source of mcpList(); track source.identifier) {
+          <pa-option [value]="source.identifier">{{ source.name }}</pa-option>
         }
       </pa-select>
     </div>

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/mcp/mcp-node.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/mcp/mcp-node.component.ts
@@ -26,7 +26,7 @@ export class McpNodeComponent extends NodeDirective implements OnInit {
           title: this.translate.instant('retrieval-agents.workflow.node-types.mcp.form.source'),
           content: [config.source]
             .map((source) => {
-              const mcp = this.mcpList().find((mcp) => mcp.id === source);
+              const mcp = this.mcpList().find((mcp) => mcp.identifier === source);
               return mcp?.name || source;
             })
             .join(', '),

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/rephrase/rephrase-form.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/rephrase/rephrase-form.component.ts
@@ -58,7 +58,9 @@ export class RephraseFormComponent extends FormDirective implements OnInit {
         take(1),
         switchMap((arag) => arag.getDrivers('nucliadb') as Observable<NucliaDBDriver[]>),
         map((drivers) =>
-          drivers.map((driver) => new OptionModel({ id: driver.id, label: driver.name, value: driver.config.kbid })),
+          drivers.map(
+            (driver) => new OptionModel({ id: driver.identifier, label: driver.name, value: driver.identifier }),
+          ),
         ),
       )
       .subscribe((options) => this.sourceOptions.set(options));

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/sql/sql-form.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/sql/sql-form.component.ts
@@ -77,7 +77,9 @@ export class SqlFormComponent extends FormDirective implements OnInit {
         take(1),
         switchMap((arag) => arag.getDrivers('sql')),
         map((drivers) =>
-          drivers.map((driver) => new OptionModel({ id: driver.id, label: driver.name, value: driver.id })),
+          drivers.map(
+            (driver) => new OptionModel({ id: driver.identifier, label: driver.name, value: driver.identifier }),
+          ),
         ),
       )
       .subscribe((options) => this.sourceOptions.set(options));

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/sql/sql-node.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/nodes/sql/sql-node.component.ts
@@ -21,7 +21,7 @@ export class SqlNodeComponent extends NodeDirective implements OnInit {
   sqlConfig = computed<ConfigBlockItem[]>(() => {
     if (this.config()) {
       const config = this.config() as SqlAgentUI;
-      const source = this.sqlDrivers().find((driver) => driver.id === config.source);
+      const source = this.sqlDrivers().find((driver) => driver.identifier === config.source);
       const display: ConfigBlockItem[] = [
         {
           title: this.translate.instant('retrieval-agents.workflow.node-types.sql.form.source'),

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.component.html
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.component.html
@@ -37,7 +37,10 @@
     @if (runningQuestion()) {
       <div class="block-separator"></div>
       <div class="interactions">
-        <section class="category-section">
+        @if (runningTest) {
+          Waiting for a response…
+        }
+        <!-- <section class="category-section">
           <app-chip fill>{{ 'retrieval-agents.workflow.sidebar.test.interactions.user-input' | translate }}</app-chip>
           <blockquote class="user-input">
             {{ runningQuestion() }}
@@ -64,7 +67,7 @@
               { content: 'Condition true' }
             ]"
             [cost]="{ timing: 325, tokens: 142 }"></app-agent-block>
-        </section>
+        </section> -->
       </div>
     }
 

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.component.html
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.component.html
@@ -37,7 +37,7 @@
     @if (runningQuestion()) {
       <div class="block-separator"></div>
       <div class="interactions">
-        @if (runningTest) {
+        @if (runningTest()) {
           Waiting for a response…
         }
         <!-- <section class="category-section">

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.component.ts
@@ -41,7 +41,8 @@ export class TestPanelComponent implements OnInit {
   triggerRun() {
     if (this.question.valid) {
       this.question.disable();
-      this.service.runTest(this.question.getRawValue(), this.session.getRawValue());
+      const question = this.question.getRawValue().trim();
+      this.service.runTest(question, this.session.getRawValue());
     }
   }
 

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.service.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { SDKService } from '@flaps/core';
-import { RetrievalAgent, Session } from '@nuclia/core';
-import { map, Observable, switchMap, take } from 'rxjs';
+import { InteractionOperation, RetrievalAgent, Session } from '@nuclia/core';
+import { map, Observable, switchMap, take, tap } from 'rxjs';
 import { runTest, stopTest } from '../../workflow.state';
 
 const TEST_SESSION_SLUG_PREFIX = 'test-session';
@@ -55,10 +55,10 @@ export class TestPanelService {
         switchMap(({ sessionId, arag }) => {
           this.currentSessionId = sessionId;
           // Open the websocket connection and send the question
-          // return arag
-          //   .listenSessionInteractions(sessionId)
-          //   .pipe(tap(() => arag.interactWithSession(sessionId, question, InteractionOperation.question)));
-          return arag.interaction(sessionId, question);
+          return arag
+            .listenSessionInteractions(sessionId)
+            .pipe(tap(() => arag.interactWithSession(sessionId, question, InteractionOperation.question)));
+          // return arag.interaction(sessionId, question);
         }),
       )
       .subscribe({

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.service.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/sidebar/test-agent/test-panel.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { SDKService } from '@flaps/core';
-import { InteractionOperation, RetrievalAgent, Session } from '@nuclia/core';
-import { map, Observable, switchMap, take, tap } from 'rxjs';
+import { RetrievalAgent, Session } from '@nuclia/core';
+import { map, Observable, switchMap, take } from 'rxjs';
 import { runTest, stopTest } from '../../workflow.state';
 
 const TEST_SESSION_SLUG_PREFIX = 'test-session';
@@ -55,16 +55,16 @@ export class TestPanelService {
         switchMap(({ sessionId, arag }) => {
           this.currentSessionId = sessionId;
           // Open the websocket connection and send the question
-          return arag
-            .listenSessionInteractions(sessionId)
-            .pipe(tap(() => arag.interactWithSession(sessionId, question, InteractionOperation.question)));
-          // return arag.interaction(sessionId, question);
+          // return arag
+          //   .listenSessionInteractions(sessionId)
+          //   .pipe(tap(() => arag.interactWithSession(sessionId, question, InteractionOperation.question)));
+          return arag.interaction(sessionId, question);
         }),
       )
       .subscribe({
         next: (data) => {
           // TODO: update the state with the data we get from the session
-          console.debug(`Data we get from websocket:`, data);
+          console.debug(`Data we get from interaction:`, data);
         },
         error: (error) => {
           console.error(`Error occurred while creating the session`, error);

--- a/libs/common/src/lib/retrieval-agent/drivers/drivers-page.component.html
+++ b/libs/common/src/lib/retrieval-agent/drivers/drivers-page.component.html
@@ -56,7 +56,7 @@
           <pa-table-cell header>{{ 'retrieval-agents.drivers.table.provider' | translate }}</pa-table-cell>
           <pa-table-cell-menu header>{{ 'retrieval-agents.drivers.table.actions' | translate }}</pa-table-cell-menu>
         </pa-table-header>
-        @for (driver of drivers(); track driver.id) {
+        @for (driver of drivers(); track driver.identifier) {
           <pa-table-row>
             <pa-table-cell>{{ driver.name }}</pa-table-cell>
             <pa-table-cell>{{ 'retrieval-agents.drivers.types.' + driver.provider | translate }}</pa-table-cell>

--- a/libs/sdk-core/src/lib/db/retrieval-agent/driver.models.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/driver.models.ts
@@ -1,7 +1,7 @@
 import { ProviderType } from './retrieval-agent.types';
 
 export interface IDriver {
-  id: string;
+  identifier: string;
   provider: ProviderType;
   name: string;
   config:
@@ -16,7 +16,7 @@ export interface IDriver {
     | McpStdioConfig;
 }
 
-export type DriverCreation = Omit<IDriver, 'id'>;
+export type DriverCreation = Omit<IDriver, 'identifier'>;
 
 export type Driver =
   | BraveDriver

--- a/libs/sdk-core/src/lib/db/retrieval-agent/driver.models.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/driver.models.ts
@@ -1,13 +1,4 @@
-export type InternetProviderType = 'brave' | 'perplexity' | 'tavily' | 'google';
-export type GuardrailsProviderType = 'alinia';
-export type ProviderType =
-  | InternetProviderType
-  | GuardrailsProviderType
-  | 'cypher'
-  | 'nucliadb'
-  | 'sql'
-  | 'mcpsse'
-  | 'mcpstdio';
+import { ProviderType } from './retrieval-agent.types';
 
 export interface IDriver {
   id: string;

--- a/libs/sdk-core/src/lib/db/retrieval-agent/index.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/index.ts
@@ -1,5 +1,7 @@
 export * from './driver.models';
+export * from './interactions.models';
 export * from './retrieval-agent';
 export * from './retrieval-agent.models';
+export * from './retrieval-agent.types';
 export * from './session';
 export * from './session.models';

--- a/libs/sdk-core/src/lib/db/retrieval-agent/interactions.models.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/interactions.models.ts
@@ -1,0 +1,59 @@
+import { AragModule } from './retrieval-agent.types';
+
+export enum InteractionOperation {
+  question = 0,
+  quit = 1,
+}
+export enum AnswerOperation {
+  answer = 0,
+  quit = 1,
+  start = 2,
+  done = 3,
+  error = 4,
+}
+
+export interface AragAnswer {
+  exception: unknown;
+  answer: string | null;
+  generated_text: string | null;
+  step: AragAnswerStep | null;
+  context: AragAnswerContext | null;
+  operation: AnswerOperation;
+  seqid: number | null;
+}
+
+export interface AragAnswerStep {
+  original_question_uuid: string;
+  actual_question_uuid: string;
+  module: AragModule;
+  title: string;
+  value: string;
+  reason: string;
+  prompt: string;
+  timeit: number;
+  input_nuclia_tokens: number;
+  output_nuclia_tokens: number;
+}
+
+export interface AragAnswerChunk {
+  chunk_id: string;
+  title: string;
+  text: string;
+  labels: string[];
+  url: string[];
+}
+
+export interface AragAnswerContext {
+  original_question_uuid: string;
+  actual_question_uuid: string;
+  question: string;
+  chunks: AragAnswerChunk[];
+  images: unknown;
+  structured: unknown[];
+  source: string;
+  agent: string;
+  summary: string;
+  answer: string | null;
+  title: string;
+  missing: unknown;
+}

--- a/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.models.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.models.ts
@@ -2,7 +2,16 @@ import { Observable } from 'rxjs';
 import { ResourceProperties } from '../db.models';
 import { IKnowledgeBoxBase, IKnowledgeBoxItem, InviteKbData, IWritableKnowledgeBox, ResourcePagination } from '../kb';
 import { ExtractedDataTypes } from '../resource';
-import { Driver, DriverCreation, InternetProviderType, ProviderType } from './driver.models';
+import { Driver, DriverCreation } from './driver.models';
+import { AragAnswer, InteractionOperation } from './interactions.models';
+import {
+  AragModule,
+  ContextModule,
+  GenerationModule,
+  PostprocessModule,
+  PreprocessModule,
+  ProviderType,
+} from './retrieval-agent.types';
 import { Session } from './session';
 import { ISession } from './session.models';
 
@@ -36,11 +45,6 @@ export interface SessionCreation {
   format: 'PLAIN' | 'HTML' | 'RST' | 'MARKDOWN' | 'JSON' | 'KEEP_MARKDOWN' | 'JSONL' | 'PLAIN_BLANKLINE_SPLIT';
 }
 
-export enum InteractionOperation {
-  question = 0,
-  quit = 1,
-}
-
 export interface IRetrievalAgent
   extends Omit<
     IWritableKnowledgeBox,
@@ -58,9 +62,8 @@ export interface IRetrievalAgent
   getSession(uuid: string, show?: SessionProperties[], extracted?: ExtractedDataTypes[]): Observable<ISession>;
   listSessions(page?: number, size?: number): Observable<SessionList>;
   createSession(session: SessionCreation): Observable<SessionCreationResponse>;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  listenSessionInteractions(sessionId: string): Observable<any>;
-  interaction(sessionId: string, question: string): Observable<unknown>;
+  listenSessionInteractions(sessionId: string): Observable<AragAnswer[]>;
+  interaction(sessionId: string, question: string): Observable<AragAnswer[]>;
   interactWithSession(sessionId: string, question: string, operation: InteractionOperation): void;
   resetSessionInteraction(sessionId: string): void;
 
@@ -99,21 +102,8 @@ export interface Rule {
   prompt: string;
 }
 
-export type PreprocessModule = 'historical' | 'rephrase' | 'pre_conditional' | 'preprocess_alinia';
-export type ContextModule =
-  | InternetProviderType
-  | 'sql'
-  | 'mcp'
-  | 'cypher'
-  | 'ask'
-  | 'context_conditional'
-  | 'restricted'
-  | 'sparql';
-export type GenerationModule = 'summarize' | 'generate';
-export type PostprocessModule = 'restart' | 'remi' | 'external' | 'post_conditional' | 'postprocess_alinia';
-
 export interface BaseAgent {
-  module: PreprocessModule | ContextModule | GenerationModule | PostprocessModule;
+  module: AragModule;
   id?: string;
   rules?: string[] | null;
   title?: string;

--- a/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.models.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.models.ts
@@ -2,7 +2,7 @@ import { Observable } from 'rxjs';
 import { ResourceProperties } from '../db.models';
 import { IKnowledgeBoxBase, IKnowledgeBoxItem, InviteKbData, IWritableKnowledgeBox, ResourcePagination } from '../kb';
 import { ExtractedDataTypes } from '../resource';
-import { Driver, DriverCreation } from './driver.models';
+import { Driver } from './driver.models';
 import { AragAnswer, InteractionOperation } from './interactions.models';
 import {
   AragModule,
@@ -70,7 +70,7 @@ export interface IRetrievalAgent
   inviteToAgent(data: InviteKbData): Observable<void>;
 
   getDrivers(provider?: ProviderType): Observable<Driver[]>;
-  addDriver(driver: DriverCreation): Observable<void>;
+  addDriver(driver: Driver): Observable<void>;
   patchDriver(driver: Driver): Observable<void>;
   deleteDriver(driverId: string): Observable<void>;
 

--- a/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.ts
@@ -1,12 +1,12 @@
 import { map, Observable } from 'rxjs';
 import { InviteKbData, WritableKnowledgeBox } from '../kb';
-import { Driver, DriverCreation, ProviderType } from './driver.models';
+import { Driver, DriverCreation } from './driver.models';
+import { AragAnswer, InteractionOperation } from './interactions.models';
 import {
   ContextAgent,
   ContextAgentCreation,
   GenerationAgent,
   GenerationAgentCreation,
-  InteractionOperation,
   IRetrievalAgent,
   PostprocessAgent,
   PostprocessAgentCreation,
@@ -18,6 +18,7 @@ import {
   SessionList,
   SessionPagination,
 } from './retrieval-agent.models';
+import { ProviderType } from './retrieval-agent.types';
 import { Session } from './session';
 import { ISession } from './session.models';
 
@@ -84,8 +85,9 @@ export class RetrievalAgent extends WritableKnowledgeBox implements IRetrievalAg
    * @param question Question to send to the agent
    * @returns
    */
-  interaction(sessionId: string, question: string): Observable<unknown> {
-    return this.nuclia.rest.post(this.getInteractionPath(sessionId), {
+  interaction(sessionId: string, question: string): Observable<AragAnswer[]> {
+    const fullPath = this.getInteractionPath(sessionId);
+    return this.nuclia.rest.post(fullPath, {
       question,
       operation: InteractionOperation.question,
     });

--- a/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.ts
@@ -1,6 +1,6 @@
 import { map, Observable } from 'rxjs';
 import { InviteKbData, WritableKnowledgeBox } from '../kb';
-import { Driver, DriverCreation } from './driver.models';
+import { Driver, IDriver } from './driver.models';
 import { AragAnswer, InteractionOperation } from './interactions.models';
 import {
   ContextAgent,
@@ -173,7 +173,7 @@ export class RetrievalAgent extends WritableKnowledgeBox implements IRetrievalAg
    * Add driver to the Retrieval Agent
    * @param driver BraveDriver | CypherDriver | NucliaDBDriver | PerplexityDriver | TavilyDriver | SqlDriver | McpDriver
    */
-  addDriver(driver: DriverCreation): Observable<void> {
+  addDriver(driver: IDriver): Observable<void> {
     return this.nuclia.rest.post(`${this.path}/drivers`, driver);
   }
 
@@ -182,7 +182,7 @@ export class RetrievalAgent extends WritableKnowledgeBox implements IRetrievalAg
    * @param driver BraveDriver | CypherDriver | NucliaDBDriver | PerplexityDriver | TavilyDriver | SqlDriver | McpDriver
    */
   patchDriver(driver: Driver): Observable<void> {
-    return this.nuclia.rest.patch(`${this.path}/driver/${driver.id}`, driver);
+    return this.nuclia.rest.patch(`${this.path}/driver/${driver.identifier}`, driver);
   }
 
   /**

--- a/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.types.ts
+++ b/libs/sdk-core/src/lib/db/retrieval-agent/retrieval-agent.types.ts
@@ -1,0 +1,24 @@
+export type InternetProviderType = 'brave' | 'perplexity' | 'tavily' | 'google';
+export type GuardrailsProviderType = 'alinia';
+export type ProviderType =
+  | InternetProviderType
+  | GuardrailsProviderType
+  | 'cypher'
+  | 'nucliadb'
+  | 'sql'
+  | 'mcpsse'
+  | 'mcpstdio';
+
+export type PreprocessModule = 'historical' | 'rephrase' | 'pre_conditional' | 'preprocess_alinia';
+export type ContextModule =
+  | InternetProviderType
+  | 'sql'
+  | 'mcp'
+  | 'cypher'
+  | 'ask'
+  | 'context_conditional'
+  | 'restricted'
+  | 'sparql';
+export type GenerationModule = 'summarize' | 'generate';
+export type PostprocessModule = 'restart' | 'remi' | 'external' | 'post_conditional' | 'postprocess_alinia';
+export type AragModule = PreprocessModule | ContextModule | GenerationModule | PostprocessModule;

--- a/libs/sdk-core/src/lib/rest/rest.ts
+++ b/libs/sdk-core/src/lib/rest/rest.ts
@@ -426,15 +426,20 @@ export class Rest implements IRest {
     this.webSockets[wsUrl] = new WebSocket(wsUrl);
 
     return new Observable((observer) => {
-      this.webSockets[wsUrl].onmessage = function (event) {
+      const ws = this.webSockets[wsUrl];
+      ws.onopen = function (event) {
+        console.debug(`Open event`, event);
+        observer.next('Opened' as T);
+      };
+      ws.onmessage = function (event) {
         console.debug(`Message`, event);
         observer.next(event.data);
       };
-      this.webSockets[wsUrl].onclose = function (event) {
+      ws.onclose = function (event) {
         console.debug(`Close event:`, event);
         observer.complete();
       };
-      this.webSockets[wsUrl].onerror = function (event) {
+      ws.onerror = function (event) {
         console.debug(`Error event:`, event);
         observer.error(event);
       };
@@ -455,7 +460,7 @@ export class Rest implements IRest {
   }
 
   /**
-   * Send data on the WebSocket previously opened on the given path
+   * Send data on the WebSocket previously opened on the given path.
    * @param path
    * @param data
    */
@@ -468,8 +473,6 @@ export class Rest implements IRest {
       );
     }
     const ws = this.webSockets[wsUrl];
-    ws.onopen = function () {
-      ws.send(data);
-    };
+    ws.send(new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' }));
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11317,17 +11317,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001449, caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001538, caniuse-lite@npm:^1.0.30001541, caniuse-lite@npm:^1.0.30001580, caniuse-lite@npm:^1.0.30001587, caniuse-lite@npm:^1.0.30001646":
-  version: 1.0.30001668
-  resolution: "caniuse-lite@npm:1.0.30001668"
-  checksum: ce6996901b5883454a8ddb3040f82342277b6a6275876dfefcdecb11f7e472e29877f34cae47c2b674f08f2e71971dd4a2acb9bc01adfe8421b7148a7e9e8297
-  languageName: node
-  linkType: hard
-
-"caniuse-lite@npm:^1.0.30001616, caniuse-lite@npm:^1.0.30001688":
-  version: 1.0.30001690
-  resolution: "caniuse-lite@npm:1.0.30001690"
-  checksum: f2c1b595f15d8de4d9ccd155d61ac9f00ac62f1515870505a0186266fd52aef169fcddc90d8a4814e52b77107244806466fadc2c216662f23f1022a430e735ee
+"caniuse-lite@npm:^1.0.0, caniuse-lite@npm:^1.0.30001449, caniuse-lite@npm:^1.0.30001464, caniuse-lite@npm:^1.0.30001517, caniuse-lite@npm:^1.0.30001538, caniuse-lite@npm:^1.0.30001541, caniuse-lite@npm:^1.0.30001580, caniuse-lite@npm:^1.0.30001587, caniuse-lite@npm:^1.0.30001616, caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001688":
+  version: 1.0.30001718
+  resolution: "caniuse-lite@npm:1.0.30001718"
+  checksum: c6598b6eb2c4358fc9f8ead8982bf5f9efdc1f29bb74948b9481d314ced10675bd0beb99771094ac52d56c2cec121049d1f18e9405cab7d81807816d1836b38a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
- Properly send messages to the WebSocket (we can now see the message sent in the network tab)
- Fix the drivers model to follow Ramon's changes:
  - `id` property will be removed (no more id generated by backend)
  - `identifier` must be provided by the front (backend create the full workflow in one snapshot) and it's this identifier which must be used as a source in agents