### PR TITLE
Invalidate cache once CDN sync happens

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -130,6 +130,13 @@ jobs:
         run: |-
           gsutil copy dist/sdk-core/umd/index.js gs://$CDN_STORAGE/nuclia-sdk.umd.js
 
+      - name: Invalidate CDN cache stage
+        if: ${{ ( steps.check-deploy.outputs.deploy-widget == 'yes' || steps.check-deploy.outputs.deploy-sdk == 'yes') && github.ref == 'refs/heads/main' }}
+        env:
+          GCP_PROJECT: ${{ secrets.GCP_STAGE_PROJECT_ID }}
+        run: |
+          gcloud compute url-maps invalidate-cdn-cache ${CDN_STORAGE} --path "/*" --global --project ${GCP_PROJECT}
+
       - name: Generate and push SDK docs
         if: steps.check-deploy.outputs.deploy-sdk == 'yes' && github.ref == 'refs/heads/main'
         run: |-

--- a/apps/dashboard/src/app/app.component.ts
+++ b/apps/dashboard/src/app/app.component.ts
@@ -36,8 +36,8 @@ export class AppComponent implements AfterViewInit, OnInit, OnDestroy {
     private ngxTranslate: TranslateService,
     private config: BackendConfigurationService,
     private sdk: SDKService,
-    private labelService: LabelsService,
     private modalService: SisModalService,
+    private labelService: LabelsService,
     private paTranslate: PaTranslateService,
     @Inject(DOCUMENT) private document: any,
   ) {

--- a/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
+++ b/libs/search-widget/src/widgets/search-widget/SearchBar.svelte
@@ -170,8 +170,8 @@
     widgetPlaceholder.set(placeholder || 'input.placeholder');
   });
 
-  let _features: Widget.WidgetFeatures = {};
   let _filters: WidgetFilters = {};
+  let _features: Widget.WidgetFeatures = {};
   let _jsonSchema: object | null = null;
   let _ragStrategies: RAGStrategy[] = [];
   let _ragImagesStrategies: RAGImageStrategy[] = [];


### PR DESCRIPTION
This pull request updates the deployment workflow in `.github/workflows/deploy.yml` to include a new step for invalidating the CDN cache when deploying to the main branch.

### Deployment workflow updates:
* Added a new step, "Invalidate CDN cache stage," to invalidate the CDN cache using the `gcloud compute url-maps invalidate-cdn-cache` command. This step is conditionally executed when either the widget or SDK is deployed and the branch is `main`.