### PR TITLE
Harden GHA #1

### DIFF
--- a/.github/workflows/bd_sca_scanner.yaml
+++ b/.github/workflows/bd_sca_scanner.yaml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
 
       - name: Calculate detect-args for BD SCA Scan
         id: calculate-detect-args

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,6 +47,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Authenticate to Google Cloud
         id: gcp-auth
@@ -243,6 +244,7 @@ jobs:
           ref: main
           path: tooling
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Push dashboard image to registries
         uses: ./tooling/.github/actions/build-img-regcache
@@ -382,6 +384,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Authenticate to Google Cloud
         id: gcp-auth
@@ -416,12 +420,13 @@ jobs:
           ref: main
           path: tooling
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Get chart version
         id: chart-version-app
         run: |
           VERSION=`cat apps/dashboard/VERSION`
-          echo "chart-version=$VERSION-${{ env.SHORT_SHA }}" >> $GITHUB_OUTPUT
+          echo "chart-version=$VERSION-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build and push helm chart
         uses: ./tooling/.github/actions/build-helm-chart
@@ -456,6 +461,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Authenticate to Google Cloud
         id: gcp-auth
@@ -490,12 +497,13 @@ jobs:
           ref: main
           path: tooling
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Get chart version
         id: chart-version-manager
         run: |
           VERSION=`cat apps/manager-v2/VERSION`
-          echo "chart-version=$VERSION-${{ env.SHORT_SHA }}" >> $GITHUB_OUTPUT
+          echo "chart-version=$VERSION-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build and push helm chart
         uses: ./tooling/.github/actions/build-helm-chart
@@ -530,6 +538,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Authenticate to Google Cloud
         id: gcp-auth
@@ -564,12 +574,13 @@ jobs:
           ref: main
           path: tooling
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Get chart version
         id: chart-version-rao
         run: |
           VERSION=`cat apps/rao/VERSION`
-          echo "chart-version=$VERSION-${{ env.SHORT_SHA }}" >> $GITHUB_OUTPUT
+          echo "chart-version=$VERSION-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build and push helm chart
         uses: ./tooling/.github/actions/build-helm-chart
@@ -604,6 +615,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Authenticate to Google Cloud
         id: gcp-auth
@@ -638,12 +651,13 @@ jobs:
           ref: main
           path: tooling
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Get chart version
         id: chart-version-platform
         run: |
           VERSION=`cat apps/platform/VERSION`
-          echo "chart-version=$VERSION-${{ env.SHORT_SHA }}" >> $GITHUB_OUTPUT
+          echo "chart-version=$VERSION-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build and push helm chart
         uses: ./tooling/.github/actions/build-helm-chart
@@ -678,6 +692,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Authenticate to Google Cloud
         id: gcp-auth
@@ -712,12 +728,13 @@ jobs:
           ref: main
           path: tooling
           token: ${{ steps.app-token.outputs.token }}
+          persist-credentials: false
 
       - name: Get chart version
         id: chart-version-auth
         run: |
           VERSION=`cat apps/auth/VERSION`
-          echo "chart-version=$VERSION-${{ env.SHORT_SHA }}" >> $GITHUB_OUTPUT
+          echo "chart-version=$VERSION-${SHORT_SHA}" >> $GITHUB_OUTPUT
 
       - name: Build and push helm chart
         uses: ./tooling/.github/actions/build-helm-chart
@@ -759,6 +776,11 @@ jobs:
           PROMO_PRODUCTION: ${{ env.PROMO_PRODUCTION }}
           TEAM: ${{ secrets.TEAM_NAME }}
           SLACK_TEAM: ${{ secrets.SLACK_TEAM }}
