### PR TITLE
feat(dashboard): cap app-wide content width at 1440px

### DIFF
--- a/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.scss
+++ b/apps/dashboard/src/app/knowledge-box/knowledge-box-home/knowledge-box-home.component.scss
@@ -8,6 +8,13 @@
   grid-template-rows: min-content;
   grid-template-columns: 1fr 1fr;
   gap: var(--gap-size);
+  // `.page-spacing` sets a `min-height` so the page fills the viewport, but this grid's
+  // `auto`-sized rows default to `align-content: stretch`, which distributes any leftover
+  // vertical space (page shorter than viewport) into those rows instead of leaving it as
+  // trailing whitespace. That inflates rows/cards well past their content (worse the more
+  // the viewport is zoomed out, since 100vh grows in CSS px while content doesn't).
+  // Pin rows to their natural content size and let extra space fall below the last row.
+  align-content: start;
 
   .fullwidth-container {
     grid-column: span 2;
@@ -47,7 +54,6 @@
   .kb-summary-card {
     background-color: $color-light-stronger;
     gap: calc(#{rhythm(2)} * 0.7);
-    height: 100%;
 
     .kb-summary-card__header {
       align-items: center;

--- a/libs/common/src/lib/base/dashboard-layout/dashboard-layout.component.html
+++ b/libs/common/src/lib/base/dashboard-layout/dashboard-layout.component.html
@@ -26,7 +26,9 @@
       id="dashboard-main"
       tabindex="-1"
       [class.with-status-bar]="showStatusBar | async">
-      <router-outlet></router-outlet>
+      <div class="dashboard-main-content">
+        <router-outlet></router-outlet>
+      </div>
     </main>
   </div>
 </div>

--- a/libs/common/src/lib/base/dashboard-layout/dashboard-layout.component.scss
+++ b/libs/common/src/lib/base/dashboard-layout/dashboard-layout.component.scss
@@ -38,6 +38,19 @@ $height-status-bar: rhythm(9);
       &.with-status-bar {
         --app-topbar-height: #{$height-top-bar + $height-status-bar};
       }
+
+      // Cap content width so pages don't stretch edge-to-edge on ultra-wide monitors.
+      // Below this width the cap has no visible effect, so no media query is needed.
+      // Applied to this static wrapper div (not `main`, which must stay full-width so its
+      // scrollbar sits at the real viewport/browser edge) and not via a `main > *` selector,
+      // since Angular's ViewEncapsulation scopes selectors with a per-component attribute
+      // that content projected through <router-outlet> doesn't carry — a `> *` selector
+      // would silently match nothing there.
+      .dashboard-main-content {
+        max-width: $size-viewport-xlarge-min;
+        margin-left: auto;
+        margin-right: auto;
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary
Caps app-wide content width at **1440px** across the shared dashboard shell (used by `dashboard`, `rao`, and `admin`), and fixes an unrelated layout bug discovered while testing it.

## UX justification for a 1440px max-width
Without a cap, dashboard content stretches edge-to-edge on ultra-wide/large monitors, which hurts usability and visual design:

- **Scanability**: data-dense layouts (tables, cards, forms) become harder to scan as line/row length grows unbounded — the eye has to travel further, and grid/table columns end up disproportionately wide relative to their content.
- **Visual hierarchy & whitespace**: components designed with specific proportions (cards, spacing rhythm, icon-to-text ratios) start to look sparse and unbalanced when stretched across 2560px+ viewports.
- **Consistency**: 1440px is already an established token in the design system (`$size-viewport-xlarge-min`) and matches precedent elsewhere in the app (e.g. `manager-v2`'s `.pa-main-container-wide` pattern) — this generalizes an existing pattern app-wide rather than introducing a new convention.
- **No regression below the cap**: implemented as a simple `max-width` + auto margins (no media query needed) — it has zero visible effect on any viewport at or below 1440px, so existing responsive behavior on laptops/tablets is untouched.

Applied to a wrapper div inside `<main>` rather than `<main>` itself, so `<main>`'s scrollbar stays pinned to the true browser edge (not the centered content edge) — verified via Playwright and manual testing at various zoom levels.

## Also fixed: KB summary card stretch bug
While testing the max-width at different zoom levels, found that zooming out on the KB home page caused the summary cards to grow abnormally tall, leaving a large gap before the next section.

**Root cause**: `.knowledge-box-home`'s CSS grid has a forced `min-height` (from `.page-spacing`, so the page fills the viewport). When actual content was shorter than that (common at wide/zoomed-out viewports), Grid's default `align-content: stretch` behavior distributed the leftover vertical space into the summary-cards row, cascading through nested grids into the individual cards.

**Fix**: `align-content: start` on `.knowledge-box-home` — rows size to their own content, and leftover space falls below the last row instead of inflating rows/cards. Also removed a redundant `height: 100%` on `.kb-summary-card` that Grid's default `align-items: stretch` already made unnecessary.

## Testing
- Compiled all changed SCSS locally (`sass` CLI) to verify output.
- Reproduced and confirmed the fix for the grid-stretch bug via Playwright across multiple simulated viewport heights (900–2400px), using the real compiled CSS.
- Manually verified in-browser at various zoom levels (including 60% zoom-out) that:
  - Content is capped/centered at 1440px on wide viewports, fully fluid below it.
  - The scrollbar remains pinned to the browser edge, not the centered content edge.
  - KB summary cards no longer stretch/gap at reduced zoom.

## Risk / affected areas
- Shared layout shell affects `dashboard`, `rao`, and `admin` apps — low risk, purely additive CSS (max-width + centering), no structural/behavioral changes.
- KB home page grid fix is scoped to a single component.
