### PR TITLE
[sc-15103] Improve scrollbar locking for modal components

### DIFF
--- a/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
+++ b/apps/manager-v2/src/app/manage-accounts/account-details/configuration/configuration.component.html
@@ -166,7 +166,7 @@
       </div>
     </div>
     <div [formGroup]="budgetForm">
-      <label class="title-xxs">Monthly budget</label>
+      <label class="title-xxs">Budget</label>
       <div class="radio-limit-container">
         <pa-radio-group
           formControlName="custom_budget"

--- a/libs/search-widget/src/common/modal/modal.utils.ts
+++ b/libs/search-widget/src/common/modal/modal.utils.ts
@@ -15,7 +15,9 @@ export function unblockBackground(fullscreenModal = false) {
     const scrollY = body.style.top;
     body.style.position = '';
     body.style.top = '';
-    setTimeout(() => scrollBackTo(scrollY));
+    if (scrollY) {
+      setTimeout(() => scrollBackTo(scrollY));
+    }
   } else {
     document.body.style.overflow = 'inherit';
   }


### PR DESCRIPTION
- `unblockBackground` function should not change scroll position if `freezeBackground` has not been called before.