+          NEEDS_DEPLOY_RAO_OUTPUTS_JSON_SUMMARY: ${{ needs.deploy-rao.outputs.json-summary }}
+          NEEDS_DEPLOY_PLATFORM_OUTPUTS_JSON_SUMMARY: ${{ needs.deploy-platform.outputs.json-summary }}
+          NEEDS_DEPLOY_MANAGER_OUTPUTS_JSON_SUMMARY: ${{ needs.deploy-manager.outputs.json-summary }}
+          NEEDS_DEPLOY_APP_OUTPUTS_JSON_SUMMARY: ${{ needs.deploy-app.outputs.json-summary }}
+          NEEDS_DEPLOY_AUTH_OUTPUTS_JSON_SUMMARY: ${{ needs.deploy-auth.outputs.json-summary }}
         run: |
           MERGED_JSON=$(jq -cs \
             --arg environment "$ENVIRONMENT" \
@@ -790,11 +812,11 @@ jobs:
             } + {
               "commit-sha": $commit_sha
             }' \
-            <(echo '${{ needs.deploy-rao.outputs.json-summary }}') \
-            <(echo '${{ needs.deploy-platform.outputs.json-summary }}') \
-            <(echo '${{ needs.deploy-manager.outputs.json-summary }}') \
-            <(echo '${{ needs.deploy-app.outputs.json-summary }}') \
-            <(echo '${{ needs.deploy-auth.outputs.json-summary }}')
+            <(echo "${NEEDS_DEPLOY_RAO_OUTPUTS_JSON_SUMMARY}") \
+            <(echo "${NEEDS_DEPLOY_PLATFORM_OUTPUTS_JSON_SUMMARY}") \
+            <(echo "${NEEDS_DEPLOY_MANAGER_OUTPUTS_JSON_SUMMARY}") \
+            <(echo "${NEEDS_DEPLOY_APP_OUTPUTS_JSON_SUMMARY}") \
+            <(echo "${NEEDS_DEPLOY_AUTH_OUTPUTS_JSON_SUMMARY}")
           )
 
           echo "JSON_PROMO_SUMMARY=$MERGED_JSON" >> $GITHUB_ENV

--- a/.github/workflows/polaris.yaml
+++ b/.github/workflows/polaris.yaml
@@ -19,6 +19,7 @@ jobs:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run Polaris PR Scan
         id: polaris-pr-scan

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: nrwl/nx-set-shas@afb73a62d26e41464e9254689e1fd6122ee683c1 # v5.0.1
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -13,6 +13,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       
       - name: TruffleHog
         uses: trufflesecurity/trufflehog@37b77001d0174ebec2fcca2bd83ff83a6d45a3ab # v3.95.3


### PR DESCRIPTION
This pull request makes several updates to GitHub Actions workflow files to improve security and consistency. The main change is setting `persist-credentials: false` for all uses of the `actions/checkout` step, which prevents the workflow from persisting the default GitHub token in the local git config. Additionally, there are minor fixes to environment variable usage and improvements to how data is passed between workflow steps.

Security and workflow improvements:

* Set `persist-credentials: false` for all `actions/checkout` steps in `.github/workflows/deploy.yml`, `.github/workflows/bd_sca_scanner.yaml`, `.github/workflows/polaris.yaml`, `.github/workflows/test.yml`, and `.github/workflows/trufflehog.yaml` to prevent the default GitHub token from being stored in the local git config. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R50) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R247) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R387-R388) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R423-R429) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R464-R465) [[6]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R500-R506) [[7]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R541-R542) [[8]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R577-R583) [[9]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R618-R619) [[10]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R654-R660) [[11]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R695-R696) [[12]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R731-R737) [[13]](diffhunk://#diff-fdd5c4809b5f116543a69b6a9fdced74c61253e66482ed7e7e3375b45df9c764R26-R27) [[14]](diffhunk://#diff-f265d1510b4f87f60f844133dfc76b27fad500ef14199f1fd9747cfe21cdbfbbR22) [[15]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R23) [[16]](diffhunk://#diff-0226146bc805a4132588ddc39ae916b6f2be619f3b0765d40be3034ec5b87c3bR16)

Bug fixes and consistency:

* Updated shell variable usage in chart version steps to use `${SHORT_SHA}` instead of `${{ env.SHORT_SHA }}` for consistency and correctness in `.github/workflows/deploy.yml`. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R423-R429) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R500-R506) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R577-R583) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R654-R660) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R731-R737)
* Changed how outputs from dependent jobs are passed and referenced in the deploy workflow, moving from direct expressions to environment variables for better shell compatibility. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R779-R783) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L793-R819)