### PR TITLE
fix(ui): use primary basic style for search and refresh buttons

### DIFF
--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.html
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/kb-header/kb-header.component.html
@@ -71,6 +71,7 @@
   </div>
   <div class="kb-header-actions">
     <pa-button
+      kind="primary"
       aspect="basic"
       icon="search"
       iconAndText

--- a/libs/common/src/lib/resources/resource-list/resource-list.component.html
+++ b/libs/common/src/lib/resources/resource-list/resource-list.component.html
@@ -220,7 +220,7 @@
         <div class="header-actions">
           @if (isMainView || isProcessedView) {
             <pa-button
-              kind="secondary"
+              kind="primary"
               aspect="basic"
               icon="refresh"
               iconAndText


### PR DESCRIPTION
## Summary
- KB home header **Search** button (`kb-header.component.html`) now uses `kind="primary" aspect="basic"`.
- Resources page **Refresh** button (`resource-list.component.html`) now uses `kind="primary" aspect="basic"` (was `kind="secondary"`).

## UX justification
Both actions are the primary, most-used interaction on their respective screens: search is the main entry point on the KB home dashboard, and refresh is the main way users get up-to-date resource state on the Resources list. Pastanaga's **primary basic** style keeps the low-visual-weight "basic" (no fill) treatment so these buttons don't compete with true solid primary CTAs (e.g. Upload), while still signalling primary intent through color. This gives users a clearer visual cue for the most important action on each screen without adding another heavy filled button to already button-dense toolbars. Previously they used **secondary basic**, which under-emphasized their importance relative to how frequently they're used.

## Verification
- `nx lint dashboard`: 0 errors (9 pre-existing warnings, unrelated to the changed files).
- Manual review of token usage: no hardcoded colors introduced — the change only adjusts the existing `kind`/`aspect` inputs on `pa-button`, so dark mode parity and all state variants (hover/active/focus-visible/disabled) are inherited from the design system's existing primary-basic button styles.

🤖 Generated with [Copilot CLI](https://github.com/github/copilot-cli)
