### PR TITLE
feat(dashboard): KB home upload interaction & button hierarchy consistency

### DIFF
--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.html
@@ -71,20 +71,53 @@
   </div>
   <div class="kb-header-actions">
     <pa-button
-      kind="primary"
+      aspect="basic"
       icon="search"
       iconAndText
       [routerLink]="kbUrl() + '/search'">
       {{ 'generic.search' | translate }}
     </pa-button>
     <pa-button
-      aspect="basic"
+      kind="primary"
       icon="upload"
       iconAndText
-      [routerLink]="kbUrl() + '/upload'">
+      [paPopup]="uploadMenu"
+      alignPopupOnLeft>
       {{ 'navbar.upload-data' | translate }}
     </pa-button>
     <!-- Shared with the onboarding header states so it's defined in one place. -->
     <app-kb-more-actions></app-kb-more-actions>
+    <pa-dropdown #uploadMenu>
+      <pa-option
+        icon="file"
+        (selectOption)="upload('files')">
+        {{ 'upload.files' | translate }}
+      </pa-option>
+      <pa-option
+        icon="folder"
+        (selectOption)="upload('folder')">
+        {{ 'upload.folder' | translate }}
+      </pa-option>
+      <pa-option
+        icon="link"
+        (selectOption)="upload('link')">
+        {{ 'upload.link' | translate }}
+      </pa-option>
+      <pa-option
+        icon="file-empty"
+        (selectOption)="upload('csv')">
+        {{ 'upload.texts' | translate }}
+      </pa-option>
+      <pa-option
+        icon="connectors"
+        (selectOption)="upload('sitemap')">
+        {{ 'upload.sitemap.title' | translate }}
+      </pa-option>
+      <pa-option
+        icon="chat"
+        (selectOption)="upload('qna')">
+        {{ 'upload.q_and_a' | translate }}
+      </pa-option>
+    </pa-dropdown>
   </div>
 </div>

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.html
@@ -77,47 +77,49 @@
       [routerLink]="kbUrl() + '/search'">
       {{ 'generic.search' | translate }}
     </pa-button>
-    <pa-button
-      kind="primary"
-      icon="upload"
-      iconAndText
-      [paPopup]="uploadMenu"
-      alignPopupOnLeft>
-      {{ 'navbar.upload-data' | translate }}
-    </pa-button>
+    <div>
+      <pa-button
+        kind="primary"
+        icon="upload"
+        iconAndText
+        [paPopup]="uploadMenu"
+        alignPopupOnLeft>
+        {{ 'navbar.upload-data' | translate }}
+      </pa-button>
+      <pa-dropdown #uploadMenu>
+        <pa-option
+          icon="file"
+          (selectOption)="upload('files')">
+          {{ 'upload.files' | translate }}
+        </pa-option>
+        <pa-option
+          icon="folder"
+          (selectOption)="upload('folder')">
+          {{ 'upload.folder' | translate }}
+        </pa-option>
+        <pa-option
+          icon="link"
+          (selectOption)="upload('link')">
+          {{ 'upload.link' | translate }}
+        </pa-option>
+        <pa-option
+          icon="file-empty"
+          (selectOption)="upload('csv')">
+          {{ 'upload.texts' | translate }}
+        </pa-option>
+        <pa-option
+          icon="connectors"
+          (selectOption)="upload('sitemap')">
+          {{ 'upload.sitemap.title' | translate }}
+        </pa-option>
+        <pa-option
+          icon="chat"
+          (selectOption)="upload('qna')">
+          {{ 'upload.q_and_a' | translate }}
+        </pa-option>
+      </pa-dropdown>
+    </div>
     <!-- Shared with the onboarding header states so it's defined in one place. -->
     <app-kb-more-actions></app-kb-more-actions>
-    <pa-dropdown #uploadMenu>
-      <pa-option
-        icon="file"
-        (selectOption)="upload('files')">
-        {{ 'upload.files' | translate }}
-      </pa-option>
-      <pa-option
-        icon="folder"
-        (selectOption)="upload('folder')">
-        {{ 'upload.folder' | translate }}
-      </pa-option>
-      <pa-option
-        icon="link"
-        (selectOption)="upload('link')">
-        {{ 'upload.link' | translate }}
-      </pa-option>
-      <pa-option
-        icon="file-empty"
-        (selectOption)="upload('csv')">
-        {{ 'upload.texts' | translate }}
-      </pa-option>
-      <pa-option
-        icon="connectors"
-        (selectOption)="upload('sitemap')">
-        {{ 'upload.sitemap.title' | translate }}
-      </pa-option>
-      <pa-option
-        icon="chat"
-        (selectOption)="upload('qna')">
-        {{ 'upload.q_and_a' | translate }}
-      </pa-option>
-    </pa-dropdown>
   </div>
 </div>

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.scss
@@ -56,8 +56,4 @@
   display: flex;
   align-items: center;
   gap: rhythm(1);
-
-  pa-dropdown {
-    display: none;
-  }
 }

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.scss
@@ -56,4 +56,8 @@
   display: flex;
   align-items: center;
   gap: rhythm(1);
