### PR TITLE
login challenge undefined

### DIFF
--- a/libs/core/src/lib/models/user.model.ts
+++ b/libs/core/src/lib/models/user.model.ts
@@ -143,6 +143,6 @@ export interface ResetResponse {
 }
 
 export interface SetupResponse {
-  login_challenge: string;
+  login_challenge?: string;
   user_hint: string;
 }

--- a/libs/user/src/lib/magic/magic.service.ts
+++ b/libs/user/src/lib/magic/magic.service.ts
@@ -49,6 +49,14 @@ export class MagicService {
       case 'goaccount':
         if (action.needs_initial_setpassword === false && this.cameFrom) {
           location.href = `${this.cameFrom}/select`;
+        } else if (action.needs_initial_setpassword === true && this.cameFrom) {
+          // Modern invite flow: user has no session token yet. Go directly to set-password
+          // in the target app so SetPasswordComponent starts the OAuth flow with
+          // `initial_setpassword: true` in the state — creating a valid login_challenge
+          // that the backend can embed in the setup email.
+          // Navigating to the authGuard-protected /setup/invite would cause a redirect
+          // loop for unauthenticated users, losing the initial_setpassword context.
+          location.href = `${this.cameFrom}/user/set-password`;
         } else {
           this.router.navigate(['/setup/invite'], {
             queryParams: { account: action.account },

--- a/libs/user/src/lib/reset/reset.component.spec.ts
+++ b/libs/user/src/lib/reset/reset.component.spec.ts
@@ -2,7 +2,7 @@ import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ReactiveFormsModule } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { LoginService } from '@flaps/core';
+import { LoginService, SDKService } from '@flaps/core';
 import { SisToastService } from '@nuclia/sistema';
 import { ReCaptchaV3Service } from 'ng-recaptcha-2';
 import { BehaviorSubject, of, throwError } from 'rxjs';
@@ -19,6 +19,7 @@ describe('ResetComponent', () => {
   let router: { navigate: jest.Mock };
   let reCaptchaV3Service: { execute: jest.Mock };
   let toaster: { success: jest.Mock; error: jest.Mock };
+  let sdk: { nuclia: { auth: { redirectToOAuth: jest.Mock } } };
 
   let queryParams$: BehaviorSubject<Record<string, string | undefined>>;
   let url$: BehaviorSubject<{ path: string }[]>;
@@ -32,6 +33,7 @@ describe('ResetComponent', () => {
         { provide: ReCaptchaV3Service, useValue: reCaptchaV3Service },
         { provide: SisToastService, useValue: toaster },
         { provide: Router, useValue: router },
+        { provide: SDKService, useValue: sdk },
         {
           provide: ActivatedRoute,
           useValue: {
@@ -58,6 +60,7 @@ describe('ResetComponent', () => {
       setup: jest.fn(() => of({ login_challenge: 'challenge-1' })),
     };
     router = { navigate: jest.fn() };
+    sdk = { nuclia: { auth: { redirectToOAuth: jest.fn() } } };
     reCaptchaV3Service = { execute: jest.fn(() => of('captcha-token')) };
     toaster = { success: jest.fn(), error: jest.fn() };
     queryParams$ = new BehaviorSubject<Record<string, string | undefined>>({ token: 'magic-token' });
@@ -212,11 +215,21 @@ describe('ResetComponent', () => {
   it('should navigate to login with challenge in goLogin', async () => {
     await buildComponent();
 
-    component.goLogin({ login_challenge: 'challenge-2' });
+    component.goLogin({ login_challenge: 'challenge-2', user_hint: 'user@example.com' });
 
     expect(router.navigate).toHaveBeenCalledWith(['../login'], {
       relativeTo: TestBed.inject(ActivatedRoute),
-      queryParams: { login_challenge: 'challenge-2' },
+      queryParams: { login_challenge: 'challenge-2', user_hint: 'user@example.com' },
     });
+    expect(sdk.nuclia.auth.redirectToOAuth).not.toHaveBeenCalled();
+  });
+
+  it('should redirect to OAuth when login_challenge is missing in goLogin', async () => {
+    await buildComponent();
+
+    component.goLogin({ user_hint: 'user@example.com' } as any);
+
+    expect(sdk.nuclia.auth.redirectToOAuth).toHaveBeenCalled();
+    expect(router.navigate).not.toHaveBeenCalled();
   });
 });

--- a/libs/user/src/lib/reset/reset.component.ts
+++ b/libs/user/src/lib/reset/reset.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
-import { LoginService, ResetResponse, SetupResponse } from '@flaps/core';
+import { LoginService, ResetResponse, SDKService, SetupResponse } from '@flaps/core';
 import { IErrorMessages } from '@guillotinaweb/pastanaga-angular';
 import { SisToastService } from '@nuclia/sistema';
 import { ReCaptchaV3Service } from 'ng-recaptcha-2';
@@ -52,6 +52,7 @@ export class ResetComponent {
     private reCaptchaV3Service: ReCaptchaV3Service,
     private toaster: SisToastService,
     private cdr: ChangeDetectorRef,
+    private sdk: SDKService,
   ) {
     this.route.queryParams.subscribe((params) => {
       this.magicToken = params['token'];
@@ -96,6 +97,14 @@ export class ResetComponent {
   }
 
   goLogin(data: ResetResponse | SetupResponse) {
+    const loginChallenge = (data as SetupResponse).login_challenge;
+    if (!loginChallenge) {
+      // The setup email was sent without a login_challenge (POST /auth/recover was called
+      // before an OAuth flow created one). The password has been set successfully, so
+      // start a fresh OAuth flow to authenticate the user normally.
+      this.sdk.nuclia.auth.redirectToOAuth();
+      return;
+    }
     this.router.navigate(['../login'], {
       relativeTo: this.route,
       queryParams: { ...data },


### PR DESCRIPTION
## Fix: `login_challenge=undefined` after new user invite setup

### Problem

A newly invited user who clicks the invite link, sets their name and password, and then ends up at `/login?login_challenge=undefined` — a Hydra 404 (`unknown_login_challenge`).

### Root cause

Two bugs in the invite flow conspire to produce this:

---

#### Bug 1 — magic.service.ts: unauthenticated new users lose the `initial_setpassword` context

When the backend returns `{ action: "goaccount", needs_initial_setpassword: true, came_from: "..." }` (the modern invite flow, no session token), the magic service navigated to `/setup/invite`:

```typescript
// before
case 'goaccount':
  if (action.needs_initial_setpassword === false && this.cameFrom) {
    location.href = `${this.cameFrom}/select`;
  } else {
    this.router.navigate(['/setup/invite'], { queryParams: { account: action.account } });
  }
```

The auth app's `/setup/invite` route has `canActivate: [authGuard]`. A brand-new user has no JWT in `localStorage`, so:

1. `authGuard` fails → redirects to `/user/login-redirect`  
2. That path doesn't exist in the auth app → `**` wildcard → `fallbackRedirectGuard` → redirects to `cameFrom/user/login-redirect`  
3. `AppLoginComponent` there calls `redirectToOAuth({ ...params })`, but `params` is `{ account: "..." }` — **`initial_setpassword: true` is never in the OAuth `state`**  
4. Hydra creates a `login_challenge` with no `needs_initial_setpassword` flag  
5. `GET /auth/oauth/login` returns no `needs_initial_setpassword: true`, so the login component never redirects to the recover page  
6. The user sees a normal login form they can't use (no password yet)

If the user *did* have a pre-existing JWT, `authGuard` passes, they see the invite screen, click "Set Password" → `cameFrom/user/set-password` → `SetPasswordComponent` → `redirectToOAuth({ initial_setpassword: true })` — the happy path. But a truly new user never gets there.

**Fix:** Add an explicit branch for `needs_initial_setpassword === true && cameFrom`. Go directly to `cameFrom/user/set-password`, bypassing the authGuard-protected invite screen. `SetPasswordComponent` in the target app calls `redirectToOAuth({ initial_setpassword: true })`, encoding the flag in the OAuth `state` and producing a valid `login_challenge`.

---

#### Bug 2 — reset.component.ts: missing `login_challenge` in the setupuser response is not handled

If `POST /auth/recover` is ever called without a `login_challenge` (e.g. via Bug 1's broken path, or a direct email link), the backend embeds no challenge in the setup-email token. `POST /auth/setupuser` responds with only `{ user_hint: "..." }` — no `login_challenge` key.

`goLogin` then spreads the response into `queryParams`:

```typescript
// before
goLogin(data: ResetResponse | SetupResponse) {
  this.router.navigate(['../login'], {
    relativeTo: this.route,
    queryParams: { ...data },  // → { user_hint: "..." }, no login_challenge
  });
}
```

Angular Router navigates to `/user/login?user_hint=...`. The login resolver sees no `login_challenge` param and returns `null`. The login component sets `this.loginChallenge = undefined`. The hidden form field `[value]="loginChallenge"` renders as `value="undefined"`, and submitting it gives Hydra `unknown_login_challenge`.

**Fix:** Check for `login_challenge` before navigating. If it's absent (the password was set successfully but there's no OAuth context to return to), call `redirectToOAuth()` for a fresh normal login instead of hitting Hydra with a broken challenge.

---

#### Bug 3 — `SetupResponse` model: `login_challenge` is declared non-optional

The TypeScript interface said `login_challenge: string` (required), but the backend legitimately omits it. Marking it `login_challenge?: string` makes the contract accurate and lets the compiler surface any callers that assume it's always present.

---

### Changes

| File | Change |
|------|--------|
| magic.service.ts | Add explicit `needs_initial_setpassword === true && cameFrom` branch → `location.href = cameFrom/user/set-password` |
| reset.component.ts | Guard `goLogin` — if `login_challenge` missing, call `redirectToOAuth()` instead of navigating to login |
| user.model.ts | `SetupResponse.login_challenge` → optional (`?`) |
| reset.component.spec.ts | Add `SDKService` mock; add test for missing-`login_challenge` fallback; update existing `goLogin` test to include `user_hint` |