### PR TITLE
Allow for shorten token time with infinite loop refresh

### DIFF
--- a/libs/sdk-core/src/lib/auth/auth.ts
+++ b/libs/sdk-core/src/lib/auth/auth.ts
@@ -10,10 +10,8 @@ import { replaceSubdomainInUrl, setZoneInRegionalUrl } from '../rest/utils';
 const LOCALSTORAGE_AUTH_KEY = 'JWT_KEY';
 const LOCALSTORAGE_REFRESH_KEY = 'JWT_REFRESH_KEY';
 const LOCALSTORAGE_ID_TOKEN_KEY = 'JWT_ID_TOKEN_KEY';
-// Restore the 6 hours delay as 5 minutes is too painful for the desktop
-// (temporary until we have the Deno agent)
-const REFRESH_DELAY = 6 * 60 * 60 * 1000; // 6 hours
-// const REFRESH_DELAY = 5 * 60 * 1000; // 5 min
+const REFRESH_DELAY = 6 * 60 * 60 * 1000; // 6 hours — cap for long-lived tokens (e.g. legacy 120h)
+const REFRESH_BUFFER = 60_000; // refresh 1 minute before expiry
 
 /**
  * It manages authentication to the Nuclia backend.
@@ -436,9 +434,10 @@ export class Authentication implements IAuthentication {
         this.logout();
       } else {
         this._isAuthenticated.next(true);
-        // we refresh the token in 6 hours (or immediately if it should expire sooner)
-        // note: expiration might be undefined when running e2e tests, if so, we just use the default delay
-        const timeout = expiration && expiration - now < REFRESH_DELAY ? 0 : REFRESH_DELAY;
+        // Schedule refresh 1 minute before expiry, capped at REFRESH_DELAY for long-lived tokens.
+        // Falls back to REFRESH_DELAY when expiration is undefined (e.g. e2e tests).
+        const timeToExpiry = expiration ? expiration - now : REFRESH_DELAY;
+        const timeout = Math.max(Math.min(timeToExpiry - REFRESH_BUFFER, REFRESH_DELAY), 0);
         this.timerSubscription?.unsubscribe();
         this.timerSubscription = timer(timeout)
           .pipe(switchMap(() => (this.getRefreshToken() ? this.refresh() : of(false))))


### PR DESCRIPTION
The frontend was refreshing tokens in a tight infinite loop whenever the access token lifetime was shorter than 6 hours, because the refresh timer was hardcoded to either "now" or "6 hours" with no middle ground. This fixes the scheduling logic to refresh 1 minute before the token actually expires, making it work correctly with any lifetime. 

This unblocks reducing first-party app tokens from 120h to 1 hour.