### PR TITLE
Harden GHA #2 + zizmor GHA

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,14 +22,13 @@ env:
   DEPLOYMENT_ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'stage' || 'dev' }}
   PROMO_PRODUCTION: false
 
-permissions:
-  id-token: write
-  contents: write
-  actions: read
-
 jobs:
   build:
     runs-on: nuclia-base
+    permissions:
+      id-token: write    # required by google-github-actions/auth (OIDC)
+      contents: write    # required by pkgdeps/git-tag-action and JamesIves/github-pages-deploy-action
+      actions: read      # required by nrwl/nx-set-shas to query previous workflow runs
 
     outputs:
       deploy-widget: ${{ steps.check-deploy.outputs.deploy-widget }}
@@ -236,6 +235,8 @@ jobs:
           app-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
           private-key: ${{ secrets.PK_GHAPP_NUCLIABOT }}
           owner: nuclia
+          repositories: tooling
+          permission-contents: read
 
       - name: Checkout tooling repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -369,6 +370,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: needs.build.outputs.deploy-app == 'yes'
+    permissions:
+      id-token: write  # required by google-github-actions/auth (OIDC)
+      contents: read   # required by actions/checkout
     outputs:
       json-summary: |
         {
@@ -412,6 +416,8 @@ jobs:
           app-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
           private-key: ${{ secrets.PK_GHAPP_NUCLIABOT }}
           owner: nuclia
+          repositories: tooling
+          permission-contents: read
 
       - name: Checkout tooling repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -446,6 +452,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: needs.build.outputs.deploy-manager == 'yes'
+    permissions:
+      id-token: write  # required by google-github-actions/auth (OIDC)
+      contents: read   # required by actions/checkout
     outputs:
       json-summary: |
         {
@@ -489,6 +498,8 @@ jobs:
           app-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
           private-key: ${{ secrets.PK_GHAPP_NUCLIABOT }}
           owner: nuclia
+          repositories: tooling
+          permission-contents: read
 
       - name: Checkout tooling repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -523,6 +534,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: needs.build.outputs.deploy-rao == 'yes'
+    permissions:
+      id-token: write  # required by google-github-actions/auth (OIDC)
+      contents: read   # required by actions/checkout
     outputs:
       json-summary: |
         {
@@ -566,6 +580,8 @@ jobs:
           app-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
           private-key: ${{ secrets.PK_GHAPP_NUCLIABOT }}
           owner: nuclia
+          repositories: tooling
+          permission-contents: read
 
       - name: Checkout tooling repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -600,6 +616,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: needs.build.outputs.deploy-platform == 'yes'
+    permissions:
+      id-token: write  # required by google-github-actions/auth (OIDC)
+      contents: read   # required by actions/checkout
     outputs:
       json-summary: |
         {
@@ -643,6 +662,8 @@ jobs:
           app-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
           private-key: ${{ secrets.PK_GHAPP_NUCLIABOT }}
           owner: nuclia
+          repositories: tooling
+          permission-contents: read
 
       - name: Checkout tooling repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -677,6 +698,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     if: needs.build.outputs.deploy-auth == 'yes'
+    permissions:
+      id-token: write  # required by google-github-actions/auth (OIDC)
+      contents: read   # required by actions/checkout
     outputs:
       json-summary: |
         {
@@ -720,6 +744,8 @@ jobs:
           app-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
           private-key: ${{ secrets.PK_GHAPP_NUCLIABOT }}
           owner: nuclia
+          repositories: tooling
+          permission-contents: read
 
       - name: Checkout tooling repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -752,6 +778,7 @@ jobs:
   send-to-promotion:
     runs-on: ubuntu-latest
     needs: [deploy-manager, deploy-app, deploy-rao, deploy-platform, deploy-auth]
+    permissions: {}    # no GITHUB_TOKEN scopes needed; dispatch uses a scoped GitHub App token
     if: |
       !failure() && !cancelled() && github.event_name == 'push' &&
       ( needs.deploy-manager.result != 'skipped' ||
@@ -767,6 +794,9 @@ jobs:
           app-id: ${{ secrets.GHAPP_ID_NUCLIABOT }}
           private-key: ${{ secrets.PK_GHAPP_NUCLIABOT }}
           owner: nuclia
+          repositories: core-apps
+          # POST /repos/{owner}/{repo}/dispatches requires contents: write
+          permission-contents: write
 
       - name: Create components promotion summary. Trigger1
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,12 +9,13 @@ on:
       - main
       - dev
 
-permissions:
-  contents: write
-
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: read # Needed in case once we enable merge queues.
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,26 @@
+name: GitHub Actions Security Analysis with zizmor
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write  # required by github/codeql-action/upload-sarif
+      contents: read          # required by actions/checkout (private-repo safe default)
+      actions: read           # required by upload-sarif to read workflow run info on private repos
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
This pull request improves GitHub Actions workflow security and maintainability by refining permissions for existing workflows and introducing a new workflow for security analysis. The main changes include setting explicit, least-privilege permissions for all jobs in the `deploy.yml` and `test.yml` workflows, and adding a new `zizmor.yml` workflow for automated security analysis of GitHub Actions files.

**Workflow permission hardening:**

* Refactored the `deploy.yml` workflow to assign explicit permissions at the job level, ensuring each job only has the minimum required GitHub token scopes. This includes setting permissions such as `id-token: write`, `contents: read/write`, and `actions: read` where necessary, and using `{}` for jobs that do not require any permissions. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3L25-R31) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R373-R375) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R455-R457) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R537-R539) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R619-R621) [[6]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R701-R703) [[7]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R781)
* Updated the `test.yml` workflow to define job-level permissions, restricting them to only `contents: read`, `actions: read`, and `pull-requests: read` as required.

**Repository dispatch and checkout improvements:**

* Updated steps that interact with other repositories (e.g., `tooling`, `core-apps`) to explicitly set the necessary repository and permission scopes for GitHub App authentication and repository dispatch events. [[1]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R238-R239) [[2]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R419-R420) [[3]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R501-R502) [[4]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R583-R584) [[5]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R665-R666) [[6]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R747-R748) [[7]](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R797-R799)

**Security analysis automation:**

* Added a new workflow, `.github/workflows/zizmor.yml`, which runs the `zizmor` action to perform security analysis on all workflow and action files, uploading results as SARIF security events. This workflow is triggered on pushes to `main` and on pull requests that modify workflow or action files.

These changes collectively strengthen the security posture of the repository’s CI/CD pipelines and introduce automated checks for workflow security.