### PR TITLE
Skip setup screen for SSO users joining a KB via invite

### DIFF
--- a/libs/user/src/lib/magic/magic.service.ts
+++ b/libs/user/src/lib/magic/magic.service.ts
@@ -57,10 +57,13 @@ export class MagicService {
         }
         break;
       case 'redict_to_kb':
-        // needs_initial_setpassword property is not avaiable, so we don't know if it's a new user or not
-        this.router.navigate(['/setup/invite'], {
-          queryParams: { account: action.account, kb: action.kb },
-        });
+        if (action.needs_initial_setpassword === false && this.cameFrom) {
+          location.href = `${this.cameFrom}/select`;
+        } else {
+          this.router.navigate(['/setup/invite'], {
+            queryParams: { account: action.account, kb: action.kb },
+          });
+        }
         break;
       case 'goselectaccount':
         this.router.navigate(['/select']);


### PR DESCRIPTION
**Description**

Users who already sign in via SSO could still land on the "Finalize user setup" screen when redeeming a knowledge-box invite, because the backend action for that flow did not carry the `needs_initial_setpassword` flag at all, so the frontend always sent them through setup.

**Solution**

The `redict_to_kb` magic action now honors `needs_initial_setpassword` the same way the account-join (`goaccount`) action already does: when it is `false`, the user is redirected straight back to the app instead of the setup screen. This depends on the companion backend PR (nuclia/backend#2893) which now returns this flag correctly.