### PR TITLE
feat(retrieval-agents): smarter workflow landing + workflows list polish

### DIFF
--- a/apps/dashboard/src/app/app-routing.module.ts
+++ b/apps/dashboard/src/app/app-routing.module.ts
@@ -41,6 +41,7 @@ import {
   KnowledgeBoxUsersComponent,
   ProfileComponent,
   OnboardingComponent,
+  redirectToWorkflowGuard,
   WorkflowsListComponent,
   WorkflowsComponent,
 } from '@flaps/common';
@@ -179,8 +180,9 @@ const routes: Routes = [
             children: [
               {
                 path: '',
-                redirectTo: 'workflows',
                 pathMatch: 'full',
+                component: EmptyComponent,
+                canActivate: [redirectToWorkflowGuard],
               },
               {
                 path: 'workflows',

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -2018,6 +2018,7 @@
 	"retrieval-agents.workflow.sidebar.test.toasts.session-closing-error": "S'ha produït un error en tancar les interaccions de la sessió.",
 	"retrieval-agents.workflow.sidebar.test.toasts.session-creation-error": "S'ha produït un error en crear la sessió.",
 	"retrieval-agents.workflow.toolbar-buttons.add-node": "Afegir un node",
+	"retrieval-agents.workflow.toolbar-buttons.back-to-workflows": "Torna a la llista de workflows",
 	"retrieval-agents.workflow.toolbar-buttons.export": "Exportar",
 	"retrieval-agents.workflow.toolbar-buttons.import": "Importar",
 	"retrieval-agents.workflow.toolbar-buttons.manage-sessions": "Gestionar sessions",

--- a/libs/common/src/assets/i18n/ca.json
+++ b/libs/common/src/assets/i18n/ca.json
@@ -2031,6 +2031,7 @@
 	"retrieval-agents.workflows-list.confirm-deletion.title": "Vols suprimir {{name}}?",
 	"retrieval-agents.workflows-list.delete": "Eliminar workflow",
 	"retrieval-agents.workflows-list.description": "Crear i gestionar workflows d'agents",
+	"retrieval-agents.workflows-list.open": "Obre workflow",
 	"retrieval-agents.workflows-list.edit": "Modificar workflow",
 	"retrieval-agents.workflows-list.empty": "Encara no has creat cap workflow",
 	"retrieval-agents.workflows-list.errors.creation": "S'ha produït un error en crear el workflow, torneu-ho a provar.",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -2018,6 +2018,7 @@
 	"retrieval-agents.workflow.sidebar.test.toasts.session-closing-error": "An error occurred while closing the session interactions.",
 	"retrieval-agents.workflow.sidebar.test.toasts.session-creation-error": "An error occurred while creating the session.",
 	"retrieval-agents.workflow.toolbar-buttons.add-node": "Add node",
+	"retrieval-agents.workflow.toolbar-buttons.back-to-workflows": "Back to workflows list",
 	"retrieval-agents.workflow.toolbar-buttons.export": "Export",
 	"retrieval-agents.workflow.toolbar-buttons.import": "Import",
 	"retrieval-agents.workflow.toolbar-buttons.manage-sessions": "Manage sessions",

--- a/libs/common/src/assets/i18n/en.json
+++ b/libs/common/src/assets/i18n/en.json
@@ -2031,6 +2031,7 @@
 	"retrieval-agents.workflows-list.confirm-deletion.title": "Delete {{name}}?",
 	"retrieval-agents.workflows-list.delete": "Delete workflow",
 	"retrieval-agents.workflows-list.description": "Create and manage agent workflows",
+	"retrieval-agents.workflows-list.open": "Open workflow",
 	"retrieval-agents.workflows-list.edit": "Edit workflow",
 	"retrieval-agents.workflows-list.empty": "You haven’t created any workflow yet",
 	"retrieval-agents.workflows-list.errors.creation": "An error occurred while creating the workflow, please try again.",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -2031,6 +2031,7 @@
 	"retrieval-agents.workflows-list.confirm-deletion.title": "Eliminar {{name}}?",
 	"retrieval-agents.workflows-list.delete": "Eliminar workflow",
 	"retrieval-agents.workflows-list.description": "Crear y gestionar workflows de agentes",
+	"retrieval-agents.workflows-list.open": "Abrir workflow",
 	"retrieval-agents.workflows-list.edit": "Modificar workflow",
 	"retrieval-agents.workflows-list.empty": "Aún no has creado ningún workflow",
 	"retrieval-agents.workflows-list.errors.creation": "Se ha producido un error al crear el workflow, inténtelo de nuevo.",

--- a/libs/common/src/assets/i18n/es.json
+++ b/libs/common/src/assets/i18n/es.json
@@ -2018,6 +2018,7 @@
 	"retrieval-agents.workflow.sidebar.test.toasts.session-closing-error": "Se ha producido un error al cerrar las interacciones de la sesión.",
 	"retrieval-agents.workflow.sidebar.test.toasts.session-creation-error": "Se ha producido un error al crear la sesión.",
 	"retrieval-agents.workflow.toolbar-buttons.add-node": "Agregar nodo",
+	"retrieval-agents.workflow.toolbar-buttons.back-to-workflows": "Volver a la lista de workflows",
 	"retrieval-agents.workflow.toolbar-buttons.export": "Exportar",
 	"retrieval-agents.workflow.toolbar-buttons.import": "Importar",
 	"retrieval-agents.workflow.toolbar-buttons.manage-sessions": "Administrar sesiones",

--- a/libs/common/src/assets/i18n/fr.json
+++ b/libs/common/src/assets/i18n/fr.json
@@ -2031,6 +2031,7 @@
 	"retrieval-agents.workflows-list.confirm-deletion.title": "Supprimer {{name}} ?",
 	"retrieval-agents.workflows-list.delete": "Supprimer le workflow",
 	"retrieval-agents.workflows-list.description": "Créer et gérer les workflows des agents",
+	"retrieval-agents.workflows-list.open": "Ouvrir le workflow",
 	"retrieval-agents.workflows-list.edit": "Modifier le workflow",
 	"retrieval-agents.workflows-list.empty": "Vous n'avez pas encore créé de workflow",
 	"retrieval-agents.workflows-list.errors.creation": "Une erreur s’est produite lors de la création du workflow, veuillez réessayer.",

--- a/libs/common/src/assets/i18n/fr.json
+++ b/libs/common/src/assets/i18n/fr.json
@@ -2018,6 +2018,7 @@
 	"retrieval-agents.workflow.sidebar.test.toasts.session-closing-error": "Une erreur s’est produite lors de la fermeture des interactions de session.",
 	"retrieval-agents.workflow.sidebar.test.toasts.session-creation-error": "Une erreur s’est produite lors de la création de la session.",
 	"retrieval-agents.workflow.toolbar-buttons.add-node": "Ajouter un nœud",
+	"retrieval-agents.workflow.toolbar-buttons.back-to-workflows": "Retour à la liste des workflows",
 	"retrieval-agents.workflow.toolbar-buttons.export": "Exporter",
 	"retrieval-agents.workflow.toolbar-buttons.import": "Importer",
 	"retrieval-agents.workflow.toolbar-buttons.manage-sessions": "Gérer les sessions",

--- a/libs/common/src/lib/base/dashboard-layout/dashboard-layout.service.ts
+++ b/libs/common/src/lib/base/dashboard-layout/dashboard-layout.service.ts
@@ -10,4 +10,8 @@ export class DashboardLayoutService {
   toggleNav() {
     this._collapsedNav.set(!this._collapsedNav());
   }
+
+  expandNav() {
+    this._collapsedNav.set(false);
+  }
 }

--- a/libs/common/src/lib/guards/index.ts
+++ b/libs/common/src/lib/guards/index.ts
@@ -1,4 +1,5 @@
 export * from './permission.guard';
+export * from './redirect-to-workflow.guard';
 export * from './root.guard';
 export * from './select-account.guard';
 export * from './select-kb.guard';

--- a/libs/common/src/lib/guards/redirect-to-workflow.guard.ts
+++ b/libs/common/src/lib/guards/redirect-to-workflow.guard.ts
@@ -1,0 +1,33 @@
+import { inject } from '@angular/core';
+import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
+import { map, take } from 'rxjs';
+import { WorkflowsService } from '../retrieval-agent';
+
+/**
+ * Landing on an agent (e.g. `/at/:account/:zone/arag/:agent`) skips the workflows list and
+ * goes straight to a workflow canvas: the last one the user worked on if there is one, otherwise
+ * the `default` workflow every agent is seeded with. Falls back to the workflows list itself only
+ * if the agent somehow has no workflows at all.
+ *
+ * This only applies to the bare agent entry point, not to explicit navigation to `/workflows`
+ * (e.g. the canvas' "Back to workflows list" button), which must always show the list.
+ */
+export const redirectToWorkflowGuard = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+  const router: Router = inject(Router);
+  const workflowsService: WorkflowsService = inject(WorkflowsService);
+
+  const agentSlug = route.paramMap.get('agent') || '';
+  const basePath = state.url.split(/[?#]/)[0].replace(/\/$/, '');
+
+  return workflowsService.workflows.pipe(
+    take(1),
+    map((workflows) => {
+      const lastWorkflowId = workflowsService.getLastWorkflowId(agentSlug);
+      const targetId =
+        (lastWorkflowId && workflows.some((workflow) => workflow.id === lastWorkflowId) && lastWorkflowId) ||
+        (workflows.some((workflow) => workflow.id === 'default') && 'default') ||
+        null;
+      return router.parseUrl(`${basePath}/workflows${targetId ? `/${targetId}` : ''}`);
+    }),
+  );
+};

--- a/libs/common/src/lib/guards/redirect-to-workflow.guard.ts
+++ b/libs/common/src/lib/guards/redirect-to-workflow.guard.ts
@@ -1,7 +1,8 @@
 import { inject } from '@angular/core';
-import { ActivatedRouteSnapshot, Router, RouterStateSnapshot } from '@angular/router';
-import { map, take } from 'rxjs';
+import { ActivatedRouteSnapshot, Router } from '@angular/router';
+import { filter, map, switchMap, take } from 'rxjs';
 import { WorkflowsService } from '../retrieval-agent';
+import { NavigationService } from '@flaps/core';
 
 /**
  * Landing on an agent (e.g. `/at/:account/:zone/arag/:agent`) skips the workflows list and
@@ -12,22 +13,24 @@ import { WorkflowsService } from '../retrieval-agent';
  * This only applies to the bare agent entry point, not to explicit navigation to `/workflows`
  * (e.g. the canvas' "Back to workflows list" button), which must always show the list.
  */
-export const redirectToWorkflowGuard = (route: ActivatedRouteSnapshot, state: RouterStateSnapshot) => {
+export const redirectToWorkflowGuard = (route: ActivatedRouteSnapshot) => {
   const router: Router = inject(Router);
   const workflowsService: WorkflowsService = inject(WorkflowsService);
+  const navigationService = inject(NavigationService);
 
+  const accountSlug = route.paramMap.get('account') || '';
   const agentSlug = route.paramMap.get('agent') || '';
-  const basePath = state.url.split(/[?#]/)[0].replace(/\/$/, '');
 
-  return workflowsService.workflows.pipe(
-    take(1),
+  return workflowsService.loadingWorkflows.pipe(
+    filter((loading) => !loading),
+    switchMap(() => workflowsService.workflows.pipe(take(1))),
     map((workflows) => {
-      const lastWorkflowId = workflowsService.getLastWorkflowId(agentSlug);
+      const lastWorkflowId = workflowsService.getLastWorkflowId(agentSlug) || 'default';
       const targetId =
-        (lastWorkflowId && workflows.some((workflow) => workflow.id === lastWorkflowId) && lastWorkflowId) ||
-        (workflows.some((workflow) => workflow.id === 'default') && 'default') ||
-        null;
-      return router.parseUrl(`${basePath}/workflows${targetId ? `/${targetId}` : ''}`);
+        lastWorkflowId && workflows.some((workflow) => workflow.id === lastWorkflowId) ? lastWorkflowId : undefined;
+      return router.parseUrl(
+        `${navigationService.getRetrievalAgentUrl(accountSlug, agentSlug)}/workflows${targetId ? `/${targetId}` : ''}`,
+      );
     }),
   );
 };

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.html
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.html
@@ -8,6 +8,14 @@
         (click)="toggleMainNav()">
         {{ 'retrieval-agents.workflow.toolbar-buttons.toggle-navbar' | translate }}
       </pa-button>
+      <pa-button
+        icon="chevrons-left"
+        aspect="basic"
+        size="small"
+        [paTooltip]="'retrieval-agents.workflow.toolbar-buttons.back-to-workflows' | translate"
+        (click)="backToWorkflows()">
+        {{ 'retrieval-agents.workflow.toolbar-buttons.back-to-workflows' | translate }}
+      </pa-button>
       <div>
         <nsi-dropdown-button
           aspect="basic"

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.scss
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.scss
@@ -30,7 +30,7 @@
     .workflow-dropdown-menu .pa-popup {
       min-width: auto;
     }
-
+    
     // paPopup toggles the .pa-active class imperatively when its dropdown closes,
     // which clears the class Angular set from [active]. Its guard reads
     // ng-reflect-active, an attribute only emitted in dev builds, so in production

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.scss
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.scss
@@ -30,7 +30,7 @@
     .workflow-dropdown-menu .pa-popup {
       min-width: auto;
     }
-    
+
     // paPopup toggles the .pa-active class imperatively when its dropdown closes,
     // which clears the class Angular set from [active]. Its guard reads
     // ng-reflect-active, an attribute only emitted in dev builds, so in production

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.ts
@@ -11,7 +11,13 @@ import {
   ViewEncapsulation,
 } from '@angular/core';
 import { ActivatedRoute, Router } from '@angular/router';
-import { ModalConfig, PaButtonModule, PaDropdownModule, PaPopupModule } from '@guillotinaweb/pastanaga-angular';
+import {
+  ModalConfig,
+  PaButtonModule,
+  PaDropdownModule,
+  PaPopupModule,
+  PaTooltipModule,
+} from '@guillotinaweb/pastanaga-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { auditTime, combineLatest, filter, fromEvent, map, Subject, switchMap, take, takeUntil } from 'rxjs';
 import { DashboardLayoutService } from '../../base';
@@ -53,6 +59,7 @@ const OVERFLOW_SIDEBARS: SidebarType[] = ['rules', 'import', 'export'];
     PaButtonModule,
     PaDropdownModule,
     PaPopupModule,
+    PaTooltipModule,
     TranslateModule,
     WorkflowRootComponent,
   ],
@@ -176,6 +183,10 @@ export class AgentDashboardComponent implements AfterViewInit, OnDestroy {
 
   goToSessions() {
     this.router.navigate([`${this.aragUrl()}/sessions`]);
+  }
+
+  backToWorkflows() {
+    this.router.navigate([`${this.aragUrl()}/workflows`]);
   }
 
   addWorkflow() {

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.ts
@@ -112,12 +112,25 @@ export class AgentDashboardComponent implements AfterViewInit, OnDestroy {
 
     this.route.params.pipe(filter((params) => !!params['id'])).subscribe((params) => {
       workflowId.set(params['id']);
-      // Remember this as the last workflow visited for this agent, so the next time the
-      // user enters the agent they land back here instead of on the workflows list.
-      this.sdk.currentArag.pipe(take(1)).subscribe((arag) => {
-        this.workflowsService.setLastWorkflowId(arag.slug, params['id']);
-      });
     });
+
+    toObservable(workflowId)
+      .pipe(
+        switchMap((workflowId) =>
+          this.sdk.currentArag.pipe(
+            take(1),
+            map((arag) => ({ workflowId, arag })),
+          ),
+        ),
+        takeUntil(this.unsubscribeAll),
+      )
+      .subscribe(({ workflowId, arag }) => {
+        // Remember this as the last workflow visited for this agent, so the next time the
+        // user enters the agent they land back here instead of on the workflows list.
+        if (workflowId) {
+          this.workflowsService.setLastWorkflowId(arag.slug, workflowId || '');
+        }
+      });
   }
 
   ngAfterViewInit(): void {

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.ts
@@ -139,6 +139,10 @@ export class AgentDashboardComponent implements AfterViewInit, OnDestroy {
     this.unsubscribeAll.next();
     this.unsubscribeAll.complete();
     this.workflowService.cleanWorkflow();
+    // Collapsing the nav is only actionable from within the canvas toolbar (no other
+    // page exposes a way to re-expand it), so restore it whenever the canvas is left,
+    // regardless of exit path (back button, browser back/forward, deep link, etc.).
+    this.layoutService.expandNav();
   }
 
   setRoot(root: WorkflowRoot) {

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/agent-dashboard.component.ts
@@ -112,6 +112,11 @@ export class AgentDashboardComponent implements AfterViewInit, OnDestroy {
 
     this.route.params.pipe(filter((params) => !!params['id'])).subscribe((params) => {
       workflowId.set(params['id']);
+      // Remember this as the last workflow visited for this agent, so the next time the
+      // user enters the agent they land back here instead of on the workflows list.
+      this.sdk.currentArag.pipe(take(1)).subscribe((arag) => {
+        this.workflowsService.setLastWorkflowId(arag.slug, params['id']);
+      });
     });
   }
 

--- a/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/workflow.service.ts
+++ b/libs/common/src/lib/retrieval-agent/agent-dashboard/workflow/workflow.service.ts
@@ -168,8 +168,14 @@ export class WorkflowService {
    */
   initAndUpdateWorkflow(root: WorkflowRoot) {
     this.workflowRoot = root;
-    return combineLatest([this.sdk.currentAccount, this.sdk.currentArag, this.workflowId]).pipe(
-      map(([account, arag, workflowId]) => {
+    return this.workflowId.pipe(
+      switchMap((workflowId) =>
+        combineLatest([this.sdk.currentAccount, this.sdk.currentArag]).pipe(
+          take(1),
+          map(([account, arag]) => ({ account, arag, workflowId })),
+        ),
+      ),
+      map(({ account, arag, workflowId }) => {
         nodeInitialisationDone.set(false);
         setAragUrl(this.navigationService.getRetrievalAgentUrl(account.slug, arag.slug));
         return { arag, workflowId };

--- a/libs/common/src/lib/retrieval-agent/workflows/mcp-endpoint-modal/index.ts
+++ b/libs/common/src/lib/retrieval-agent/workflows/mcp-endpoint-modal/index.ts
@@ -1,0 +1,1 @@
+export * from './mcp-endpoint-modal.component';

--- a/libs/common/src/lib/retrieval-agent/workflows/mcp-endpoint-modal/mcp-endpoint-modal.component.html
+++ b/libs/common/src/lib/retrieval-agent/workflows/mcp-endpoint-modal/mcp-endpoint-modal.component.html
@@ -1,0 +1,29 @@
+<pa-modal-advanced
+  fitContent
+  fitContentHeight>
+  <pa-modal-title>{{ 'retrieval-agents.workflows-list.mcp-endpoint' | translate }}</pa-modal-title>
+  <pa-modal-content>
+    <div class="container">
+      <div class="integration-value">
+        <pa-textarea
+          rows="3"
+          readonly
+          [value]="endpoint()"></pa-textarea>
+        <pa-button
+          [icon]="copied() ? 'check' : 'copy'"
+          aspect="basic"
+          size="small"
+          (click)="copy()">
+          {{ 'generic.copy' | translate }}
+        </pa-button>
+      </div>
+    </div>
+  </pa-modal-content>
+  <pa-modal-footer>
+    <pa-button
+      aspect="basic"
+      (click)="close()">
+      {{ 'generic.close' | translate }}
+    </pa-button>
+  </pa-modal-footer>
+</pa-modal-advanced>

--- a/libs/common/src/lib/retrieval-agent/workflows/mcp-endpoint-modal/mcp-endpoint-modal.component.scss
+++ b/libs/common/src/lib/retrieval-agent/workflows/mcp-endpoint-modal/mcp-endpoint-modal.component.scss
@@ -1,0 +1,19 @@
+@use 'apps/dashboard/src/variables' as *;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: rhythm(3);
+  padding: rhythm(1) 0;
+  width: rhythm(64);
+}
+
+.integration-value {
+  align-items: flex-start;
+  display: flex;
+  gap: rhythm(1);
+
+  pa-textarea {
+    width: 100%;
+  }
+}

--- a/libs/common/src/lib/retrieval-agent/workflows/mcp-endpoint-modal/mcp-endpoint-modal.component.ts
+++ b/libs/common/src/lib/retrieval-agent/workflows/mcp-endpoint-modal/mcp-endpoint-modal.component.ts
@@ -1,0 +1,43 @@
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { CommonModule } from '@angular/common';
+import { ModalRef, PaButtonModule, PaModalModule, PaTextFieldModule } from '@guillotinaweb/pastanaga-angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { SDKService, ZoneService } from '@flaps/core';
+import { catchError, map, of, switchMap } from 'rxjs';
+
+@Component({
+  imports: [CommonModule, PaButtonModule, PaModalModule, PaTextFieldModule, TranslateModule],
+  templateUrl: './mcp-endpoint-modal.component.html',
+  styleUrl: './mcp-endpoint-modal.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class McpEndpointModalComponent {
+  private sdk = inject(SDKService);
+  private zoneService = inject(ZoneService);
+
+  protected modal = inject(ModalRef);
+  protected copied = signal(false);
+
+  protected endpoint = toSignal(
+    this.sdk.currentArag.pipe(
+      switchMap((arag) =>
+        this.zoneService
+          .buildZoneUrl(arag.zone, this.sdk.nuclia.options.backend, 'dp')
+          .pipe(map((baseUrl) => `${baseUrl}/v1${arag.path}/session/ephemeral/mcp`)),
+      ),
+      catchError(() => of('')),
+    ),
+    { initialValue: '' },
+  );
+
+  protected copy(): void {
+    navigator.clipboard.writeText(this.endpoint());
+    this.copied.set(true);
+    setTimeout(() => this.copied.set(false), 1000);
+  }
+
+  protected close(): void {
+    this.modal.close();
+  }
+}

--- a/libs/common/src/lib/retrieval-agent/workflows/workflows-list.component.html
+++ b/libs/common/src/lib/retrieval-agent/workflows/workflows-list.component.html
@@ -2,29 +2,27 @@
   <header>
     <div class="page-title">
       {{ 'retrieval-agents.workflows-list.title' | translate }}
-      <pa-button
-        icon="circle-plus"
-        iconAndText
-        (click)="add()">
-        {{ 'retrieval-agents.workflows-list.add' | translate }}
-      </pa-button>
+      <div class="page-title-actions">
+        <pa-button
+          kind="primary"
+          icon="circle-plus"
+          iconAndText
+          (click)="add()">
+          {{ 'retrieval-agents.workflows-list.add' | translate }}
+        </pa-button>
+        <pa-button
+          aspect="basic"
+          icon="more-vertical"
+          [paPopup]="workflowsMoreActions"></pa-button>
+        <pa-dropdown #workflowsMoreActions>
+          <pa-option (selectOption)="openMcpEndpoint()">
+            {{ 'retrieval-agents.workflows-list.mcp-endpoint' | translate }}
+          </pa-option>
+        </pa-dropdown>
+      </div>
     </div>
     <div class="page-description">{{ 'retrieval-agents.workflows-list.description' | translate }}</div>
   </header>
-
-  <div class="section">
-    <div class="section-title title-s">{{ 'retrieval-agents.workflows-list.mcp-endpoint' | translate }}</div>
-    <div class="endpoint">
-      <pa-button
-        aspect="basic"
-        size="small"
-        [icon]="copied() ? 'check' : 'copy'"
-        (click)="copyEndpoint()">
-        {{ 'generic.copy' | translate }}
-      </pa-button>
-      <pre><code>{{ endpoint | async }}</code></pre>
-    </div>
-  </div>
 
   <div class="section">
     @if (((workflows | async) || []).length === 0) {
@@ -59,6 +57,9 @@
                   icon="more-vertical"
                   [paPopup]="menu"></pa-button>
                 <pa-dropdown #menu>
+                  <pa-option (selectOption)="goToWorkflow(workflow)">
+                    {{ 'retrieval-agents.workflows-list.open' | translate }}
+                  </pa-option>
                   <pa-option (selectOption)="edit(workflow, $event)">
                     {{ 'retrieval-agents.workflows-list.edit' | translate }}
                   </pa-option>

--- a/libs/common/src/lib/retrieval-agent/workflows/workflows-list.component.scss
+++ b/libs/common/src/lib/retrieval-agent/workflows/workflows-list.component.scss
@@ -18,6 +18,12 @@
     justify-content: space-between;
   }
 
+  .page-title-actions {
+    align-items: center;
+    display: flex;
+    gap: rhythm(1);
+  }
+
   .section {
     max-width: $width-large-screen;
   }
@@ -25,19 +31,5 @@
   .section-title {
     color: $color-neutral-regular;
     margin-bottom: rhythm(0.5);
-  }
-
-  .endpoint {
-    align-items: center;
-    background-color: $color-neutral-lightest;
-    border: 1px solid $color-neutral-light;
-    border-radius: rhythm(0.5);
-    display: flex;
-    gap: rhythm(0.5);
-
-    pre {
-      margin-bottom: 0;
-      white-space: normal;
-    }
   }
 }

--- a/libs/common/src/lib/retrieval-agent/workflows/workflows-list.component.ts
+++ b/libs/common/src/lib/retrieval-agent/workflows/workflows-list.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import {
   ModalConfig,
   PaButtonModule,
@@ -14,8 +14,8 @@ import { filter, map, switchMap, take } from 'rxjs';
 import { WorkflowModalComponent } from './workflow-modal';
 import { ActivatedRoute, Router } from '@angular/router';
 import { WorkflowsService } from './workflows.service';
-import { SDKService, ZoneService } from '@flaps/core';
 import { ToolParametersModalComponent } from './tool-parameters-modal';
+import { McpEndpointModalComponent } from './mcp-endpoint-modal';
 
 @Component({
   imports: [
@@ -38,25 +38,17 @@ export class WorkflowsListComponent {
   private router = inject(Router);
   private route = inject(ActivatedRoute);
   private translate = inject(TranslateService);
-  private sdk = inject(SDKService);
-  private zoneService = inject(ZoneService);
 
   workflows = this.workflowsService.workflows.pipe(
     map((workflows) => [...workflows].sort((a, b) => a.name.localeCompare(b.name))),
   );
 
-  endpoint = this.sdk.currentArag.pipe(
-    switchMap((arag) =>
-      this.zoneService
-        .buildZoneUrl(arag.zone, this.sdk.nuclia.options.backend, 'dp')
-        .pipe(map((baseUrl) => `${baseUrl}/v1${arag.path}/session/ephemeral/mcp`)),
-    ),
-  );
-
-  copied = signal(false);
-
   goToWorkflow(workflow: Workflow) {
     this.router.navigate([workflow.id], { relativeTo: this.route });
+  }
+
+  openMcpEndpoint() {
+    this.modalService.openModal(McpEndpointModalComponent);
   }
 
   add() {
@@ -68,9 +60,10 @@ export class WorkflowsListComponent {
             this.modalService.openModal(WorkflowModalComponent, new ModalConfig({ data: { workflows } })).onClose,
         ),
         filter((workflow) => !!workflow),
-        switchMap((workflow) => this.workflowsService.createWorkflow(workflow)),
+        switchMap((workflow) => this.workflowsService.createWorkflow(workflow).pipe(map(() => workflow))),
       )
       .subscribe({
+        next: (workflow) => this.goToWorkflow(workflow),
         error: () => {
           this.toaster.error('retrieval-agents.workflows-list.errors.creation');
         },
@@ -126,13 +119,5 @@ export class WorkflowsListComponent {
           this.toaster.error('retrieval-agents.workflows-list.errors.deletion');
         },
       });
-  }
-
-  copyEndpoint() {
-    this.endpoint.pipe(take(1)).subscribe((endpoint) => {
-      navigator.clipboard.writeText(endpoint);
-      this.copied.set(true);
-      setTimeout(() => this.copied.set(false), 1000);
-    });
   }
 }

--- a/libs/common/src/lib/retrieval-agent/workflows/workflows.service.ts
+++ b/libs/common/src/lib/retrieval-agent/workflows/workflows.service.ts
@@ -1,6 +1,6 @@
 import { inject, Injectable } from '@angular/core';
 import { SDKService } from '@flaps/core';
-import { shareReplay, startWith, Subject, switchMap, take, tap } from 'rxjs';
+import { catchError, of, ReplaySubject, startWith, Subject, switchMap, take, tap } from 'rxjs';
 import { Workflow } from '@nuclia/core';
 import { LOCAL_STORAGE } from '@ng-web-apis/common';
 
@@ -14,13 +14,25 @@ export class WorkflowsService {
   private localStorage = inject(LOCAL_STORAGE);
 
   private triggerUpdate = new Subject<void>();
+  private _workflows = new ReplaySubject<Workflow[]>(1);
+  private _loadingWorkflows = new ReplaySubject<boolean>(1);
 
-  workflows = this.triggerUpdate.pipe(
-    startWith(true),
-    switchMap(() => this.sdk.currentArag),
-    switchMap((arag) => arag.getWorkflows()),
-    shareReplay(1),
-  );
+  workflows = this._workflows.asObservable();
+  loadingWorkflows = this._loadingWorkflows.asObservable();
+
+  constructor() {
+    this.triggerUpdate
+      .pipe(
+        startWith(true),
+        switchMap(() => this.sdk.currentArag),
+        tap(() => this._loadingWorkflows.next(true)),
+        switchMap((arag) => arag.getWorkflows().pipe(catchError(() => of([])))),
+      )
+      .subscribe((workflows) => {
+        this._workflows.next(workflows);
+        this._loadingWorkflows.next(false);
+      });
+  }
 
   update() {
     this.triggerUpdate.next();

--- a/libs/common/src/lib/retrieval-agent/workflows/workflows.service.ts
+++ b/libs/common/src/lib/retrieval-agent/workflows/workflows.service.ts
@@ -2,12 +2,16 @@ import { inject, Injectable } from '@angular/core';
 import { SDKService } from '@flaps/core';
 import { shareReplay, startWith, Subject, switchMap, take, tap } from 'rxjs';
 import { Workflow } from '@nuclia/core';
+import { LOCAL_STORAGE } from '@ng-web-apis/common';
+
+const LAST_WORKFLOW_KEY_PREFIX = 'NUCLIA_ARAG_LAST_WORKFLOW';
 
 @Injectable({
   providedIn: 'root',
 })
 export class WorkflowsService {
   private sdk = inject(SDKService);
+  private localStorage = inject(LOCAL_STORAGE);
 
   private triggerUpdate = new Subject<void>();
 
@@ -20,6 +24,15 @@ export class WorkflowsService {
 
   update() {
     this.triggerUpdate.next();
+  }
+
+  /** Remembers the last workflow the user opened for a given agent, so the next visit can resume there. */
+  setLastWorkflowId(agentSlug: string, workflowId: string) {
+    this.localStorage.setItem(`${LAST_WORKFLOW_KEY_PREFIX}_${agentSlug}`, workflowId);
+  }
+
+  getLastWorkflowId(agentSlug: string): string | null {
+    return this.localStorage.getItem(`${LAST_WORKFLOW_KEY_PREFIX}_${agentSlug}`);
   }
 
   createWorkflow(workflow: Workflow) {


### PR DESCRIPTION
## Summary

Three related UX improvements to the Retrieval Agents workflows experience: a canvas back button, smarter landing behavior when entering an agent, and a decluttered workflows list header/actions.

---

### 1. Back button in the canvas toolbar

**What changed:** Added a dedicated back button (chevrons-left icon, with a "Back to workflows list" tooltip) to the workflow canvas toolbar, positioned between the nav toggle and the workflow picker. Clicking it navigates back to the workflows list.

**UX justification:** The canvas and the workflows list are router siblings, but without an explicit way back the canvas felt like a disconnected, dead-end page — the only way out was browser back or the nav sidebar. A visible, always-available back button makes the relationship between "list of workflows" and "a workflow's canvas" obvious and removes reliance on browser navigation.

### 2. Land on the default or last-visited workflow canvas

**What changed:** Entering an agent used to always redirect to the workflows *list*. It now resolves, via a route guard, to the workflow the user last worked on (persisted per-agent in `localStorage`), falling back to the seeded `default` workflow, and only falling back to the list if neither exists.

**UX justification:** Almost every agent has at least one workflow (all agents ship with a `default` one), and most users work in a single workflow most of the time. Forcing a list-page stop on every entry added a redundant click for the common case and broke the "resume where I left off" expectation. This doesn't regress the back button above (#1), which still explicitly navigates to `/workflows` on demand.

### 3. "Open workflow" menu option + redirect to canvas after creation

**What changed:** Added an "Open workflow" item to each row's overflow (⋮) menu, and after creating a workflow from the "Add workflow" modal, the user is now taken straight to its canvas instead of staying on the list.

**UX justification:** Rows were already clickable to open the canvas, but that wasn't obvious — no visual affordance signaled it. Rather than adding a new chevron/link treatment, we reused the existing overflow menu users already open for Edit/Delete, making the action discoverable without adding UI clutter. Separately, since the entire point of creating a workflow is to start building it, staying on the list after creation was an unnecessary extra click.

### 4. Primary "Add workflow" button + MCP endpoint moved into a modal

**What changed:**
- "Add workflow" is now styled `kind="primary"` (blue), matching the primary-action pattern used elsewhere in the dashboard (e.g. the Knowledge Box header).
- The MCP endpoint block — previously a permanently visible code snippet + copy button taking up page real estate — was moved into a small modal, accessed via a new overflow icon button next to "Add workflow". The modal mirrors the existing "Developer integrations" copyable-endpoint modal pattern already used on the dashboard home.

**UX justification:** Having the Add button visually equal-weighted with the (unrelated) endpoint copy action diluted the page's single clear call-to-action. The MCP endpoint is a power-user/integration detail needed occasionally, not on every visit — hiding it behind one extra click declutters the default view while keeping it fully accessible and consistent with an established pattern elsewhere in the product.

---

## Screenshots / how to verify
- Canvas toolbar → back button (chevrons-left) next to the nav toggle → hover shows "Back to workflows list" tooltip → click returns to the workflows list.
- Enter an agent that has a `default` workflow (or one you've visited before) → you should land directly on its canvas.
- Workflows list: "Add workflow" is blue; new overflow icon (⋮) next to it opens "MCP endpoint" → modal with copyable field.
- Row overflow menu → "Open workflow" navigates to that workflow's canvas.
- Create a new workflow → lands on its canvas immediately.

## Validation
- `nx lint common` — clean (only pre-existing unrelated warnings)
- `nx build dashboard` — succeeds (only pre-existing unrelated warnings)
- `nx test common` — 198/199 pass (1 pre-existing unrelated failure, date-based)

## Notes
- No backend/API changes.
- A previously-investigated "can't recreate a workflow with the same name right after deleting it" issue was intentionally **not** addressed in this PR — the fix attempted (`synchronous: true` on write calls) didn't fully resolve it on further testing and was reverted; root cause looks backend-side and is out of scope here.
