### PR TITLE
Change permission scope to job

### DIFF
--- a/.github/workflows/bd_sca_scanner.yaml
+++ b/.github/workflows/bd_sca_scanner.yaml
@@ -17,6 +17,8 @@ on:
 jobs:
   blackduck-sca-scan:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     concurrency:
       group: bd-sca-scan-${{ github.ref_name }}
       cancel-in-progress: true

--- a/.github/workflows/trufflehog.yaml
+++ b/.github/workflows/trufflehog.yaml
@@ -8,6 +8,8 @@ on:
 jobs:
   trufflehog-scan:
     runs-on: nuclia-base
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
This pull request updates the permissions settings in two GitHub Actions workflow files to explicitly grant read access to repository contents. This change helps to follow GitHub's best practices for least-privilege permissions and may resolve issues with workflow steps that require access to repository contents.

**Workflow permission updates:**

* Added `permissions: contents: read` to the `blackduck-sca-scan` job in `.github/workflows/bd_sca_scanner.yaml` to ensure the workflow can read repository contents.
* Added `permissions: contents: read` to the `trufflehog-scan` job in `.github/workflows/trufflehog.yaml` for the same purpose.