### PR TITLE
Show a success message on login after redeeming an account/KB invite

### DIFF
--- a/libs/user/src/assets/i18n/ca.json
+++ b/libs/user/src/assets/i18n/ca.json
@@ -10,6 +10,7 @@
 	"login.access_request": "vol accedir al teu compte de Agentic RAG i poder: ",
 	"login.account_already_exists": "Ja existeix un compte amb aquest correu electrònic. Si us plau, inicia la sessió.",
 	"login.account_ready_please_login": "El teu compte ja està a punt, si us plau inicia sessió.",
+	"login.invite_accepted_please_login": "Invitació acceptada — si us plau inicia sessió per continuar.",
 	"login.check_email.check_spams": "o comproveu la vostra carpeta de correu brossa.",
 	"login.check_email.details": "Feu clic a l'enllaç d'activació que us acabem d'enviar a <strong>{{ email }}</strong>. ",
 	"login.check_email.email_sent": "T’hem enviat un mail! :)",

--- a/libs/user/src/assets/i18n/en.json
+++ b/libs/user/src/assets/i18n/en.json
@@ -10,6 +10,7 @@
 	"login.access_request": "wants to access Agentic RAG on your behalf and be able to:",
 	"login.account_already_exists": "An account with this email already exists. Please log in.",
 	"login.account_ready_please_login": "Your account is ready — please log in.",
+	"login.invite_accepted_please_login": "Invitation accepted — please log in to continue.",
 	"login.check_email.check_spams": "or check your spam folder.",
 	"login.check_email.details": "Click on the activation link we just sent you at <strong>{{ email }}</strong>. ",
 	"login.check_email.email_sent": "We’ve sent you an email!",

--- a/libs/user/src/assets/i18n/es.json
+++ b/libs/user/src/assets/i18n/es.json
@@ -10,6 +10,7 @@
 	"login.access_request": "quiere acceder a tu cuenta de Agentic RAG y poder: ",
 	"login.account_already_exists": "Ya existe una cuenta con este correo electrónico. Inicia sesión.",
 	"login.account_ready_please_login": "Tu cuenta está lista, por favor inicia sesión.",
+	"login.invite_accepted_please_login": "Invitación aceptada — inicia sesión para continuar.",
 	"login.check_email.check_spams": "o revisa tu carpeta de spam.",
 	"login.check_email.details": "Haga clic en el enlace de activación que le acabamos de enviar a <strong>{{ email }}</strong>.",
 	"login.check_email.email_sent": "Te hemos enviado un mail! :)",

--- a/libs/user/src/assets/i18n/fr.json
+++ b/libs/user/src/assets/i18n/fr.json
@@ -10,6 +10,7 @@
 	"login.access_request": "souhaite accéder à Agentic RAG en votre nom et être en mesure de :",
 	"login.account_already_exists": "Un compte existe déjà avec cette adresse e-mail. Veuillez vous connecter.",
 	"login.account_ready_please_login": "Votre compte est prêt, veuillez vous connecter.",
+	"login.invite_accepted_please_login": "Invitation acceptée — veuillez vous connecter pour continuer.",
 	"login.check_email.check_spams": "ou vérifiez vos courriers indésirables.",
 	"login.check_email.details": "Cliquez sur le lien d'activation que nous venons de vous envoyer à <strong>{{ email }}</strong>. ",
 	"login.check_email.email_sent": "On vous a envoyé un email!",

--- a/libs/user/src/lib/login/login.component.ts
+++ b/libs/user/src/lib/login/login.component.ts
@@ -25,7 +25,11 @@ export class LoginComponent {
   message = signal<string | null>(null);
   error: string | null = null;
 
-  isPositiveMessage = computed(() => this.message() === 'login.account_ready_please_login');
+  private static readonly POSITIVE_MESSAGES = new Set([
+    'login.account_ready_please_login',
+    'login.invite_accepted_please_login',
+  ]);
+  isPositiveMessage = computed(() => LoginComponent.POSITIVE_MESSAGES.has(this.message() || ''));
 
   loginValidationMessages = {
     email: {

--- a/libs/user/src/lib/magic/magic.service.ts
+++ b/libs/user/src/lib/magic/magic.service.ts
@@ -49,7 +49,7 @@ export class MagicService {
         break;
       case 'goaccount':
         if (action.needs_initial_setpassword === false && this.cameFrom) {
-          location.href = `${this.cameFrom}/select`;
+          this.goToCameFromWithMessage('/select', 'login.invite_accepted_please_login');
         } else {
           this.router.navigate(['/setup/invite'], {
             queryParams: { account: action.account },
@@ -58,7 +58,7 @@ export class MagicService {
         break;
       case 'redict_to_kb':
         if (action.needs_initial_setpassword === false && this.cameFrom) {
-          location.href = `${this.cameFrom}/select`;
+          this.goToCameFromWithMessage('/select', 'login.invite_accepted_please_login');
         } else {
           this.router.navigate(['/setup/invite'], {
             queryParams: { account: action.account, kb: action.kb },
@@ -86,6 +86,14 @@ export class MagicService {
         this.readyToLogin = true;
         break;
     }
+  }
+
+  private goToCameFromWithMessage(path: string, message: string) {
+    // The invited user has no session yet, so cameFrom's own auth guard will bounce them into
+    // login; forward `message` so it survives that redirect and shows up on the login screen.
+    const url = new URL(`${this.cameFrom}${path}`);
+    url.searchParams.set('message', message);
+    location.href = url.toString();
   }
 
   joinKb(action: MagicAction) {


### PR DESCRIPTION
**Description**

After the SSO-invite fix (#3083), an invited user whose invite was resolved successfully (`needs_initial_setpassword === false`) is sent straight back to `${cameFrom}/select`. Since they have no active session yet, the originating app's own auth guard bounces them to its login screen — which shows no indication that the invite actually succeeded, just a bare login form.

**Solution**

Reuse the existing `?message=` forwarding mechanism already used for the `account_ready_please_login` case: when redirecting to `${cameFrom}/select`, a `message` query param is now attached. It survives the auth-guard redirect into the OAuth login flow and is displayed as a positive banner on the login screen, telling the user the invite was accepted and they can log in.