### PR TITLE
fix(retrieval-agents): align main CTAs across agent pages

### DIFF
--- a/libs/common/src/lib/retrieval-agent/drivers/drivers-page.component.html
+++ b/libs/common/src/lib/retrieval-agent/drivers/drivers-page.component.html
@@ -2,11 +2,12 @@
   <header>
     <div class="page-title">
       {{ 'retrieval-agents.drivers.title' | translate }}
-      <div class="add-driver-container">
+      <div class="page-title-actions">
         <nsi-dropdown-button
+          kind="primary"
           icon="circle-plus"
-          iconAndText
-          fullWidth
+          freeWidth
+          [alignLeft]="false"
           [popupRef]="driverTypes">
           {{ 'retrieval-agents.drivers.add.button' | translate }}
         </nsi-dropdown-button>

--- a/libs/common/src/lib/retrieval-agent/drivers/drivers-page.component.scss
+++ b/libs/common/src/lib/retrieval-agent/drivers/drivers-page.component.scss
@@ -18,8 +18,10 @@
     justify-content: space-between;
   }
 
-  .add-driver-container {
-    width: rhythm(28);
+  .page-title-actions {
+    align-items: center;
+    display: flex;
+    gap: rhythm(1);
   }
 
   .driver-list {

--- a/libs/common/src/lib/retrieval-agent/sessions/sessions-list.component.html
+++ b/libs/common/src/lib/retrieval-agent/sessions/sessions-list.component.html
@@ -1,12 +1,20 @@
 <div class="session-list page-spacing">
   <header>
-    <div class="page-title">{{ 'retrieval-agents.sessions.list.title' | translate }}</div>
+    <div class="page-title">
+      {{ 'retrieval-agents.sessions.list.title' | translate }}
+      <div class="page-title-actions">
+        <pa-button
+          kind="primary"
+          routerLink="..">
+          {{ 'retrieval-agents.sessions.list.setup-workflow' | translate }}
+        </pa-button>
+      </div>
+    </div>
     <div class="page-description">{{ 'retrieval-agents.sessions.list.description' | translate }}</div>
   </header>
 
   @if (noSessions()) {
     <nsi-info-card icon="info">{{ 'retrieval-agents.sessions.list.empty' | translate }}</nsi-info-card>
-    <pa-button routerLink="..">{{ 'retrieval-agents.sessions.list.setup-workflow' | translate }}</pa-button>
   } @else {
     <div class="session-list-content">
       <div class="search-bar">

--- a/libs/common/src/lib/retrieval-agent/sessions/sessions-list.component.scss
+++ b/libs/common/src/lib/retrieval-agent/sessions/sessions-list.component.scss
@@ -5,6 +5,16 @@
   flex-direction: column;
   gap: rhythm(4);
 
+  .page-title {
+    justify-content: space-between;
+  }
+
+  .page-title-actions {
+    align-items: center;
+    display: flex;
+    gap: rhythm(1);
+  }
+
   .table-container {
     position: relative;
     min-height: calc(100dvh - var(--app-topbar-height) - var(--table-top-position));

--- a/libs/common/src/lib/search-widget/widgets/widget-list.component.html
+++ b/libs/common/src/lib/search-widget/widgets/widget-list.component.html
@@ -1,12 +1,18 @@
 <div class="widget-list-page page-spacing">
   <header>
-    <div>
-      <div class="page-title">
-        {{ 'search.widgets.title' | translate }}
+    <div class="page-title">
+      {{ 'search.widgets.title' | translate }}
+      <div class="page-title-actions">
+        <pa-button
+          kind="primary"
+          icon="circle-plus"
+          iconAndText
+          (click)="createWidget()">
+          {{ 'search.widgets.action.create-widget-button' | translate }}
+        </pa-button>
       </div>
-      <div class="page-description">{{ 'search.widgets.page-description' | translate }}</div>
     </div>
-    <pa-button (click)="createWidget()">{{ 'search.widgets.action.create-widget-button' | translate }}</pa-button>
+    <div class="page-description">{{ 'search.widgets.page-description' | translate }}</div>
   </header>
 
   @if (emptyList | async) {

--- a/libs/common/src/lib/search-widget/widgets/widget-list.component.scss
+++ b/libs/common/src/lib/search-widget/widgets/widget-list.component.scss
@@ -2,9 +2,17 @@
 
 .widget-list-page {
   header {
-    display: flex;
-    justify-content: space-between;
     margin-bottom: rhythm(4);
+  }
+
+  .page-title {
+    justify-content: space-between;
+  }
+
+  .page-title-actions {
+    align-items: center;
+    display: flex;
+    gap: rhythm(1);
   }
 
   .table-link {


### PR DESCRIPTION
## Problem

The primary action on the agent pages was inconsistent in both **styling** and **placement**, and only the workflows page got it right.

| Page | Before | Placement |
| --- | --- | --- |
| Workflows | 🔵 Primary (blue) | Header, top-right |
| Sessions | ⚪ Secondary (grey) | Below the empty-state card |
| Sources | ⚪ Secondary (grey) | Header, top-right — fixed `rhythm(28)` width |
| Widgets | ⚪ Secondary (grey) | Header, but outside `.page-title` |

Both `pa-button` and `nsi-dropdown-button` default to `kind="secondary"`. Only the workflows page explicitly set `kind="primary"`, so every other page's main action was rendering in the design system's *secondary* treatment.

## UX justification

**1. The visual hierarchy was inverted.**
Each of these pages has exactly one main action, but three of the four rendered it in the same grey used for secondary and tertiary actions elsewhere in the product. Users scanning the page had no visual signal for "this is the thing to do here" — the main action carried the same weight as the overflow menu beside it.

**2. The sessions CTA vanished exactly when it was still needed.**
"Setup agent workflow" was rendered *below* the empty-state info card, inside the `@if (noSessions())` branch. The moment a single session existed, the only route from this page to the workflow editor disappeared. Sessions are the output of a workflow, so the need to go tune that workflow *increases* once sessions start appearing — this was precisely backwards. It now lives in the header and is always available.

**3. Inconsistent placement broke positional memory.**
Workflows, sessions, sources and widgets are sibling destinations in the agent nav. Users move between them frequently, so the main action should stay in one predictable spot. Having it in the header on some pages and buried below content on others forced a re-scan on every navigation.

**4. The sources CTA was disproportionately heavy.**
Its fixed `rhythm(28)` width made it substantially wider than the equivalent action on workflows, reading as a different (more prominent) class of control despite being the same kind of action.

## Solution

Adopt the workflows header pattern across all three pages:

```html
<div class="page-title">
  {{ title }}
  <div class="page-title-actions">
    <pa-button kind="primary" …>
  </div>
</div>
<div class="page-description">…</div>
```

- **Sessions** — promoted into the header as a primary action, always visible. Intentionally **no `circle-plus` icon**: this action navigates to the workflow editor, it does not create a session. Using the create icon here would misrepresent what the button does.
- **Sources** — switched to primary, dropped `fullWidth` + the fixed width so it sizes naturally like the others.
- **Widgets** — moved inside `.page-title` and switched to primary with `circle-plus`, consistent with the other genuine create actions.

## Bug fixed along the way

Removing the sources dropdown's fixed width surfaced a latent issue: **`pa-popup` has no viewport overflow protection** (`popup.directive.ts` computes position with no bounds check). The old fixed width forced `sameWidth` positioning, which accidentally masked it by clamping the popup to the button. A natural-width popup opening leftwards from a right-aligned button would have rendered partly off-screen.

Fixed by anchoring the popup to the button's right edge via `[alignLeft]="false"` — the same alignment the workflows overflow menu already uses. The underlying directive limitation is untouched and pre-existing.

Also removed a dead `iconAndText` attribute on `nsi-dropdown-button`; that component derives the flag internally from its `icon` input and exposes no such input.

## Affected areas

All edited components live in `libs/common` and are shared between **`apps/rao`** and **`apps/dashboard`**.

- `retrieval-agent/sessions` + `retrieval-agent/drivers` — ARAG-only, both apps
- `search-widget/widgets` — also reachable from the KB (non-ARAG) route in dashboard, so the widgets header changes there too

This is intentional and consistent with the goal, but it is the widest blast radius in the PR and the main thing worth eyeballing during review.

## Risk

Low — presentational only. No component logic, routing, or API calls changed. New SCSS is layout-only (`flex` / `gap`); no colour literals were introduced, so `kind="primary"` carries dark-mode and state coverage (hover / active / focus-visible / disabled) straight from the design system tokens.

## Validation

- ✅ `nx build rao --configuration=production` — succeeded. All warnings pre-existing (`tasks-automation` NG8107, CommonJS deps, bundle budget); none in touched files.
- ✅ `prettier --check` — clean on all 6 files.
- ✅ Pre-commit hook (`lint-staged` + `nx affected --target=lint` + `nx affected --target=test`) passed.
- ℹ️ No spec files exist for these three components, so there were no unit tests to update.

## Review checklist

- [ ] Sessions: CTA visible in header both with **and** without existing sessions
- [ ] Sources: dropdown opens fully on-screen, right-anchored, at narrow viewport widths
- [ ] Widgets: header renders correctly in **both** the ARAG and KB routes (column layout differs via `inArag`)
- [ ] All four pages (workflows / sessions / sources / widgets) agree in light **and** dark mode
