### PR TITLE
Fix: Send run-agents ids in `agent_ids`  instead of `agents_ids`

### DIFF
--- a/libs/sdk-core/src/lib/db/resource/resource.ts
+++ b/libs/sdk-core/src/lib/db/resource/resource.ts
@@ -424,7 +424,7 @@ export class Resource extends ReadableResource implements IResource {
    * Run tasks on the resource and return the results
    * (the results are not stored within the resource).
    */
-  runTasks(agents_ids?: string[]) {
-    return this.nuclia.rest.post<TaskResults>(`${this.path}/run-agents`, { agents_ids }, undefined, undefined, true);
+  runTasks(agent_ids?: string[]) {
+    return this.nuclia.rest.post<TaskResults>(`${this.path}/run-agents`, { agent_ids }, undefined, undefined, true);
   }
 }


### PR DESCRIPTION
The filtering by id wasn't working properly because the parameter name was not correct