### PR TITLE
Update grafana URL to https://grafana.gcp-internal-1.nuclia.cloud/

### DIFF
--- a/apps/manager-v2/src/app/manage-accounts/regional-account.service.ts
+++ b/apps/manager-v2/src/app/manage-accounts/regional-account.service.ts
@@ -46,7 +46,7 @@ export class RegionalAccountService {
                       kbMode: index.kb_mode,
                       activity: {
                         redash: `http://redash.nuclia.com/queries/24?p_KB=${kb.id}`,
-                        grafana: `http://platform.grafana.nuclia.com/d/${
+                        grafana: `https://grafana.gcp-internal-1.nuclia.cloud/d/${
                           index.account_id
                         }/1-nucliadb-knowledgebox?orgId=1&var-kbid=${kb.id}&var-cluster=${
                           zone.slug === 'europe-1' ? 'flaps' : zone.slug


### PR DESCRIPTION
This pull request updates the Grafana dashboard URL in the `RegionalAccountService` to use the internal GCP Grafana instance. This ensures that links to Grafana point to the correct environment.

Configuration update:

* Changed the `grafana` URL in `RegionalAccountService` from `http://platform.grafana.nuclia.com` to `https://grafana.gcp-internal-1.nuclia.cloud` to direct users to the internal GCP Grafana instance.