+
+  pa-dropdown {
+    display: none;
+  }
 }

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
+import { RouterModule } from '@angular/router';
 import { PaButtonModule, PaDropdownModule, PaPopupModule, PaTooltipModule } from '@guillotinaweb/pastanaga-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { Counters } from '@nuclia/core';
 import { NavigationService, SDKService, STFPipesModule } from '@flaps/core';
-import { AppService } from '@flaps/common';
-import { UploadDialogService, UploadType } from '@flaps/common';
+import { AppService, UploadDialogService, UploadType } from '@flaps/common';
 import { combineLatest, map } from 'rxjs';
 import { KbMoreActionsComponent } from '../kb-more-actions/kb-more-actions.component';
 
@@ -25,6 +25,7 @@ import { KbMoreActionsComponent } from '../kb-more-actions/kb-more-actions.compo
     PaDropdownModule,
     PaPopupModule,
     PaTooltipModule,
+    RouterModule,
     STFPipesModule,
     TranslateModule,
   ],

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.ts
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.ts
@@ -1,12 +1,12 @@
 import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { CommonModule } from '@angular/common';
-import { RouterModule } from '@angular/router';
 import { PaButtonModule, PaDropdownModule, PaPopupModule, PaTooltipModule } from '@guillotinaweb/pastanaga-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { Counters } from '@nuclia/core';
 import { NavigationService, SDKService, STFPipesModule } from '@flaps/core';
 import { AppService } from '@flaps/common';
+import { UploadDialogService, UploadType } from '@flaps/common';
 import { combineLatest, map } from 'rxjs';
 import { KbMoreActionsComponent } from '../kb-more-actions/kb-more-actions.component';
 
@@ -25,7 +25,6 @@ import { KbMoreActionsComponent } from '../kb-more-actions/kb-more-actions.compo
     PaDropdownModule,
     PaPopupModule,
     PaTooltipModule,
-    RouterModule,
     STFPipesModule,
     TranslateModule,
   ],
@@ -37,6 +36,7 @@ export class KbHeaderComponent {
   private sdk = inject(SDKService);
   private appService = inject(AppService);
   private navigationService = inject(NavigationService);
+  private uploadService = inject(UploadDialogService);
 
   private currentKb = this.sdk.currentKb;
 
@@ -57,4 +57,8 @@ export class KbHeaderComponent {
     ),
     { initialValue: '' },
   );
+
+  upload(type: UploadType) {
+    this.uploadService.upload(type);
+  }
 }

--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-more-actions/kb-more-actions.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-more-actions/kb-more-actions.component.html
@@ -4,13 +4,13 @@
   icon="more-vertical"
   [paPopup]="kbHeaderActionsDropdown"></pa-button>
 <pa-dropdown #kbHeaderActionsDropdown>
-  <pa-option [routerLink]="kbUrl() + '/manage'">
-    {{ 'dashboard-home.go-to.kb-settings' | translate }}
-  </pa-option>
   <pa-option (selectOption)="openDeveloperIntegrations()">
     {{ 'home.developer-integrate.title' | translate }}
   </pa-option>
   <pa-option (selectOption)="openTestPage()">
     {{ 'dashboard-home.kb-details.test-page' | translate }}
+  </pa-option>
+  <pa-option [routerLink]="kbUrl() + '/manage'">
+    {{ 'dashboard-home.go-to.kb-settings' | translate }}
   </pa-option>
 </pa-dropdown>


### PR DESCRIPTION
## KB Home — Upload Data interaction & button hierarchy consistency

### Summary

Aligns the KB home header with the interaction patterns and visual hierarchy already established on the Resource List page.

---

### Changes

**`kb-header` — button hierarchy**
- `Upload data` is now the primary (solid blue) action; `Search` is secondary (outline). Uploading is the dominant write action on the KB home screen — consistent with how primary actions are weighted across the rest of the app.
- `Upload data` is positioned on the right, `Search` on the left — placing the higher-priority action in the natural reading terminus and thumb-reach position.

**`kb-header` — upload interaction**
- Replaced the `Upload data` router link to `/upload` with the same dropdown used on the Resource List (`UploadDialogService`). Users can now select their upload type directly from the home screen without a full page navigation.
- No new logic introduced — `UploadDialogService` is reused verbatim, keeping a single source of truth for all upload entry points.

**`kb-more-actions` — settings menu order**
- Moved `KB Settings` to the bottom of the `⋮` dropdown. Settings is a low-frequency destination; surfacing quick actions first reduces cognitive load.

---

### What was not changed

- The `/upload` route and nav item are untouched — retiring them is a separate decision (3 live references remain).
- No changes to the Resource List, onboarding header, or any other component.

---

### Testing

- [ ] Upload data dropdown opens from KB home and all 6 options trigger the correct modal
- [ ] Search button navigates correctly to `/search`
- [ ] `⋮` menu shows Developer integrations and Test page before Settings
- [ ] Button gap is visually consistent across all three header actions